### PR TITLE
Single-source surname keys + self-checking oracles to prevent comparison asymmetry (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-28
+
+### Changed
+- **Comparison surnames now have a single source of truth (`PublishedRecord.surname_keys`)**: the recurring "subtle wrong verdict" bugs all shared one root cause — *comparison asymmetry*, where the BibTeX-entry side and the API-record side reduced the same surname through *different* normalization (e.g. entry `"Aaron van den Oord"` → `oord` vs. record `family` kept raw as `van den oord` → Jaccard `0` → false `AUTHOR_MISMATCH` / `HALLUCINATED`). The fix had been a helper called at ~7 separate sites, which is exactly how it drifted. `PublishedRecord` now exposes `surname_keys(limit)` — the one place that turns a record author into a comparison key, routing each `family` through the same `last_name_from_person` the entry side uses via `authors_last_names`. All seven comparison sites (5 in `updater.py`, 2 in `fact_checker.py`, plus `FieldFiller._find_best_crossref_match` and `WorkingPaperVerifier._score` which were still keying the record side *raw*) now consume it, so the two sides are symmetric by construction and cannot drift again. The now-redundant module-level `_record_surnames` helper was removed. No thresholds, weights, or verdict logic changed.
+
+### Added
+- **`PublishedRecord.canonical_venue`**: a single record-side accessor for the canonical venue (wrapping `get_canonical_venue`), mirroring `surname_keys` for the venue dimension.
+
+### Fixed
+- **DBLP homonym-disambiguation suffix is now stripped at the surname-key level too**: a record family carrying a `NNNN` homonym suffix (`"Yu Sun 0020"`, `"Chuan Guo 0001"`) reduced to the *number* (`0020`) as its comparison key, falsely mismatching the same author. `last_name_from_person` now drops a trailing 4-digit token before reducing to the final surname token (guarded so an all-digits name is never emptied). This is defense-in-depth alongside the existing strip in `dblp_hit_to_record`, so the key is robust even when a suffix reaches the comparison layer from any source.
+
+### Tests
+- **+54 tests across two new self-checking oracles** that would have caught the asymmetry class before it shipped, instead of after:
+  - `tests/test_record_roundtrip.py` — a record turned into an entry (via the production `Updater.update_entry` path) must verify against *itself* with zero field mismatches and clear the resolver `MATCH_THRESHOLD`; covers particle surnames, multi-word particles, diacritics, conference venues, and many-author records.
+  - `tests/test_metamorphic_symmetry.py` — states each past bug as an *invariance*: a true match's verdict must survive citation-style transforms (`"Given Family"` ↔ `"Family, Given"`, diacritics, DBLP suffix, particle placement), `combined_author_score` must be symmetric, and `canonical_venue` must not collapse sibling journals.
+- Full suite: 839 passed, 1 skipped (was 785 + 54 new; zero regressions).
+
 ## [0.9.2] - 2026-05-27
 
 ### Fixed
@@ -315,7 +332,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite with pytest fixtures
 - MIT License
 
-[Unreleased]: https://github.com/rpatrik96/bibtexupdater/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/rpatrik96/bibtexupdater/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/rpatrik96/bibtexupdater/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/rpatrik96/bibtexupdater/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/rpatrik96/bibtexupdater/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/rpatrik96/bibtexupdater/compare/v0.7.0...v0.9.0

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -81,7 +81,6 @@ from bibtex_updater.utils import (
     is_valid_arxiv_id,
     # Matching
     jaccard_similarity,
-    last_name_from_person,
     # Text normalization
     normalize_title_for_match,
     s2_data_to_record,
@@ -1179,7 +1178,7 @@ class WorkingPaperVerifier(BaseVerifier):
         title_score = token_sort_ratio(title_entry, title_rec) / 100.0
 
         authors_entry = authors_last_names(entry.get("author", ""), limit=3)
-        authors_rec = [strip_diacritics(a.get("family", "")).lower() for a in rec.authors[:3]]
+        authors_rec = rec.surname_keys(limit=3)
         author_score = jaccard_similarity(authors_entry, authors_rec)
 
         return 0.7 * title_score + 0.3 * author_score
@@ -2041,8 +2040,7 @@ class FactChecker:
         title_b = normalize_title_for_match(rec.title or "")
         title_score = token_sort_ratio(title_norm, title_b) / 100.0
 
-        authors_b = [last_name_from_person(a.get("family", "")) for a in rec.authors][:3]
-        authors_b = [a for a in authors_b if a]
+        authors_b = rec.surname_keys(limit=3)
         author_score = jaccard_similarity(authors_ref, authors_b)
 
         return 0.7 * title_score + 0.3 * author_score
@@ -2162,8 +2160,9 @@ class FactChecker:
         # Author (P2.3: Ordered author comparison)
         entry_authors = entry.get("author", "")
         entry_names = authors_last_names(entry_authors, limit=10)
-        api_names = [last_name_from_person(a.get("family", "")) for a in record.authors]
-        api_names = [n for n in api_names if n]
+        # Route the API side through the same canonical surname reduction as the
+        # entry side. The API side was previously unsliced; keep that.
+        api_names = record.surname_keys(limit=10_000)
         # Use combined score (Jaccard + sequence similarity)
         author_score = combined_author_score(entry_names, api_names, jaccard_weight=0.5, sequence_weight=0.5)
         api_authors_str = " and ".join(f"{a.get('given', '')} {a.get('family', '')}".strip() for a in record.authors)

--- a/src/bibtex_updater/updater.py
+++ b/src/bibtex_updater/updater.py
@@ -538,7 +538,7 @@ class FieldFiller:
             title_b = normalize_title_for_match(rec.title or "")
             title_score = token_sort_ratio(title_a, title_b)
 
-            authors_b = [a.get("family", "").lower() for a in rec.authors[:3]]
+            authors_b = rec.surname_keys(limit=3)
             auth_score = jaccard_similarity(authors_a, authors_b)
 
             combined = 0.7 * (title_score / 100.0) + 0.3 * auth_score
@@ -801,17 +801,6 @@ class Detector:
             )
 
         return PreprintDetection(False)
-
-
-def _record_surnames(authors: list[dict[str, Any]], limit: int = 3) -> list[str]:
-    """Comparable surname keys for a record's authors.
-
-    Routes the API-record ``family`` names through the same ``last_name_from_person``
-    reduction the entry side uses (via ``authors_last_names``), so author Jaccard
-    comparison is symmetric for particle surnames ("van den Oord" -> "oord" on
-    both sides) instead of scoring a spurious mismatch.
-    """
-    return [n for n in (last_name_from_person(a.get("family") or "") for a in authors) if n][:limit]
 
 
 def _s2_record_is_still_preprint(msg: dict[str, Any], doi: str | None) -> bool:
@@ -2007,7 +1996,7 @@ class Resolver:
         """
         tb = normalize_title_for_match(rec.title or "")
         title_score = token_sort_ratio(title_norm, tb)  # 0..100
-        blns = _record_surnames(rec.authors)
+        blns = rec.surname_keys(limit=3)
         auth_score = jaccard_similarity(authors_ref[:3], blns)
         return 0.7 * (title_score / 100.0) + 0.3 * auth_score
 
@@ -2692,7 +2681,7 @@ class AsyncResolver:
                         continue
                     tb = normalize_title_for_match(rec.title or "")
                     title_score = token_sort_ratio(title_norm, tb)
-                    blns = _record_surnames(rec.authors)
+                    blns = rec.surname_keys(limit=3)
                     auth_score = jaccard_similarity(authors[:3], blns)
                     combined = 0.7 * (title_score / 100.0) + 0.3 * auth_score
                     if combined >= self.MATCH_THRESHOLD and self._credible_journal_article(rec):
@@ -2731,7 +2720,7 @@ class AsyncResolver:
                     )
                     tb = normalize_title_for_match(rec.title or "")
                     title_score = token_sort_ratio(title_norm, tb)
-                    blns = _record_surnames(rec.authors)
+                    blns = rec.surname_keys(limit=3)
                     auth_score = jaccard_similarity(authors[:3], blns)
                     combined = 0.7 * (title_score / 100.0) + 0.3 * auth_score
                     if combined >= self.MATCH_THRESHOLD and self._credible_journal_article(rec):
@@ -2753,7 +2742,7 @@ class AsyncResolver:
                         continue
                     tb = normalize_title_for_match(rec.title or "")
                     title_score = token_sort_ratio(title_norm, tb)
-                    blns = _record_surnames(rec.authors)
+                    blns = rec.surname_keys(limit=3)
                     auth_score = jaccard_similarity(authors[:3], blns)
                     combined = 0.7 * (title_score / 100.0) + 0.3 * auth_score
                     if combined >= self.MATCH_THRESHOLD and self._credible_journal_article(rec):
@@ -2869,7 +2858,7 @@ class AsyncResolver:
                     authors_ref = authors_last_names(entry.get("author", ""))
                     tb = normalize_title_for_match(rec.title or "")
                     title_score = token_sort_ratio(title_norm, tb)
-                    blns = _record_surnames(rec.authors)
+                    blns = rec.surname_keys(limit=3)
                     auth_score = jaccard_similarity(authors_ref[:3], blns)
                     combined = 0.7 * (title_score / 100.0) + 0.3 * auth_score
                     if combined >= self.MATCH_THRESHOLD and self._credible_journal_article(rec):

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -150,12 +150,16 @@ def last_name_from_person(name: str) -> str:
     if "," in name:
         last = name.split(",", 1)[0].strip()
     else:
-        toks = name.split()
-        last = toks[-1].strip() if toks else ""
+        last = name.strip()
     last = strip_diacritics(last).lower()
     last = re.sub(r"[^a-z0-9\s-]", "", last).strip()
 
     tokens = last.split()
+    # Drop a trailing 4-digit DBLP homonym-disambiguation suffix ("Sun 0020",
+    # "Li 0001") so the key is the real surname rather than the number. Guarded
+    # by len > 1 so a name that is only digits is never emptied.
+    while len(tokens) > 1 and re.fullmatch(r"\d{4}", tokens[-1]):
+        tokens.pop()
     if tokens:
         last = tokens[-1]
     return last
@@ -1091,6 +1095,28 @@ class PublishedRecord:
     type: str | None = None
     method: str | None = None  # how found
     confidence: float = 0.0
+
+    def surname_keys(self, limit: int = 3) -> list[str]:
+        """Canonical surname comparison keys derived from ``self.authors``.
+
+        Single source of truth for turning a record author into a surname key:
+        each ``family`` field is reduced via ``last_name_from_person`` (the same
+        function the BibTeX-entry side uses through ``authors_last_names``), so
+        the entry and record sides are provably symmetric. Mirrors
+        ``authors_last_names`` exactly -- truncate to ``limit`` first, then drop
+        empties -- so neither side can drift from the other.
+        """
+        keys = [last_name_from_person(a.get("family", "") or "") for a in self.authors][:limit]
+        return [k for k in keys if k]
+
+    @property
+    def canonical_venue(self) -> str | None:
+        """Canonical venue id for ``self.journal`` (or None if unrecognized)."""
+        # Lazy import: matching.py imports from utils, so a module-level import
+        # here would be a cycle.
+        from bibtex_updater.matching import get_canonical_venue
+
+        return get_canonical_venue(self.journal or "")
 
 
 # ------------- API Response Converters -------------

--- a/tests/test_metamorphic_symmetry.py
+++ b/tests/test_metamorphic_symmetry.py
@@ -1,0 +1,274 @@
+"""Metamorphic / symmetry properties for author comparison.
+
+Each subtle false-mismatch bug can be stated as an *invariance*: a TRUE match's
+verdict must not change when the SAME underlying name is written in a different
+but equivalent citation style. We hold one side fixed and apply a
+representation-preserving transform to the other, then assert the author
+comparison still matches.
+
+We reproduce the production author-comparison contract from
+``FactChecker._compare_all_fields``:
+
+* the ENTRY side is keyed with ``authors_last_names`` (which routes each name
+  through ``last_name_from_person``);
+* the RECORD side is keyed with ``PublishedRecord.surname_keys`` -- the single
+  source of truth that also routes each ``family`` through
+  ``last_name_from_person``, so the two sides are derived symmetrically;
+* the two key lists are scored with ``combined_author_score`` and compared to
+  ``FactCheckerConfig.author_threshold``.
+
+The point of routing BOTH sides through the same reduction is that these
+invariances hold by construction. Each property below would have failed under
+the historical asymmetric contract (entry reduced to a token, record kept raw),
+which is exactly the class of bug this suite guards against.
+
+``hypothesis`` is NOT installed in this environment, so the property tests below
+are written as thorough ``@pytest.mark.parametrize`` example tables rather than
+generators. The file therefore runs under plain pytest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bibtex_updater.fact_checker import FactCheckerConfig
+from bibtex_updater.matching import combined_author_score
+from bibtex_updater.utils import (
+    PublishedRecord,
+    authors_last_names,
+    last_name_from_person,
+)
+
+AUTHOR_THRESHOLD = FactCheckerConfig().author_threshold
+
+
+# ------------- Production-contract helpers (mirror _compare_all_fields) --------
+
+
+def _entry_keys(author_field: str) -> list[str]:
+    """Entry-side surname keys, exactly as _compare_all_fields derives them."""
+    return authors_last_names(author_field, limit=10)
+
+
+def _record_keys(families: list[str]) -> list[str]:
+    """Record-side surname keys, exactly as _compare_all_fields derives them.
+
+    Mirrors the production contract: the record side goes through
+    ``PublishedRecord.surname_keys`` (the single source of truth), which routes
+    each ``family`` through the same ``last_name_from_person`` the entry side
+    uses.
+    """
+    return PublishedRecord(doi="x", authors=[{"family": f} for f in families]).surname_keys(limit=10)
+
+
+def _author_matches(author_field: str, families: list[str]) -> bool:
+    """Replicate the author FieldComparison.matches decision."""
+    score = combined_author_score(_entry_keys(author_field), _record_keys(families), 0.5, 0.5)
+    return score >= AUTHOR_THRESHOLD
+
+
+# ------------- Property 1: surname-key invariance under name-order reorder -----
+
+
+class TestGivenFamilyVsFamilyGivenKey:
+    """``last_name_from_person`` must yield the same surname key for
+    'Given Family' and 'Family, Given' representations of one person.
+
+    This is the hypothesis-style property, expressed as a generated-by-hand
+    table of (given, family) pairs since hypothesis is unavailable.
+    """
+
+    # Plain ASCII single-token surnames: the invariant holds today.
+    _ASCII = [
+        ("John", "Smith"),
+        ("Jane", "Doe"),
+        ("Ashish", "Vaswani"),
+        ("Yoshua", "Bengio"),
+        ("Fei-Fei", "Li"),
+        ("Kyunghyun", "Cho"),
+        ("Quoc", "Le"),
+        ("Geoffrey", "Hinton"),
+    ]
+
+    @pytest.mark.parametrize(("given", "family"), _ASCII)
+    def test_reorder_surname_key_invariant_ascii(self, given, family):
+        gf = last_name_from_person(f"{given} {family}")
+        fg = last_name_from_person(f"{family}, {given}")
+        assert gf == fg, f"surname key differs by name order: {gf!r} != {fg!r}"
+
+    # Diacritic surnames: invariant also holds (diacritics are stripped both ways).
+    _DIACRITIC = [
+        ("Bernhard", "Schölkopf"),
+        ("Klaus-Robert", "Müller"),
+        ("Yann", "LeCun"),
+        ("François", "Chollet"),
+    ]
+
+    @pytest.mark.parametrize(("given", "family"), _DIACRITIC)
+    def test_reorder_surname_key_invariant_diacritic(self, given, family):
+        gf = last_name_from_person(f"{given} {family}")
+        fg = last_name_from_person(f"{family}, {given}")
+        assert gf == fg, f"surname key differs by name order: {gf!r} != {fg!r}"
+
+    # Particle surnames: both forms reduce to the final, most distinctive token.
+    _PARTICLE = [
+        ("Aaron", "van den Oord"),
+        ("Peter", "von der Malsburg"),
+        ("Maria", "de la Cruz"),
+        ("Richard", "von Mises"),
+    ]
+
+    @pytest.mark.parametrize(("given", "family"), _PARTICLE)
+    def test_reorder_surname_key_invariant_particle(self, given, family):
+        gf = last_name_from_person(f"{given} {family}")
+        fg = last_name_from_person(f"{family}, {given}")
+        assert gf == fg, f"surname key differs by name order: {gf!r} != {fg!r}"
+
+
+# ------------- Property 2: comparison symmetry --------------------------------
+
+
+class TestAuthorComparisonSymmetry:
+    """``combined_author_score`` must be symmetric in its two arguments: swapping
+    entry-keys and record-keys cannot change the score.
+    """
+
+    _PAIRS = [
+        (["smith", "doe"], ["smith", "doe"]),
+        (["smith", "doe"], ["doe", "smith"]),
+        (["vaswani", "shazeer", "parmar"], ["vaswani", "shazeer"]),
+        (["scholkopf"], ["scholkopf"]),
+        (["oord"], ["van den oord"]),
+        (["sun"], ["sun 0020"]),
+        ([], ["smith"]),
+    ]
+
+    @pytest.mark.parametrize(("a", "b"), _PAIRS)
+    def test_score_symmetric(self, a, b):
+        assert combined_author_score(a, b, 0.5, 0.5) == pytest.approx(combined_author_score(b, a, 0.5, 0.5))
+
+
+# ------------- Property 3: a true match survives entry-side transforms --------
+
+# Base matching pair: entry author field <-> record family list, same people.
+_BASE_ENTRY = "Ashish Vaswani and Noam Shazeer"
+_BASE_FAMILIES = ["Vaswani", "Shazeer"]
+
+
+def test_base_pair_matches():
+    """Sanity: the untransformed base pair is a TRUE match."""
+    assert _author_matches(_BASE_ENTRY, _BASE_FAMILIES)
+
+
+class TestEntrySideTransformsInvariant:
+    """Apply a citation-style transform to the ENTRY author field (record held
+    fixed); a true match must stay a match.
+    """
+
+    # (id, transformed_entry_author, marks)
+    _CASES = [
+        # "Given Family" -> "Family, Given" reordering.
+        ("reorder_comma", "Vaswani, Ashish and Shazeer, Noam", ()),
+        # Add diacritics on the entry side only.
+        ("add_diacritics", "Áshish Vaswani and Noam Shâzeer", ()),
+        # Remove a middle name / initial (still same surnames).
+        ("extra_initials", "Ashish K. Vaswani and Noam M. Shazeer", ()),
+    ]
+
+    @pytest.mark.parametrize(
+        ("entry_author",),
+        [pytest.param(c[1], marks=c[2], id=c[0]) for c in _CASES],
+    )
+    def test_entry_transform_preserves_match(self, entry_author):
+        assert _author_matches(entry_author, _BASE_FAMILIES)
+
+
+class TestRecordSideTransformsInvariant:
+    """Apply a transform to the RECORD family list (entry held fixed); a true
+    match must stay a match.
+    """
+
+    _CASES = [
+        # Add diacritics on the record side only.
+        ("add_diacritics", ["Váswani", "Shazéer"], ()),
+        # DBLP-style homonym suffix on a record family name: stripped by the key.
+        ("dblp_suffix_0020", ["Vaswani 0020", "Shazeer"], ()),
+        ("dblp_suffix_0001", ["Vaswani", "Shazeer 0001"], ()),
+    ]
+
+    @pytest.mark.parametrize(
+        ("families",),
+        [pytest.param(c[1], marks=c[2], id=c[0]) for c in _CASES],
+    )
+    def test_record_transform_preserves_match(self, families):
+        assert _author_matches(_BASE_ENTRY, families)
+
+
+# ------------- Property 4: particle placement, both sides ---------------------
+
+
+class TestParticlePlacementInvariant:
+    """A nobiliary-particle author must match itself regardless of which side
+    spells the particle, because both sides reduce the family to its final,
+    most distinctive token through ``last_name_from_person``.
+    """
+
+    # Entry uses 'Given Family'; record keeps the full family. Both reduce to
+    # the same final token, so they match.
+    @pytest.mark.parametrize(
+        ("entry_author", "families"),
+        [
+            ("Aaron van den Oord", ["van den Oord"]),
+            ("Peter von der Malsburg", ["von der Malsburg"]),
+            ("Maria de la Cruz", ["de la Cruz"]),
+        ],
+        ids=["van_den_oord", "von_der_malsburg", "de_la_cruz"],
+    )
+    def test_given_family_particle_matches_record(self, entry_author, families):
+        assert _author_matches(entry_author, families)
+
+    # Entry uses 'Family, Given' (full particle preserved); this DOES match
+    # today and must keep matching.
+    @pytest.mark.parametrize(
+        ("entry_author", "families"),
+        [
+            ("van den Oord, Aaron", ["van den Oord"]),
+            ("von der Malsburg, Peter", ["von der Malsburg"]),
+            ("de la Cruz, Maria", ["de la Cruz"]),
+        ],
+        ids=["van_den_oord", "von_der_malsburg", "de_la_cruz"],
+    )
+    def test_family_given_particle_matches_record(self, entry_author, families):
+        assert _author_matches(entry_author, families)
+
+
+# ------------- Property 5: record-level canonical venue accessor --------------
+
+
+class TestRecordCanonicalVenue:
+    """``PublishedRecord.canonical_venue`` is the single record-side venue
+    accessor; it must agree with ``get_canonical_venue`` and must NOT collapse
+    distinct sibling journals onto a generic parent venue.
+    """
+
+    @pytest.mark.parametrize(
+        ("journal", "expected"),
+        [
+            ("NeurIPS", "neurips"),
+            ("Advances in Neural Information Processing Systems", "neurips"),
+            ("Nature", "nature"),
+        ],
+    )
+    def test_canonical_venue_matches_helper(self, journal, expected):
+        from bibtex_updater.matching import get_canonical_venue
+
+        rec = PublishedRecord(doi="x", journal=journal)
+        assert rec.canonical_venue == get_canonical_venue(journal) == expected
+
+    @pytest.mark.parametrize("journal", ["Nature Physics", "Science Robotics", "PNAS Nexus"])
+    def test_sibling_journal_not_collapsed(self, journal):
+        """A sibling journal must not canonicalize to its generic parent."""
+        rec = PublishedRecord(doi="x", journal=journal)
+        assert rec.canonical_venue != "nature"
+        assert rec.canonical_venue != "science"
+        assert rec.canonical_venue != "pnas"

--- a/tests/test_record_roundtrip.py
+++ b/tests/test_record_roundtrip.py
@@ -1,0 +1,244 @@
+"""Self-consistency oracle for record <-> entry round-tripping.
+
+Core invariant
+--------------
+A ``PublishedRecord`` turned into a BibTeX entry (the exact same data, just in
+the citation representation) MUST verify against itself with zero field
+mismatches. Any failure here is a *comparison asymmetry* bug: the entry side and
+the record side normalize the same surname / venue / title differently, which in
+production surfaces as a false AUTHOR_MISMATCH / HALLUCINATED / VENUE_MISMATCH for
+a perfectly-cited paper.
+
+The entry is built from the record using the production code path
+(``Updater.update_entry``), so this also exercises the converter that real runs
+use. We then feed (entry, record) into ``FactChecker._compare_all_fields`` and
+assert every comparison ``.matches``.
+
+A second oracle exercises the resolver match-score path: the match score of a
+record against an entry built from itself must clear the resolver
+``MATCH_THRESHOLD`` (~0.85). Both ``_compare_all_fields`` and
+``_compute_match_score`` are lightweight (no network), so we instantiate the real
+``FactChecker`` / ``Resolver`` with mocked HTTP clients.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from bibtex_updater.fact_checker import (
+    CrossrefClient,
+    DBLPClient,
+    FactChecker,
+    FactCheckerConfig,
+    SemanticScholarClient,
+)
+from bibtex_updater.updater import PreprintDetection, Resolver, Updater
+from bibtex_updater.utils import (
+    HttpClient,
+    PublishedRecord,
+    authors_last_names,
+    normalize_title_for_match,
+)
+
+# ------------- Fixtures (replicated, not imported, per task) -------------
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_record_roundtrip")
+
+
+@pytest.fixture
+def fake_http():
+    """Mock HTTP client that never makes real requests."""
+    mock = MagicMock()
+    mock._request.return_value = MagicMock(status_code=404, json=lambda: {})
+    return mock
+
+
+@pytest.fixture
+def checker(fake_http, logger):
+    """Real FactChecker with mocked API clients (no network)."""
+    return FactChecker(
+        CrossrefClient(fake_http),
+        DBLPClient(fake_http),
+        SemanticScholarClient(fake_http),
+        FactCheckerConfig(),
+        logger,
+    )
+
+
+class _FakeHttpClient(HttpClient):
+    """HttpClient subclass that refuses network access."""
+
+    def __init__(self):  # noqa: D401 - intentionally skip parent network setup
+        pass
+
+    def _request(self, *args, **kwargs):
+        raise NotImplementedError("network disabled in tests")
+
+
+@pytest.fixture
+def resolver(logger):
+    """Real Resolver instance (match-score path is pure / no network)."""
+    return Resolver(_FakeHttpClient(), logger)
+
+
+@pytest.fixture
+def updater():
+    return Updater(keep_preprint_note=False, rekey=False)
+
+
+# ------------- Representative records (each stresses a past failure) ----------
+
+
+def _records() -> list[tuple[str, PublishedRecord, tuple]]:
+    """(id, record, marks) triples. ``marks`` carries any xfail for the case."""
+    return [
+        (
+            "plain_ascii",
+            PublishedRecord(
+                doi="10.1234/jml.2020.001",
+                title="Deep Learning for Natural Language Processing",
+                authors=[
+                    {"given": "John", "family": "Smith"},
+                    {"given": "Jane", "family": "Doe"},
+                ],
+                journal="Journal of Machine Learning Research",
+                year=2020,
+                type="journal-article",
+            ),
+            (),
+        ),
+        (
+            "nobiliary_particle",
+            PublishedRecord(
+                doi="10.1234/wavenet.2016",
+                title="WaveNet: A Generative Model for Raw Audio",
+                authors=[
+                    {"given": "Aaron", "family": "van den Oord"},
+                    {"given": "Sander", "family": "Dieleman"},
+                ],
+                journal="Speech Synthesis Workshop",
+                year=2016,
+                type="journal-article",
+            ),
+            (),
+        ),
+        (
+            "multiword_particle",
+            PublishedRecord(
+                doi="10.1234/vision.2019",
+                title="A Model of Cortical Self-Organization",
+                authors=[
+                    {"given": "Peter", "family": "von der Malsburg"},
+                    {"given": "Maria", "family": "de la Cruz"},
+                ],
+                journal="Biological Cybernetics",
+                year=2019,
+                type="journal-article",
+            ),
+            (),
+        ),
+        (
+            "diacritics",
+            PublishedRecord(
+                doi="10.1234/kernel.2002",
+                title="Learning with Kernels",
+                authors=[
+                    {"given": "Bernhard", "family": "Schölkopf"},
+                    {"given": "Klaus-Robert", "family": "Müller"},
+                ],
+                journal="Neural Computation",
+                year=2002,
+                type="journal-article",
+            ),
+            (),
+        ),
+        (
+            "conference",
+            PublishedRecord(
+                doi="10.1234/neurips.2017.attention",
+                title="Attention Is All You Need",
+                authors=[
+                    {"given": "Ashish", "family": "Vaswani"},
+                    {"given": "Noam", "family": "Shazeer"},
+                ],
+                journal="Advances in Neural Information Processing Systems",
+                year=2017,
+                type="proceedings-article",
+            ),
+            (),
+        ),
+        (
+            "many_authors",
+            PublishedRecord(
+                doi="10.1234/bigteam.2021",
+                title="Scaling Laws for Neural Language Models",
+                authors=[
+                    {"given": "Jared", "family": "Kaplan"},
+                    {"given": "Sam", "family": "McCandlish"},
+                    {"given": "Tom", "family": "Henighan"},
+                    {"given": "Tom", "family": "Brown"},
+                    {"given": "Benjamin", "family": "Chess"},
+                    {"given": "Rewon", "family": "Child"},
+                ],
+                journal="Journal of Machine Learning Research",
+                year=2021,
+                type="journal-article",
+            ),
+            (),
+        ),
+    ]
+
+
+_RECORD_PARAMS = [pytest.param(rec, marks=marks, id=name) for name, rec, marks in _records()]
+
+
+# ------------- Oracle 1: _compare_all_fields self-consistency ----------------
+
+
+class TestCompareAllFieldsRoundtrip:
+    """A record -> entry must verify against itself with no field mismatch."""
+
+    @pytest.mark.parametrize("record", _RECORD_PARAMS)
+    def test_all_fields_match(self, checker, updater, record):
+        detection = PreprintDetection(is_preprint=False)
+        entry = updater.update_entry({"ID": "x", "ENTRYTYPE": "article"}, record, detection)
+
+        comparisons = checker._compare_all_fields(entry, record)
+
+        for field in ("title", "author", "year", "venue"):
+            assert field in comparisons, f"missing comparison: {field}"
+            comp = comparisons[field]
+            assert comp.matches, (
+                f"{field} falsely mismatched on self-roundtrip: "
+                f"entry={comp.entry_value!r} api={comp.api_value!r} "
+                f"score={comp.similarity_score:.3f}"
+            )
+
+
+# ------------- Oracle 2: resolver match-score self-consistency ----------------
+
+
+class TestMatchScoreRoundtrip:
+    """A record scored against an entry built from itself clears the threshold."""
+
+    @pytest.mark.parametrize("record", _RECORD_PARAMS)
+    def test_match_score_above_threshold(self, resolver, updater, record):
+        detection = PreprintDetection(is_preprint=False)
+        entry = updater.update_entry({"ID": "x", "ENTRYTYPE": "article"}, record, detection)
+
+        title_norm = normalize_title_for_match(entry.get("title", ""))
+        authors_ref = authors_last_names(entry.get("author", ""))
+
+        score = resolver._compute_match_score(title_norm, record, authors_ref)
+
+        assert score >= resolver.MATCH_THRESHOLD, (
+            f"self-roundtrip match score {score:.3f} below "
+            f"MATCH_THRESHOLD {resolver.MATCH_THRESHOLD} "
+            f"(title={title_norm!r}, authors={authors_ref!r})"
+        )


### PR DESCRIPTION
## Why

The recurring "subtle wrong verdict" bugs (particle surnames, DBLP homonym suffix, venue collapsing) all shared **one root cause: comparison asymmetry** — the BibTeX-entry side and the API-record side reduced the *same* surname/venue through *different* normalization (e.g. entry `"Aaron van den Oord"` → `oord` vs. record `family` kept raw as `van den oord` → Jaccard `0` → false `AUTHOR_MISMATCH` / `HALLUCINATED`). The prior fix was a helper called at ~7 separate sites, which is exactly how it drifted (a post-merge review had to repair a site that diverged).

This PR makes the asymmetry **structurally impossible** rather than caught-after-the-fact, and adds two self-checking oracles that would have caught the whole class before it shipped.

## What changed

**A. Single source of truth for comparison keys** (behavior-preserving consolidation)
- `PublishedRecord.surname_keys(limit)` is now the one place that turns a record author into a surname key, routing each `family` through the same `last_name_from_person` the entry side uses via `authors_last_names`. The two sides are now symmetric *by construction*.
- All 7 comparison sites (5 in `updater.py`, 2 in `fact_checker.py`) consume it — including `FieldFiller._find_best_crossref_match` and `WorkingPaperVerifier._score`, which were **still keying the record side raw** (two more latent asymmetries, now fixed).
- Removed the now-redundant `_record_surnames` helper. **No thresholds, weights, or verdict logic changed.**
- Added `PublishedRecord.canonical_venue` mirroring `surname_keys` for the venue dimension.

**B/C. Self-checking oracles** (+54 tests)
- `tests/test_record_roundtrip.py` — a record turned into an entry (via the production `Updater.update_entry` path) must verify against *itself* with zero field mismatches and clear the resolver `MATCH_THRESHOLD`. Covers particle surnames, multi-word particles, diacritics, conference venues, many-author records.
- `tests/test_metamorphic_symmetry.py` — states each past bug as an *invariance*: a true match's verdict must survive citation-style transforms (`"Given Family"` ↔ `"Family, Given"`, diacritics, DBLP suffix, particle placement); `combined_author_score` must be symmetric; `canonical_venue` must not collapse sibling journals (Nature Physics ≠ Nature).

**Fixed (surfaced by the oracle)**
- `last_name_from_person` now strips a trailing 4-digit DBLP homonym suffix (`"Sun 0020"` → `sun`) at the key level — defense-in-depth alongside the existing strip in `dblp_hit_to_record`, guarded so an all-digits name is never emptied.

## Test plan
- [x] Full suite: **839 passed, 1 skipped** (785 baseline + 54 new, zero regressions)
- [x] `ruff check` clean on changed files
- [x] `black` leaves all added code unchanged (only an unrelated pre-existing `SqliteCache` block differs under a newer local black; CI's pinned black 24.10.0 is unaffected)
- [x] No import cycle (`canonical_venue` imports `get_canonical_venue` lazily)

## Release
Targets **0.10.0** (CHANGELOG updated). Version is git-tag driven via hatch-vcs and PyPI publish fires on a GitHub Release — after merge, create release `v0.10.0` to publish.

https://claude.ai/code/session_01RqgA1JbCQ3stpSrYSyHhaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqgA1JbCQ3stpSrYSyHhaV)_