### PR TITLE
fix: enforce arXiv-ID↔title consistency to catch misattributed identifiers

### DIFF
--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -190,6 +190,7 @@ class FactCheckStatus(Enum):
     PARTIAL_MATCH = "partial_match"
     HALLUCINATED = "hallucinated"
     API_ERROR = "api_error"
+    ARXIV_ID_MISMATCH = "arxiv_id_mismatch"  # Entry's cited arXiv ID resolves to a different paper
 
     # Pre-API validation statuses
     FUTURE_DATE = "future_date"  # Year is in the future
@@ -261,6 +262,13 @@ class FactCheckerConfig:
     max_candidates_per_source: int = 10
     check_years: bool = True
     check_dois: bool = True
+    # Verify the entry's own arXiv ID points to the entry's paper (catches
+    # misattributed identifiers that title/author search silently VERIFIES).
+    check_arxiv_consistency: bool = True
+    # Below this normalized title score (0-1), the entry's arXiv ID is treated
+    # as pointing to a *different* paper. Deliberately low so only clear
+    # different-paper cases trip it, not minor preprint/published title edits.
+    arxiv_consistency_min_title: float = 0.50
     # CheckIfExist additions (Item 1 + 2): explicit cascading + top-K retrieval
     cascade_mode: bool = False
     top_k: int = DEFAULT_TOP_K
@@ -1553,6 +1561,15 @@ class FactChecker:
                     errors=[f"DOI does not resolve: {entry.get('doi', '')}"],
                 )
 
+        # Pre-search consistency: the entry's own arXiv ID must point to *this*
+        # paper. A wrong ID otherwise survives because title/author search
+        # VERIFIES the entry against the real paper from Crossref/DBLP/S2,
+        # silently leaving the misattributed identifier in place.
+        if self.config.check_arxiv_consistency:
+            arxiv_status = self._check_arxiv_id_consistency(entry)
+            if arxiv_status is not None:
+                return arxiv_status
+
         query = f"{title_norm} {first_author}".strip()
         # Item 1: explicit cascade vs. legacy parallel search.
         if self.config.cascade_mode:
@@ -1702,6 +1719,68 @@ class FactChecker:
             if m:
                 return re.sub(r"v\d+$", "", m.group(1).strip())
         return None
+
+    def _check_arxiv_id_consistency(self, entry: dict[str, Any]) -> FactCheckResult | None:
+        """Flag entries whose cited arXiv ID resolves to a *different* paper.
+
+        Title/author search happily VERIFIES a misattributed entry against the
+        real paper returned by Crossref/DBLP/S2, so a wrong arXiv ID (a
+        copy-paste or lookup error) survives unnoticed. Here we fetch the
+        entry's own arXiv ID and require its title to match the entry; a clear
+        mismatch is a misattributed identifier, not a valid preprint, and is
+        reported as :class:`FactCheckStatus.ARXIV_ID_MISMATCH`.
+
+        Returns ``None`` when there is nothing to check (no arXiv client, no
+        arXiv ID, lookup failed, or the titles are consistent) so the normal
+        verification flow proceeds.
+        """
+        if self.arxiv is None:
+            return None
+        arxiv_id = self._arxiv_id_from_entry(entry)
+        if not arxiv_id:
+            return None
+
+        try:
+            xml = self.arxiv.fetch_atom(arxiv_id)
+        except Exception:
+            return None
+        if not xml:
+            return None
+        rec = arxiv_atom_to_record(xml)
+        if rec is None or not rec.title:
+            return None
+
+        entry_title = normalize_title_for_match(entry.get("title", ""))
+        if not entry_title:
+            return None
+        arxiv_title = normalize_title_for_match(rec.title)
+        title_score = token_sort_ratio(entry_title, arxiv_title) / 100.0
+        if title_score >= self.config.arxiv_consistency_min_title:
+            return None
+
+        self.logger.warning(
+            "arXiv ID %s for entry %r points to a different paper: entry title "
+            "%r vs arXiv title %r (title score %.2f)",
+            arxiv_id,
+            entry.get("ID", "?"),
+            entry.get("title", ""),
+            rec.title,
+            title_score,
+        )
+        return FactCheckResult(
+            entry_key=entry.get("ID", "unknown"),
+            entry_type=entry.get("ENTRYTYPE", "misc").lower(),
+            status=FactCheckStatus.ARXIV_ID_MISMATCH,
+            overall_confidence=0.0,
+            field_comparisons={},
+            best_match=rec,
+            api_sources_queried=["arxiv"],
+            api_sources_with_hits=["arxiv"],
+            errors=[
+                f"arXiv ID {arxiv_id} resolves to {rec.title!r}, which does not "
+                f"match entry title {entry.get('title', '')!r}"
+            ],
+        )
 
     def _query_arxiv_by_id(
         self,

--- a/src/bibtex_updater/updater.py
+++ b/src/bibtex_updater/updater.py
@@ -1685,11 +1685,13 @@ class Resolver:
 
         # Stage 1: Direct lookup (arXiv -> S2 -> Crossref)
         result, candidate_doi = self._stage1_direct_lookup(detection)
+        result = self._verify_arxiv_match(result, entry, title_norm)
         if result:
             return result
 
         # Stage 1b: OpenAlex lookup (preprint-to-published version tracking)
         result = self._stage1b_openalex(detection, candidate_doi)
+        result = self._verify_arxiv_match(result, entry, title_norm)
         if result:
             return result
 
@@ -1728,6 +1730,40 @@ class Resolver:
         if result:
             return result
 
+        return None
+
+    def _verify_arxiv_match(
+        self, result: PublishedRecord | None, entry: dict[str, Any], title_norm: str
+    ) -> PublishedRecord | None:
+        """Reject an arXiv-ID-keyed record whose title/author do not match the entry.
+
+        Stages 1 and 1b resolve purely from ``detection.arxiv_id`` and assign
+        ``confidence = 1.0`` to whatever that ID maps to. If the entry's cited
+        arXiv ID is wrong, those stages would silently rewrite the entry into an
+        unrelated paper. Gate them on the same combined title/author match score
+        the search-based stages (1c, 3-5) already require, so a misattributed
+        identifier falls through to title-based resolution instead of corrupting
+        the entry.
+
+        Returns ``result`` unchanged when it is ``None`` or when the entry has no
+        title to verify against (we then trust the direct ID lookup as before).
+        """
+        if result is None:
+            return None
+        if not title_norm:
+            return result
+        authors_ref = authors_last_names(entry.get("author", ""))
+        score = self._compute_match_score(title_norm, result, authors_ref)
+        if score >= self.MATCH_THRESHOLD:
+            return result
+        self.logger.warning(
+            "Rejecting %s: arXiv-keyed record title %r does not match entry %r (score %.2f < %.2f)",
+            result.method,
+            result.title,
+            entry.get("title", ""),
+            score,
+            self.MATCH_THRESHOLD,
+        )
         return None
 
     def _stage1_direct_lookup(self, detection: PreprintDetection) -> tuple[PublishedRecord | None, str | None]:

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -1128,6 +1128,12 @@ def dblp_hit_to_record(hit: dict[str, Any]) -> PublishedRecord | None:
         if not full:
             continue
         parts = full.split()
+        # DBLP appends a 4-digit disambiguation suffix to homonymous author
+        # names ("Yu Sun 0020", "Chuan Guo 0001"). Drop it so the surname is the
+        # real family name rather than the number, which would otherwise score a
+        # false author mismatch against the bib entry.
+        if len(parts) >= 2 and re.fullmatch(r"\d{4}", parts[-1]):
+            parts = parts[:-1]
         if len(parts) >= 2:
             authors.append({"given": " ".join(parts[:-1]), "family": parts[-1]})
         else:

--- a/tests/test_arxiv_id_lookup.py
+++ b/tests/test_arxiv_id_lookup.py
@@ -57,6 +57,108 @@ ARXIV_ERROR_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
 </feed>
 """
 
+# The real ONEBench paper (arXiv:2412.07689).
+ONEBENCH_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2412.07689v1</id>
+    <published>2024-12-10T18:00:00Z</published>
+    <title>ONEBench to Test Them All: Sample-Level Benchmarking Over Open-Ended Capabilities</title>
+    <summary>We propose ONEBench...</summary>
+    <author><name>Adhiraj Ghosh</name></author>
+    <author><name>Sebastian Dziadzio</name></author>
+    <author><name>Ameya Prabhu</name></author>
+    <author><name>Vishaal Udandarao</name></author>
+    <author><name>Samuel Albanie</name></author>
+    <author><name>Matthias Bethge</name></author>
+    <arxiv:primary_category term="cs.LG"/>
+  </entry>
+</feed>
+"""
+
+# The *unrelated* paper that the wrong arXiv:2412.06745 actually points to.
+ROBOTRON_ATOM = """<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2412.06745v1</id>
+    <published>2024-12-09T18:00:00Z</published>
+    <title>RoboTron-Drive: All-in-One Large Multimodal Model for Autonomous Driving</title>
+    <summary>We present RoboTron-Drive...</summary>
+    <author><name>Zhijian Huang</name></author>
+    <author><name>Chengjian Feng</name></author>
+    <author><name>Feng Yan</name></author>
+    <arxiv:primary_category term="cs.CV"/>
+  </entry>
+</feed>
+"""
+
+
+def _onebench_entry(arxiv_url: str) -> dict[str, str]:
+    """ONEBench bib entry parameterized by the arXiv URL it cites."""
+    return {
+        "ID": "onebench2024",
+        "ENTRYTYPE": "inproceedings",
+        "title": "ONEBench to Test Them All: Sample-Level Benchmarking Over Open-Ended Capabilities",
+        "author": (
+            "Ghosh, Adhiraj and Dziadzio, Sebastian and Prabhu, Ameya and "
+            "Udandarao, Vishaal and Albanie, Samuel and Bethge, Matthias"
+        ),
+        "url": arxiv_url,
+        "year": "2024",
+    }
+
+
+class TestArxivIdConsistency:
+    """Regression: an entry whose cited arXiv ID resolves to a *different* paper
+    must be flagged ARXIV_ID_MISMATCH, not silently VERIFIED against the real
+    paper found by title/author search. This is the onebench2024 failure where
+    the correct arXiv:2412.07689 was replaced with the unrelated 2412.06745.
+    """
+
+    def test_wrong_arxiv_id_flagged_mismatch(self, dead_sources, logger):
+        crossref, dblp, s2 = dead_sources
+        arxiv = _StubArxiv({"2412.06745": ROBOTRON_ATOM})
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger, arxiv=arxiv)
+
+        result = checker.check_entry(_onebench_entry("https://arxiv.org/abs/2412.06745"))
+
+        assert result.status == FactCheckStatus.ARXIV_ID_MISMATCH
+        assert "2412.06745" in arxiv.requested
+        assert result.best_match is not None
+        assert "RoboTron" in result.best_match.title
+        assert result.errors and "2412.06745" in result.errors[0]
+
+    def test_correct_arxiv_id_not_flagged(self, dead_sources, logger):
+        """The correct ID resolves to ONEBench, so the entry verifies instead."""
+        crossref, dblp, s2 = dead_sources
+        arxiv = _StubArxiv({"2412.07689": ONEBENCH_ATOM})
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger, arxiv=arxiv)
+
+        result = checker.check_entry(_onebench_entry("https://arxiv.org/abs/2412.07689"))
+
+        assert result.status != FactCheckStatus.ARXIV_ID_MISMATCH
+        assert result.status == FactCheckStatus.VERIFIED
+
+    def test_mismatch_check_disabled_by_config(self, dead_sources, logger):
+        """With the guard disabled, the wrong ID is not flagged (opt-out works)."""
+        crossref, dblp, s2 = dead_sources
+        arxiv = _StubArxiv({"2412.06745": ROBOTRON_ATOM})
+        config = FactCheckerConfig(check_arxiv_consistency=False)
+        checker = FactChecker(crossref, dblp, s2, config, logger, arxiv=arxiv)
+
+        result = checker.check_entry(_onebench_entry("https://arxiv.org/abs/2412.06745"))
+
+        assert result.status != FactCheckStatus.ARXIV_ID_MISMATCH
+
+    def test_no_arxiv_client_skips_consistency_check(self, dead_sources, logger):
+        """Without an arXiv client the guard is a no-op (no false mismatch)."""
+        crossref, dblp, s2 = dead_sources
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(_onebench_entry("https://arxiv.org/abs/2412.06745"))
+
+        assert result.status != FactCheckStatus.ARXIV_ID_MISMATCH
+
 
 class _StubArxiv:
     """ArxivClient stand-in returning canned Atom XML, no network."""

--- a/tests/test_bib_utils.py
+++ b/tests/test_bib_utils.py
@@ -222,6 +222,47 @@ class TestDblpHitToRecord:
         assert rec is not None
         assert rec.url == "https://example.com/paper"
 
+    def test_dblp_disambiguation_suffix_stripped_from_surname(self):
+        """Regression: DBLP appends a 4-digit homonym suffix ("Yu Sun 0020",
+        "Chuan Guo 0001"). It must be dropped so the family name is the real
+        surname, not the number -- otherwise the author comparison scores a
+        false author_mismatch against the correct bib entry.
+        """
+        hit = {
+            "info": {
+                "title": "On Calibration of Modern Neural Networks",
+                "authors": {"author": ["Chuan Guo 0001", "Geoff Pleiss", "Yu Sun 0020", "Kilian Q. Weinberger"]},
+                "venue": "Journal of Testing",
+                "year": "2017",
+                "doi": "10.1234/dblp.calib",
+                "type": "Conference and Workshop Papers",
+            }
+        }
+        rec = dblp_hit_to_record(hit)
+        assert rec is not None
+        families = [a["family"] for a in rec.authors]
+        assert families == ["Guo", "Pleiss", "Sun", "Weinberger"]
+        # The disambiguation digits move into the given name, not the surname.
+        assert rec.authors[0] == {"given": "Chuan", "family": "Guo"}
+        assert rec.authors[2] == {"given": "Yu", "family": "Sun"}
+
+    def test_corr_venue_rejected_as_preprint(self):
+        """Regression (F4): DBLP labels arXiv papers with venue "CoRR". Such a
+        hit must be rejected (return None) so resolution falls through to the
+        real published venue instead of accepting the preprint as published.
+        """
+        hit = {
+            "info": {
+                "title": "Some Preprint Indexed Under CoRR",
+                "authors": {"author": ["Jane Doe"]},
+                "venue": "CoRR",
+                "year": "2024",
+                "doi": "10.48550/arXiv.2401.00001",
+                "type": "Journal Articles",
+            }
+        }
+        assert dblp_hit_to_record(hit) is None
+
 
 class TestS2DataToRecord:
     """Tests for s2_data_to_record function."""

--- a/tests/test_resolver_stages.py
+++ b/tests/test_resolver_stages.py
@@ -271,6 +271,59 @@ class TestResolverMixinMethods:
         )
         assert resolver._credible_journal_article(journal_record)
 
+    def test_verify_arxiv_match_rejects_title_mismatch(self, resolver):
+        """Regression (onebench/agrawal): Stage 1/1b trust ``detection.arxiv_id``
+        and assign confidence 1.0. If the cited arXiv ID is wrong, the record it
+        maps to is an unrelated paper; _verify_arxiv_match must reject it so the
+        cascade falls through to title-based resolution instead of silently
+        rewriting the entry into that other paper.
+        """
+        entry = {
+            "title": "ONEBench to Test Them All: Sample-Level Benchmarking Over Open-Ended Capabilities",
+            "author": "Ghosh, Adhiraj and Dziadzio, Sebastian and Prabhu, Ameya",
+        }
+        # The record the wrong arXiv ID (2412.06745) actually resolves to.
+        wrong_paper = PublishedRecord(
+            doi="10.1000/robotron",
+            title="RoboTron-Drive: All-in-One Large Multimodal Model for Autonomous Driving",
+            journal="Some Journal",
+            year=2024,
+            authors=[{"given": "Zhijian", "family": "Huang"}, {"given": "Chengjian", "family": "Feng"}],
+            type="journal-article",
+        )
+        title_norm = normalize_title_for_match(entry["title"])
+        assert resolver._verify_arxiv_match(wrong_paper, entry, title_norm) is None
+
+    def test_verify_arxiv_match_accepts_title_match(self, resolver):
+        """A record whose title/author match the entry passes the gate unchanged."""
+        entry = {
+            "title": "ONEBench to Test Them All: Sample-Level Benchmarking Over Open-Ended Capabilities",
+            "author": "Ghosh, Adhiraj and Dziadzio, Sebastian and Prabhu, Ameya",
+        }
+        right_paper = PublishedRecord(
+            doi="10.18653/v1/2025.acl-long.1560",
+            title="ONEBench to Test Them All: Sample-Level Benchmarking Over Open-Ended Capabilities",
+            journal="ACL",
+            year=2025,
+            authors=[
+                {"given": "Adhiraj", "family": "Ghosh"},
+                {"given": "Sebastian", "family": "Dziadzio"},
+                {"given": "Ameya", "family": "Prabhu"},
+            ],
+            type="proceedings-article",
+        )
+        title_norm = normalize_title_for_match(entry["title"])
+        assert resolver._verify_arxiv_match(right_paper, entry, title_norm) is right_paper
+
+    def test_verify_arxiv_match_passthrough_without_title(self, resolver):
+        """With no entry title to verify against, the direct ID lookup is trusted."""
+        rec = PublishedRecord(doi="10.1/x", title="Whatever Paper", year=2024, authors=[])
+        assert resolver._verify_arxiv_match(rec, {"title": ""}, "") is rec
+
+    def test_verify_arxiv_match_none_stays_none(self, resolver):
+        """A miss (None) is propagated unchanged."""
+        assert resolver._verify_arxiv_match(None, {"title": "anything"}, "anything") is None
+
     def test_authors_to_bibtex_string_formats_correctly(self, resolver):
         """_authors_to_bibtex_string should format authors correctly."""
         record = PublishedRecord(


### PR DESCRIPTION
## Problem

An entry's cited arXiv ID was trusted without checking that the ID's *actual* paper matches the entry. A wrong ID (copy-paste / lookup error) survived because title/author search VERIFIED the entry against the real paper from Crossref/DBLP/S2 — silently leaving the misattributed identifier in place. Worse, the resolver's arXiv-ID-keyed stages would rewrite an entry into an unrelated paper at `confidence = 1.0`.

Concrete failures (found in a real `references.bib`):
- `onebench2024`: correct `2412.07689` ("ONEBench…") replaced by `2412.06745` ("RoboTron-Drive: …Autonomous Driving") — a completely different paper.
- `agrawal2024`: same pattern.

## Fix

- **`fact_checker.py`**: new `FactCheckStatus.ARXIV_ID_MISMATCH` + `_check_arxiv_id_consistency()`, run in `check_entry` before the search cascade. Fetches the entry's own arXiv ID and flags it when the fetched paper's title diverges. Gated by `FactCheckerConfig.check_arxiv_consistency` (default on) with `arxiv_consistency_min_title=0.50`.
- **`updater.py`**: `Resolver._verify_arxiv_match()` gates Stage 1 / Stage 1b (arXiv-ID-keyed lookups) on `MATCH_THRESHOLD`, matching the search-based stages (1c, 3–5). A wrong cited ID now falls through to title-based resolution instead of corrupting the entry.
- **`utils.dblp_hit_to_record`**: strip DBLP's 4-digit homonym suffix (`"Yu Sun 0020"` → family `"Sun"`) that produced false `author_mismatch` verdicts.

## Tests

- `tests/test_arxiv_id_lookup.py::TestArxivIdConsistency` — real onebench fixtures: wrong ID flagged, correct ID verifies, config opt-out, no-arxiv-client no-op.
- `tests/test_resolver_stages.py` — `_verify_arxiv_match` reject/accept/passthrough cases.
- `tests/test_bib_utils.py` — DBLP suffix stripping + `CoRR`-venue reject (previously fixed but untested).

Full suite: 761 passed, `ruff check` clean. (The 2 `test_obsidian_keywords.py::TestCLI` failures are pre-existing — they spawn a bare `python` not on PATH.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)