### PR TITLE
refactor: add class-level constants for accepted publication types

### DIFF
--- a/bibtex_updater.py
+++ b/bibtex_updater.py
@@ -473,6 +473,19 @@ class PublishedRecord:
 
 
 class Resolver:
+    # Accepted publication types for upgrades (includes ML conference papers)
+    ACCEPTED_TYPES = {
+        "journal-article",
+        "proceedings-article",  # Conference papers (NeurIPS, ICML, AISTATS, etc.)
+        "book-chapter",
+    }
+
+    # Semantic Scholar publication type mappings
+    ACCEPTED_S2_TYPES = {
+        "journalarticle",
+        "conference",
+    }
+
     def __init__(
         self, http: HttpClient, logger: logging.Logger, scholarly_client: Optional[ScholarlyClient] = None
     ) -> None:


### PR DESCRIPTION
Move ACCEPTED_TYPES and ACCEPTED_S2_TYPES to class-level constants in Resolver for better organization and reusability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)