### PR TITLE
solve tmp and working dir being not on the same filesystem bug

### DIFF
--- a/src/bibtex_updater/updater.py
+++ b/src/bibtex_updater/updater.py
@@ -40,6 +40,8 @@ import difflib
 import json
 import logging
 import os
+import errno
+import shutil
 import re
 import sys
 import tempfile
@@ -130,7 +132,14 @@ class BibWriter:
             os.fsync(tmp.fileno())
         finally:
             tmp.close()
-        os.replace(tmp.name, path)
+        try: # replace fails if tmp file and destination are not on the same file system
+            os.replace(tmp.name, path)
+        except OSError as e:
+            if e.errno == errno.EXDEV:
+                shutil.copyfile(tmp.name, path)
+                os.unlink(tmp.name)
+            else:
+                raise e
 
 
 # ------------- Google Scholar Client (optional) -------------

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import collections
 import json
 import os
+import errno
+import shutil
 import random
 import re
 import sqlite3
@@ -550,7 +552,14 @@ class DiskCache:
                 os.fsync(tmp.fileno())
             finally:
                 tmp.close()
-            os.replace(tmp.name, self.path)
+            try: # replace fails if tmp file and destination are not on the same file system
+                os.replace(tmp.name, self.path)
+            except OSError as e:
+                if e.errno == errno.EXDEV:
+                    shutil.copyfile(tmp.name, self.path)
+                    os.unlink(tmp.name)
+                else:
+                    raise e
 
     def has(self, key: str) -> bool:
         """Check if a key exists in the cache."""
@@ -807,7 +816,14 @@ class ResolutionCache:
             os.fsync(tmp.fileno())
         finally:
             tmp.close()
-        os.replace(tmp.name, self.path)
+        try: # replace fails if tmp file and destination are not on the same file system
+            os.replace(tmp.name, self.path)
+        except OSError as e:
+            if e.errno == errno.EXDEV:
+                shutil.copyfile(tmp.name, self.path)
+                os.unlink(tmp.name)
+            else:
+                raise e
 
     def _make_key(self, arxiv_id: str | None, doi: str | None) -> str:
         """Create cache key from identifiers."""


### PR DESCRIPTION
if tmp folder and working directory are not on the same filesystem, os.replace throws an error. I am now reverting the normal copy and unlink in this case.