### PR TITLE
fix(updater): retain non-standard BibTeX entry types and report dropped entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Silent data loss on non-standard BibTeX entry types**: `BibLoader` constructed `BibTexParser(common_strings=True)` without `ignore_nonstandard_types=False`. Because bibtexparser defaults `ignore_nonstandard_types=True`, biblatex entry types (`@online`, `@software`, `@dataset`, `@patent`, `@electronic`, `@thesis`, …) were silently dropped at parse time — never entering the database, never resolved, written, or reported (a real run lost `@online{nanda2025pragmatic}`, 177→176 entries). The parser now passes `ignore_nonstandard_types=False`, so these entries are retained and round-trip through `BibWriter` unchanged. (Accepted trade-off: this also retains typo'd/unknown entry types such as `@junk` instead of dropping them — a visible, fixable artifact is preferable to silent data loss.)
+- **Dropped-entry audit trail**: added a defense-in-depth safety net for entries the parser still skips silently (genuinely malformed input). A new pure helper `detect_dropped_keys(raw_text, parsed_ids)` compares declared `@key` markers against parsed IDs; `load_databases` now logs a `WARNING` naming each dropped citation key and its file, and — when `--report` is set — emits one JSONL row per dropped key via the new `write_dropped_report_line` using the existing report schema with `action="dropped"`. Existing report rows and their ordering are unchanged.
+
 ## [0.9.0] - 2026-05-08
 
 ### Added

--- a/src/bibtex_updater/updater.py
+++ b/src/bibtex_updater/updater.py
@@ -102,7 +102,15 @@ except Exception:  # pragma: no cover
 # ------------- IO Helpers -------------
 class BibLoader:
     def __init__(self) -> None:
-        self.parser = BibTexParser(common_strings=True)
+        # ignore_nonstandard_types defaults to True in bibtexparser, which
+        # SILENTLY DROPS biblatex entry types such as @online, @software,
+        # @dataset, @patent, @electronic, @thesis at parse time. Disabling it
+        # keeps these entries so they are resolved, written, and reported.
+        # Trade-off: disabling the filter also retains typo'd/unknown entry
+        # types (e.g. @junk) instead of dropping them; we accept that over
+        # silent data loss, since a stray bad type is visible and fixable
+        # whereas a vanished entry is not.
+        self.parser = BibTexParser(common_strings=True, ignore_nonstandard_types=False)
         self.parser.customization = None
 
     def load_file(self, path: str) -> bibtexparser.bibdatabase.BibDatabase:
@@ -3645,6 +3653,68 @@ def write_report_line(fh, res: ProcessResult, src_file: str | None = None) -> No
     fh.write(json.dumps(line, ensure_ascii=False) + "\n")
 
 
+# Matches a BibTeX entry header: @type{ key , ... — captures the citation key.
+# Anchored to the start of a logical line (optional leading whitespace only) so
+# the scan does not false-positive on (a) full-line ``%`` comments — the comment
+# marker precedes ``@`` on the line — or (b) a ``@type{key,`` substring sitting
+# inside a field value, which is never at column ~0.
+_ENTRY_KEY_RE = re.compile(r"(?m)^[ \t]*@\w+\s*\{\s*([^,\s]+)\s*,")
+
+
+def detect_dropped_keys(raw_text: str, parsed_ids: set[str]) -> list[str]:
+    """Find entry keys declared in raw BibTeX text but missing from the parsed DB.
+
+    Defense-in-depth against silent data loss: even with
+    ``ignore_nonstandard_types=False`` the parser still skips genuinely
+    malformed entries without naming them. This compares the citation keys
+    declared in the source text against the IDs that actually made it into the
+    database.
+
+    Args:
+        raw_text: The raw BibTeX file contents.
+        parsed_ids: The set of entry IDs present in the parsed database.
+
+    Returns:
+        Declared keys absent from ``parsed_ids``, in declaration order, deduped.
+    """
+    dropped: list[str] = []
+    seen: set[str] = set()
+    for match in _ENTRY_KEY_RE.finditer(raw_text):
+        key = match.group(1)
+        if key in parsed_ids or key in seen:
+            continue
+        seen.add(key)
+        dropped.append(key)
+    return dropped
+
+
+def write_dropped_report_line(fh, key: str, src_file: str | None = None) -> None:
+    """Write a JSONL report row for a dropped (unparseable) entry.
+
+    Emits exactly the same schema as :func:`write_report_line` so the report
+    stays consistent for downstream consumers, with ``action="dropped"`` and
+    only the original key populated.
+
+    Args:
+        fh: Open writable file handle.
+        key: The dropped citation key.
+        src_file: Source file the entry was declared in.
+    """
+    line = {
+        "file": src_file,
+        "key_old": key,
+        "key_new": None,
+        "doi_old": None,
+        "doi_new": None,
+        "action": "dropped",
+        "method": None,
+        "confidence": None,
+        "title_old": "",
+        "title_new": None,
+    }
+    fh.write(json.dumps(line, ensure_ascii=False) + "\n")
+
+
 # ------------- Main function helper components -------------
 
 
@@ -3795,10 +3865,28 @@ def load_databases(
         List of (path, database) tuples, or None if loading fails.
     """
     databases: list[tuple[str, bibtexparser.bibdatabase.BibDatabase]] = []
+    dropped: list[tuple[str, str]] = []  # (src_file, dropped_key)
     try:
         for path in args.inputs:
             db = loader.load_file(path)
             databases.append((path, db))
+
+            # Defense-in-depth: detect entries declared in the source file but
+            # missing from the parsed DB (genuinely malformed entries the parser
+            # skips silently). Name every dropped citation key so the loss is
+            # never silent again.
+            try:
+                with open(path, encoding="utf-8") as f:
+                    raw_text = f.read()
+            except OSError:
+                raw_text = ""
+            parsed_ids = {e.get("ID") for e in db.entries if e.get("ID")}
+            for key in detect_dropped_keys(raw_text, parsed_ids):
+                logger.warning("Dropped unparseable entry '%s' from %s (not added to database)", key, path)
+                dropped.append((path, key))
+
+        # Thread dropped keys to the report writer (consumed when --report set).
+        args._dropped_entries = dropped
         return databases
     except Exception as e:
         logger.error("Failed to read inputs: %s", e)
@@ -3920,6 +4008,14 @@ def write_output_and_report(
             for idx, res in enumerate(results):
                 src_file = src_for_entry[idx] if src_for_entry and idx < len(src_for_entry) else None
                 write_report_line(fh, res, src_file=src_file)
+
+            # Append an audit row per dropped (unparseable) entry so the loss is
+            # recorded, not just logged. Emit once even across multi-file
+            # in-place runs to avoid duplicate rows.
+            if not getattr(args, "_dropped_reported", False):
+                for src_file, key in getattr(args, "_dropped_entries", []) or []:
+                    write_dropped_report_line(fh, key, src_file=src_file)
+                args._dropped_reported = True
 
     return 0
 

--- a/tests/test_bib_loader.py
+++ b/tests/test_bib_loader.py
@@ -1,0 +1,192 @@
+"""Tests for BibLoader non-standard entry type retention and dropped-key audit trail.
+
+Regression coverage for the silent data-loss bug where bibtexparser's default
+``ignore_nonstandard_types=True`` silently discarded biblatex entry types such
+as ``@online``, ``@software``, ``@dataset`` at parse time. These tests are
+network-free and exercise only parsing, writing, and the dropped-key safety net.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from bibtex_updater.updater import (
+    BibLoader,
+    BibWriter,
+    detect_dropped_keys,
+    write_dropped_report_line,
+)
+
+ONLINE_ENTRY = """@online{nanda2025pragmatic,
+  title  = {Pragmatic Mechanistic Interpretability},
+  author = {Nanda, Neel},
+  year   = {2025},
+  url    = {https://example.org/pragmatic}
+}
+"""
+
+SOFTWARE_ENTRY = """@software{somesoftware2024,
+  title  = {Some Software Package},
+  author = {Doe, Jane},
+  year   = {2024}
+}
+"""
+
+DATASET_ENTRY = """@dataset{somedataset2023,
+  title  = {Some Dataset},
+  author = {Smith, John},
+  year   = {2023}
+}
+"""
+
+ARTICLE_ENTRY = """@article{stdarticle2022,
+  title   = {A Standard Article},
+  author  = {Roe, Richard},
+  journal = {Journal of Things},
+  year    = {2022}
+}
+"""
+
+
+class TestBibLoaderNonstandardTypes:
+    """Non-standard biblatex entry types must survive parsing and round-trip."""
+
+    def test_loads_retains_online_entry(self):
+        """``loads()`` keeps an ``@online`` entry instead of silently dropping it."""
+        db = BibLoader().loads(ONLINE_ENTRY)
+        ids = {e.get("ID") for e in db.entries}
+        assert "nanda2025pragmatic" in ids
+        entry = next(e for e in db.entries if e.get("ID") == "nanda2025pragmatic")
+        assert entry.get("ENTRYTYPE") == "online"
+
+    @pytest.mark.parametrize(
+        ("text", "key", "entrytype"),
+        [
+            (SOFTWARE_ENTRY, "somesoftware2024", "software"),
+            (DATASET_ENTRY, "somedataset2023", "dataset"),
+        ],
+    )
+    def test_loads_retains_software_and_dataset(self, text, key, entrytype):
+        """``loads()`` keeps ``@software`` and ``@dataset`` entries."""
+        db = BibLoader().loads(text)
+        ids = {e.get("ID") for e in db.entries}
+        assert key in ids
+        entry = next(e for e in db.entries if e.get("ID") == key)
+        assert entry.get("ENTRYTYPE") == entrytype
+
+    def test_loads_retains_nonstandard_alongside_standard(self):
+        """A standard ``@article`` is retained alongside non-standard types."""
+        text = ONLINE_ENTRY + SOFTWARE_ENTRY + DATASET_ENTRY + ARTICLE_ENTRY
+        db = BibLoader().loads(text)
+        ids = {e.get("ID") for e in db.entries}
+        assert ids == {
+            "nanda2025pragmatic",
+            "somesoftware2024",
+            "somedataset2023",
+            "stdarticle2022",
+        }
+
+    def test_load_file_roundtrips_online_entry(self, tmp_path):
+        """``load_file()`` -> ``BibWriter`` round-trips an ``@online`` entry."""
+        src = tmp_path / "in.bib"
+        src.write_text(ONLINE_ENTRY, encoding="utf-8")
+
+        db = BibLoader().load_file(str(src))
+        ids = {e.get("ID") for e in db.entries}
+        assert "nanda2025pragmatic" in ids
+
+        dumped = BibWriter().dumps(db)
+        assert "nanda2025pragmatic" in dumped
+        assert "@online" in dumped
+
+
+class TestDroppedKeySafetyNet:
+    """Genuinely unparseable entries must be logged and recorded, not lost silently."""
+
+    def test_detect_dropped_keys_pure_function(self):
+        """``detect_dropped_keys`` returns declared keys absent from parsed IDs."""
+        raw = ONLINE_ENTRY + ARTICLE_ENTRY
+        parsed_ids = {"stdarticle2022"}  # simulate @online lost at parse time
+        dropped = detect_dropped_keys(raw, parsed_ids)
+        assert dropped == ["nanda2025pragmatic"]
+
+    def test_detect_dropped_keys_none_dropped(self):
+        """No dropped keys when every declared key is parsed."""
+        raw = ONLINE_ENTRY + ARTICLE_ENTRY
+        parsed_ids = {"nanda2025pragmatic", "stdarticle2022"}
+        assert detect_dropped_keys(raw, parsed_ids) == []
+
+    def test_malformed_entry_is_detected_as_dropped(self):
+        """A truly malformed entry the parser cannot keep is detected as dropped."""
+        malformed = "@article{broken_entry, title = {Unterminated \n\n"
+        raw = ARTICLE_ENTRY + malformed
+        db = BibLoader().loads(raw)
+        parsed_ids = {e.get("ID") for e in db.entries}
+        dropped = detect_dropped_keys(raw, parsed_ids)
+        assert "broken_entry" in dropped
+        assert "stdarticle2022" not in dropped
+
+    def test_commented_out_entry_is_not_a_false_positive(self):
+        """A full-line ``%``-commented ``@article{...}`` must NOT be reported dropped."""
+        raw = ARTICLE_ENTRY + "% @article{commented_out, title = {Disabled}, year = {2020}}\n"
+        db = BibLoader().loads(raw)
+        parsed_ids = {e.get("ID") for e in db.entries}
+        assert "stdarticle2022" in parsed_ids
+        dropped = detect_dropped_keys(raw, parsed_ids)
+        assert "commented_out" not in dropped
+        assert dropped == []
+
+    def test_entry_marker_inside_field_value_is_not_a_false_positive(self):
+        """``@type{key,`` appearing inside a field value must NOT be reported dropped."""
+        raw = (
+            "@online{real_entry,\n"
+            "  title  = {A Real Entry},\n"
+            "  author = {Doe, Jane},\n"
+            "  year   = {2025},\n"
+            "  note   = {See also @article{fake, } discussed inline},\n"
+            "  url    = {https://example.org/real}\n"
+            "}\n"
+        )
+        db = BibLoader().loads(raw)
+        parsed_ids = {e.get("ID") for e in db.entries}
+        assert "real_entry" in parsed_ids
+        dropped = detect_dropped_keys(raw, parsed_ids)
+        assert "fake" not in dropped
+        assert dropped == []
+
+    def test_dropped_key_logged_with_citation_key_named(self, caplog):
+        """The dropped citation key and file are named in a warning log line."""
+        import logging
+
+        logger = logging.getLogger("bibtex_updater.test_dropped")
+        with caplog.at_level(logging.WARNING, logger="bibtex_updater.test_dropped"):
+            for key in detect_dropped_keys(ONLINE_ENTRY, set()):
+                logger.warning("Dropped unparseable entry %r from %s (not added to database)", key, "in.bib")
+        assert "nanda2025pragmatic" in caplog.text
+        assert "in.bib" in caplog.text
+
+    def test_dropped_report_line_schema(self):
+        """``write_dropped_report_line`` emits the existing JSONL schema with action='dropped'."""
+        fh = io.StringIO()
+        write_dropped_report_line(fh, "nanda2025pragmatic", src_file="in.bib")
+        line = json.loads(fh.getvalue().strip())
+        assert line["action"] == "dropped"
+        assert line["key_old"] == "nanda2025pragmatic"
+        assert line["key_new"] is None
+        # Same schema keys as write_report_line so the report stays consistent.
+        assert set(line.keys()) == {
+            "file",
+            "key_old",
+            "key_new",
+            "doi_old",
+            "doi_new",
+            "action",
+            "method",
+            "confidence",
+            "title_old",
+            "title_new",
+        }
+        assert line["file"] == "in.bib"


### PR DESCRIPTION
## Problem (data loss)

`BibLoader.__init__` constructed `BibTexParser(common_strings=True)` without `ignore_nonstandard_types=False`. bibtexparser defaults that flag to `True`, so **non-standard biblatex entry types (`@online`, `@software`, `@dataset`, `@patent`, `@electronic`, `@thesis`, …) were silently dropped at parse time** — they never entered the database, were never resolved, never written, and never appeared in the JSONL report.

Discovered in the wild: a real `bibtex-update` run dropped `@online{nanda2025pragmatic,...}` from a 177-entry bibliography (→176). The only signal was a generic stderr `WARNING: Entry type online not standard. Not considered.` that does **not** name the citation key, and the `--report` audit trail recorded nothing. A bibliography-maintenance tool silently deleting entries is a serious correctness bug.

## Fix

1. **Retain non-standard types** — `BibTexParser(common_strings=True, ignore_nonstandard_types=False)`. Applies to both `load_file` and `loads` (shared parser). `BibWriter` already round-trips these types unchanged.
   - Accepted trade-off: typo'd/unknown types (e.g. `@junk`) are now also retained rather than dropped — a visible, fixable artifact beats silent data loss.
2. **Dropped-key safety net / audit trail** — defense-in-depth for entries bibtexparser still legitimately skips (genuinely malformed). New pure helper `detect_dropped_keys(raw_text, parsed_ids)` compares declared `@type{key,` headers against parsed IDs; each missing key now (a) logs a `WARNING` that **names the citation key and file**, and (b) emits a JSONL report row with `action="dropped"` (same schema as `write_report_line`). Regex anchored to logical-line start to avoid false positives on `%`-comments and `@{...}` markers inside field values.

## Tests

- New `tests/test_bib_loader.py` (12 tests): `@online`/`@software`/`@dataset` retention via `loads()` and `load_file()`+`BibWriter` round-trip alongside standard types; `detect_dropped_keys` happy/none/malformed paths; per-key warning naming; report-row schema parity with `write_report_line`; false-positive guards for commented-out entries and entry markers inside field values.
- Full suite: **736 passed, 1 skipped, 0 failed** (724 baseline + 12 new; zero regressions). Network-free.
- `pre-commit run --all-files` clean (black 24.10.0, ruff 0.7.4).

## Review

Independently code-reviewed: verdict **APPROVE** after the regex-hardening nit (folded in). Confirmed correct fix, sound safety net (no false-flagging of `@string`/`@comment`/duplicate keys/legitimate merges), report schema parity, and zero regression on the normal all-standard-types path.

## Notes

- No version bump (hatch-vcs derives from tags). Merging does **not** trigger PyPI publish (release-event-gated only).
- CHANGELOG updated under `[Unreleased] → Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)