### PR TITLE
Faster lookup cascade + fix 61%→9% valid-entry false-positive rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ A 0–100 numeric `confidence_score` (additive in the JSONL output) summarizes p
 - Penalties: title-mismatch `-20`, author-mismatch `-20`, journal-mismatch `-15`, fabricated-author `-10` each (capped at `-20`)
 - Asymmetric formula for the high-title-low-author chimeric case: `confidence = S_title − 0.5 × (100 − S_author)`
 
+#### Verdicts: verified vs. could-not-verify vs. problematic
+
+`VERIFIED` requires every claimed field to be *positively confirmed* against the matched record — not merely "not contradicted". When a record is found but a claimed field can't be confirmed (e.g. a published venue backed only by a preprint, or an incomplete author list), the entry is reported as **could-not-verify** (`UNCONFIRMED`/`NOT_FOUND`), distinct from a **problematic** flag (`*_mismatch`, `doi_mismatch`, chimeric, …) which is positive evidence of a defect. A "could-not-verify" is *not* a clean pass: it means the tool couldn't decide, and such entries warrant review.
+
+#### Author order (`--ignore-author-order`)
+
+All four sources return authors in as-published order, so an author-order difference usually indicates a real citation error and is flagged by default. Pass `--ignore-author-order` to treat an author list as confirmed when the author *set* matches regardless of order. This is opt-in because it also stops detecting `swapped_authors` hallucinations (same people, reordered). Surname comparison uses each source's structured `family` field where available (so family-first/CJK names like "Chen Xing" ↔ "Xing Chen" are not falsely flagged), falling back to a Crossref structured-name lookup when the matched source lacks one.
+
 #### Non-generative-AI mode (`--non-generative`)
 
 For venue-policy compliance ([ACL ARR](https://aclrollingreview.org/reviewerguidelines#q-can-i-use-generative-ai), [ICML 2026](https://icml.cc/Conferences/2026/LLM-Policy)) the `--non-generative` flag (or `BIBTEX_CHECK_NON_GENERATIVE=1` env var) refuses to load any LLM backend at runtime. Today the package has no LLM backends, so this is a forward-compat guard plus a startup banner:

--- a/README.md
+++ b/README.md
@@ -216,21 +216,18 @@ For `filter_bibliography.py` only (no dependencies required):
 - **Structured reports**: JSON and JSONL output formats
 - **CI/CD integration**: Strict mode with exit codes for automation
 
-#### Cascading verification (default; disable with `--no-cascade`)
+#### Cascading verification
 
-Inspired by [Abbonato 2026 (CheckIfExist)](https://arxiv.org/abs/2602.15871), the cascade explicitly orders sources CrossRef → OpenAlex → Semantic Scholar and short-circuits as soon as one source produces a high-confidence match. Combined with top-K candidate retrieval and cross-source author intersection, it catches `swapped_authors` / chimeric citations that single-source verification misses.
+Inspired by [Abbonato 2026 (CheckIfExist)](https://arxiv.org/abs/2602.15871), verification orders sources CrossRef → OpenAlex → DBLP → Semantic Scholar and short-circuits as soon as one source produces a high-confidence match. Combined with top-K candidate retrieval and cross-source author intersection, it catches `swapped_authors` / chimeric citations that single-source verification misses.
 
-The order is throughput-aware: CrossRef and OpenAlex (polite pool, ~100 req/min) come first, so the slow keyless Semantic Scholar fallback (~10 req/min) is only reached on hard entries. This is the default; `--no-cascade` falls back to the legacy parallel CrossRef+DBLP+S2 fan-out, which queries every source on every entry and is gated by the slowest rate limit. Set a Semantic Scholar API key (`--s2-api-key` or `S2_API_KEY`) to lift S2 from ~10 to ~60 req/min.
+The order is throughput-aware: CrossRef and OpenAlex (polite pool, ~100 req/min) come first, so the slow keyless Semantic Scholar fallback (~10 req/min) is only reached on hard entries. Set a Semantic Scholar API key (`--s2-api-key` or `S2_API_KEY`) to lift S2 from ~10 to ~60 req/min.
 
 ```bash
-# Cascading verification with top-3 candidates per source (cascade is the default)
+# Verification with top-3 candidates per source
 bibtex-check references.bib --top-k 3 --jsonl out.jsonl
 
 # Polite OpenAlex pool (recommended)
 bibtex-check references.bib --openalex-mailto you@example.com
-
-# Legacy parallel fan-out (queries CrossRef + DBLP + S2 on every entry)
-bibtex-check references.bib --no-cascade
 ```
 
 A 0–100 numeric `confidence_score` (additive in the JSONL output) summarizes per-field similarity with explicit penalty/bonus contributions:

--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ A 0–100 numeric `confidence_score` (additive in the JSONL output) summarizes p
 
 `VERIFIED` requires every claimed field to be *positively confirmed* against the matched record — not merely "not contradicted". When a record is found but a claimed field can't be confirmed (e.g. a published venue backed only by a preprint, or an incomplete author list), the entry is reported as **could-not-verify** (`UNCONFIRMED`/`NOT_FOUND`), distinct from a **problematic** flag (`*_mismatch`, `doi_mismatch`, chimeric, …) which is positive evidence of a defect. A "could-not-verify" is *not* a clean pass: it means the tool couldn't decide, and such entries warrant review.
 
-#### Author order (`--ignore-author-order`)
+#### Author handling
 
-All four sources return authors in as-published order, so an author-order difference usually indicates a real citation error and is flagged by default. Pass `--ignore-author-order` to treat an author list as confirmed when the author *set* matches regardless of order. This is opt-in because it also stops detecting `swapped_authors` hallucinations (same people, reordered). Surname comparison uses each source's structured `family` field where available (so family-first/CJK names like "Chen Xing" ↔ "Xing Chen" are not falsely flagged), falling back to a Crossref structured-name lookup when the matched source lacks one.
+All four sources return authors in as-published order, so an author-order difference is treated as a real citation error (e.g. a transposed or wrong lead author) and flagged — it is not an API artifact. Surname comparison uses each source's structured `family` field where available, so family-first/CJK names like "Chen Xing" ↔ "Xing Chen" are not falsely flagged; when the matched source lacks structured names (Semantic Scholar flat names, DBLP), a Crossref structured-name lookup is used to vet a potential author mismatch before reporting it.
 
 #### Non-generative-AI mode (`--non-generative`)
 

--- a/README.md
+++ b/README.md
@@ -216,16 +216,21 @@ For `filter_bibliography.py` only (no dependencies required):
 - **Structured reports**: JSON and JSONL output formats
 - **CI/CD integration**: Strict mode with exit codes for automation
 
-#### Cascading verification (`--cascade`)
+#### Cascading verification (default; disable with `--no-cascade`)
 
-Inspired by [Abbonato 2026 (CheckIfExist)](https://arxiv.org/abs/2602.15871), the cascade explicitly orders sources CrossRef → Semantic Scholar → OpenAlex and short-circuits as soon as one source produces a high-confidence match. Combined with top-K candidate retrieval and cross-source author intersection, it catches `swapped_authors` / chimeric citations that single-source verification misses.
+Inspired by [Abbonato 2026 (CheckIfExist)](https://arxiv.org/abs/2602.15871), the cascade explicitly orders sources CrossRef → OpenAlex → Semantic Scholar and short-circuits as soon as one source produces a high-confidence match. Combined with top-K candidate retrieval and cross-source author intersection, it catches `swapped_authors` / chimeric citations that single-source verification misses.
+
+The order is throughput-aware: CrossRef and OpenAlex (polite pool, ~100 req/min) come first, so the slow keyless Semantic Scholar fallback (~10 req/min) is only reached on hard entries. This is the default; `--no-cascade` falls back to the legacy parallel CrossRef+DBLP+S2 fan-out, which queries every source on every entry and is gated by the slowest rate limit. Set a Semantic Scholar API key (`--s2-api-key` or `S2_API_KEY`) to lift S2 from ~10 to ~60 req/min.
 
 ```bash
-# Cascading verification with top-3 candidates per source
-bibtex-check references.bib --cascade --top-k 3 --jsonl out.jsonl
+# Cascading verification with top-3 candidates per source (cascade is the default)
+bibtex-check references.bib --top-k 3 --jsonl out.jsonl
 
 # Polite OpenAlex pool (recommended)
-bibtex-check references.bib --cascade --openalex-mailto you@example.com
+bibtex-check references.bib --openalex-mailto you@example.com
+
+# Legacy parallel fan-out (queries CrossRef + DBLP + S2 on every entry)
+bibtex-check references.bib --no-cascade
 ```
 
 A 0–100 numeric `confidence_score` (additive in the JSONL output) summarizes per-field similarity with explicit penalty/bonus contributions:

--- a/src/bibtex_updater/__init__.py
+++ b/src/bibtex_updater/__init__.py
@@ -88,6 +88,7 @@ from bibtex_updater.utils import (
     authors_last_names,
     # API converters
     crossref_message_to_record,
+    dblp_hit_to_candidate_record,
     dblp_hit_to_record,
     # DOI/arXiv utilities
     doi_normalize,
@@ -180,6 +181,7 @@ __all__ = [
     "extract_acl_anthology_id",
     # API converters
     "crossref_message_to_record",
+    "dblp_hit_to_candidate_record",
     "dblp_hit_to_record",
     "europepmc_result_to_record",
     "openalex_work_to_record",

--- a/src/bibtex_updater/__init__.py
+++ b/src/bibtex_updater/__init__.py
@@ -102,6 +102,7 @@ from bibtex_updater.utils import (
     last_name_from_person,
     # Text normalization
     latex_to_plain,
+    normalize_doi_for_resolution,
     normalize_title_for_match,
     openalex_work_to_record,
     s2_data_to_record,
@@ -162,6 +163,7 @@ __all__ = [
     "SqliteCache",
     # Text normalization
     "latex_to_plain",
+    "normalize_doi_for_resolution",
     "normalize_title_for_match",
     "safe_lower",
     "strip_diacritics",

--- a/src/bibtex_updater/calibration.py
+++ b/src/bibtex_updater/calibration.py
@@ -25,40 +25,102 @@ __all__ = [
     "STATUS_BASE_CONFIDENCE",
 ]
 
-# Status-specific base confidences (priors, adjusted by evidence)
-# These represent initial confidence before factoring in match scores
+# Status-specific base confidences (priors), grounded in the fact-checker's
+# THREE-WAY verdict model. The number is "how confident are we that the assigned
+# verdict is the right call", NOT a probability that the entry is correct.
+#
+# Three buckets, with a strict ordering the priors MUST respect:
+#
+#   CLEARLY-CORRECT  (high, ~0.85-0.90): a positive record confirms the entry.
+#       verified / preprint_only / published_version_exists / *_verified.
+#
+#   CLEARLY-PROBLEM  (high): positive evidence the entry is wrong.
+#       - STRONGEST (~0.92-0.95): the evidence is self-contained and not a fuzzy
+#         field comparison -- future_date / invalid_year (arithmetic), a
+#         fabricated DOI that resolves elsewhere (doi_mismatch) or an arXiv ID
+#         that resolves elsewhere (arxiv_id_mismatch), and hallucinated (no real
+#         paper / chimeric title stitched from several papers).
+#       - SOFTER (~0.72-0.80): a single bibliographic field disagrees while the
+#         rest match (title/author/year/venue/url_content mismatch, partial_match).
+#         One fuzzy-compared field is weaker positive evidence than the above.
+#
+#   DON'T-KNOW / abstention  (LOW, near-neutral ~0.40-0.50): the tool could not
+#       decide. By construction this MUST sit below BOTH confident buckets -- an
+#       entry we failed to adjudicate must never report high confidence either
+#       way. Covers not_found / unconfirmed / api_error / doi_not_found and the
+#       book/working-paper/url "not found" variants, plus url_accessible (HTTP
+#       200 with no content check) which only weakly informs the verdict.
+#
+# Anchors (do not creep): confident buckets >= 0.72; abstentions <= 0.50.
+_CONF_CORRECT = 0.88  # CLEARLY-CORRECT anchor
+_PROB_STRONG = 0.93  # CLEARLY-PROBLEM, self-contained positive evidence
+_PROB_SOFT = 0.78  # CLEARLY-PROBLEM, single fuzzy-compared field disagrees
+_ABSTAIN = 0.45  # DON'T-KNOW, near-neutral, strictly below both above
 STATUS_BASE_CONFIDENCE = {
-    "verified": 0.85,
-    "not_found": 0.70,
-    # Abstention: a record was found but a claimed field could not be positively
-    # confirmed (preprint-only venue, incomplete authors). Treated like not_found
-    # (could-not-verify), not a confident verdict.
-    "unconfirmed": 0.65,
-    "hallucinated": 0.90,
-    "title_mismatch": 0.80,
-    "author_mismatch": 0.75,
-    "year_mismatch": 0.85,
-    "venue_mismatch": 0.80,
-    "partial_match": 0.65,
-    "api_error": 0.30,
-    "future_date": 0.95,
-    "invalid_year": 0.95,
-    "doi_not_found": 0.85,
-    # A DOI that resolves to a clearly different paper is strong positive
-    # evidence of a misattributed identifier (copy-paste / lookup error).
-    "doi_mismatch": 0.85,
-    "preprint_only": 0.90,
-    "published_version_exists": 0.85,
-    "url_verified": 0.90,
-    "url_accessible": 0.70,
-    "url_not_found": 0.85,
-    "url_content_mismatch": 0.75,
-    "book_verified": 0.85,
-    "book_not_found": 0.75,
-    "working_paper_verified": 0.80,
-    "working_paper_not_found": 0.70,
+    # --- CLEARLY-CORRECT: a positive record confirms the entry ---
+    "verified": _CONF_CORRECT,
+    "preprint_only": _CONF_CORRECT,
+    "published_version_exists": _CONF_CORRECT,
+    "url_verified": _CONF_CORRECT,
+    "book_verified": _CONF_CORRECT,
+    "working_paper_verified": _CONF_CORRECT,
+    # --- CLEARLY-PROBLEM (strong): self-contained positive evidence ---
+    "hallucinated": _PROB_STRONG,  # no real paper / chimeric title
+    "future_date": _PROB_STRONG,  # arithmetic, not a fuzzy match
+    "invalid_year": _PROB_STRONG,  # arithmetic, not a fuzzy match
+    "doi_mismatch": _PROB_STRONG,  # cited DOI resolves to a different paper
+    "arxiv_id_mismatch": _PROB_STRONG,  # cited arXiv ID resolves elsewhere
+    # --- CLEARLY-PROBLEM (soft): one disagreeing field, rest match ---
+    "title_mismatch": _PROB_SOFT,
+    "author_mismatch": _PROB_SOFT,
+    "year_mismatch": _PROB_SOFT,
+    "venue_mismatch": _PROB_SOFT,
+    "partial_match": _PROB_SOFT,
+    "url_content_mismatch": _PROB_SOFT,
+    # --- DON'T-KNOW / abstention: could not adjudicate, near-neutral ---
+    "not_found": _ABSTAIN,
+    "unconfirmed": _ABSTAIN,
+    "api_error": _ABSTAIN,
+    "doi_not_found": _ABSTAIN,
+    "url_not_found": _ABSTAIN,
+    "book_not_found": _ABSTAIN,
+    "working_paper_not_found": _ABSTAIN,
+    "url_accessible": _ABSTAIN,  # 200 only, no content check -> weak signal
+    # --- not verifiable ---
     "skipped": 0.0,
 }
+
+# Abstention ("don't-know") statuses. These must stay near-neutral: their
+# confidence is capped below the confident buckets and is NOT boosted by
+# inverting a low match score or by counting how many sources were queried.
+# (Mirrors fact_checker.ABSTAINED_STATUS_VALUES, kept local to avoid importing
+# the concurrently-edited module.)
+_ABSTAIN_STATUSES = frozenset(
+    {
+        "not_found",
+        "unconfirmed",
+        "api_error",
+        "doi_not_found",
+        "url_not_found",
+        "book_not_found",
+        "working_paper_not_found",
+        "url_accessible",
+    }
+)
+
+# Self-contained positive-evidence problems whose verdict does NOT come from a
+# scored title-search candidate (arithmetic on the year, or an identifier that
+# resolves to a different paper). Source coverage is irrelevant to them, so they
+# must not be docked the "few sources returned hits" penalty -- otherwise these
+# strongest problems would calibrate below soft single-field mismatches.
+_SELF_EVIDENT_PROBLEM_STATUSES = frozenset(
+    {
+        "future_date",
+        "invalid_year",
+        "doi_mismatch",
+        "arxiv_id_mismatch",
+    }
+)
 
 # Default field importance weights for confidence decomposition
 # Higher weight = more discriminative for determining correctness
@@ -94,24 +156,32 @@ def compute_confidence_from_scores(
     # Get base confidence from status
     base_conf = STATUS_BASE_CONFIDENCE.get(status, 0.5)
 
+    # Abstentions ("don't-know") return their low base prior unchanged: a verdict
+    # the tool could not make must NOT be inflated by inverting a low match score.
+    # (A high match score would contradict the abstention, so cap at the prior.)
+    if status in _ABSTAIN_STATUSES:
+        if best_match_score is not None and best_match_score > 0.5:
+            # A strong candidate contradicts the abstention -> even less certain.
+            return base_conf * 0.5
+        return base_conf
+
     # Statuses that don't involve API matching (no scores to use)
     no_match_statuses = {
         "future_date",
         "invalid_year",
-        "doi_not_found",
-        # Pre-search positive-evidence check: the verdict comes from the DOI's
-        # own Crossref record, not from a scored title-search candidate.
+        # Pre-search positive-evidence check: the verdict comes from the DOI's /
+        # arXiv ID's own record, not from a scored title-search candidate.
         "doi_mismatch",
-        "api_error",
+        "arxiv_id_mismatch",
         "skipped",
     }
 
     if status in no_match_statuses or best_match_score is None:
         return base_conf
 
-    # For statuses with matches, blend base confidence with actual match score
-    # High match scores boost confidence for positive statuses (verified, mismatches)
-    # Low match scores boost confidence for negative statuses (not_found, hallucinated)
+    # For statuses with matches, blend base confidence with actual match score.
+    # High match scores boost confidence for positive statuses (verified);
+    # low match scores boost confidence for hallucinated.
 
     if status == "verified":
         # Verified: high match score → high confidence
@@ -124,18 +194,14 @@ def compute_confidence_from_scores(
         confidence_in_low_score = 1.0 - best_match_score
         return 0.7 * confidence_in_low_score + 0.3 * base_conf
 
-    elif status == "not_found":
-        # Not found: absence of good matches → confidence depends on coverage
-        # If we have a best_match_score, it should be low
-        if best_match_score < 0.5:
-            # Low score confirms not_found
-            confidence_in_low_score = 1.0 - best_match_score
-            return 0.6 * confidence_in_low_score + 0.4 * base_conf
-        else:
-            # High score contradicts not_found → lower confidence
-            return base_conf * 0.5
-
-    elif status in ("title_mismatch", "author_mismatch", "year_mismatch", "venue_mismatch", "partial_match"):
+    elif status in (
+        "title_mismatch",
+        "author_mismatch",
+        "year_mismatch",
+        "venue_mismatch",
+        "partial_match",
+        "url_content_mismatch",
+    ):
         # Field-specific mismatches: moderate match score expected
         # Use base confidence adjusted by how extreme the mismatch is
         # If overall match is high despite mismatch, confidence should be lower
@@ -230,11 +296,17 @@ def status_aware_confidence(
     error_penalty = 1.0 - (0.15 * min(num_errors, 3))  # Cap at 3 errors for penalty
 
     # Coverage boost/penalty depends on status
-    if status == "not_found":
-        # For NOT_FOUND: more sources checked → more confident nothing exists
-        # Scale with num_queried, not coverage (hits don't matter for not_found)
-        queried_factor = min(num_queried / 3.0, 1.0)  # 3 sources = full confidence
-        coverage_factor = 0.7 + 0.3 * queried_factor
+    if status in _ABSTAIN_STATUSES:
+        # Abstentions stay near-neutral. We deliberately do NOT scale confidence
+        # up with the number of sources queried: "not found in N databases" is
+        # still a don't-know, and querying more sources must not push an
+        # abstention toward a confident verdict. Hold the low prior flat.
+        coverage_factor = 1.0
+    elif status in _SELF_EVIDENT_PROBLEM_STATUSES:
+        # Self-contained problems (year arithmetic, mis-resolving DOI/arXiv ID):
+        # the verdict isn't a scored candidate match, so source coverage is
+        # irrelevant. Don't penalize them for "no hits"; hold the strong prior.
+        coverage_factor = 1.0
     elif status in ("verified", "title_mismatch", "author_mismatch", "year_mismatch", "venue_mismatch"):
         # For positive matches: coverage matters less (one good match is enough)
         # But still penalize if only 1 source and it has errors
@@ -314,8 +386,19 @@ def calibrate_result(
         errors,
     )
 
-    # Blend base confidence with field-level evidence
-    match_statuses = ("verified", "title_mismatch", "author_mismatch", "venue_mismatch", "partial_match")
+    # Blend base confidence with field-level evidence. Only for statuses where a
+    # record was found and per-field scores are meaningful (CLEARLY-CORRECT
+    # `verified` and the soft single-field CLEARLY-PROBLEM mismatches). Abstentions
+    # are excluded so field scores cannot inflate a don't-know.
+    match_statuses = (
+        "verified",
+        "title_mismatch",
+        "author_mismatch",
+        "year_mismatch",
+        "venue_mismatch",
+        "partial_match",
+        "url_content_mismatch",
+    )
     if weighted_field_score is not None and status in match_statuses:
         # For match-based statuses, field decomposition provides additional signal
         return 0.7 * base_confidence + 0.3 * weighted_field_score

--- a/src/bibtex_updater/calibration.py
+++ b/src/bibtex_updater/calibration.py
@@ -44,6 +44,9 @@ STATUS_BASE_CONFIDENCE = {
     "future_date": 0.95,
     "invalid_year": 0.95,
     "doi_not_found": 0.85,
+    # A DOI that resolves to a clearly different paper is strong positive
+    # evidence of a misattributed identifier (copy-paste / lookup error).
+    "doi_mismatch": 0.85,
     "preprint_only": 0.90,
     "published_version_exists": 0.85,
     "url_verified": 0.90,
@@ -96,6 +99,9 @@ def compute_confidence_from_scores(
         "future_date",
         "invalid_year",
         "doi_not_found",
+        # Pre-search positive-evidence check: the verdict comes from the DOI's
+        # own Crossref record, not from a scored title-search candidate.
+        "doi_mismatch",
         "api_error",
         "skipped",
     }

--- a/src/bibtex_updater/calibration.py
+++ b/src/bibtex_updater/calibration.py
@@ -30,6 +30,10 @@ __all__ = [
 STATUS_BASE_CONFIDENCE = {
     "verified": 0.85,
     "not_found": 0.70,
+    # Abstention: a record was found but a claimed field could not be positively
+    # confirmed (preprint-only venue, incomplete authors). Treated like not_found
+    # (could-not-verify), not a confident verdict.
+    "unconfirmed": 0.65,
     "hallucinated": 0.90,
     "title_mismatch": 0.80,
     "author_mismatch": 0.75,

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -2199,13 +2199,10 @@ class FactChecker:
             # identifier, so a genuine author mismatch here is positive evidence
             # of ID-anchored author fabrication (swapped/placeholder authors on
             # an entry that otherwise carries the correct DOI).
-            return self._id_anchored_author_mismatch(
-                entry, rec, source="crossref", identifier=raw_doi, id_kind="DOI"
-            )
+            return self._id_anchored_author_mismatch(entry, rec, source="crossref", identifier=raw_doi, id_kind="DOI")
 
         self.logger.warning(
-            "DOI %s for entry %r points to a different paper: entry title "
-            "%r vs DOI title %r (title score %.2f)",
+            "DOI %s for entry %r points to a different paper: entry title " "%r vs DOI title %r (title score %.2f)",
             raw_doi,
             entry.get("ID", "?"),
             entry.get("title", ""),
@@ -2247,9 +2244,7 @@ class FactChecker:
             return None
         return crossref_message_to_record(msg)
 
-    def _structured_author_recheck(
-        self, entry: dict[str, Any], best_match: PublishedRecord
-    ) -> PublishedRecord | None:
+    def _structured_author_recheck(self, entry: dict[str, Any], best_match: PublishedRecord) -> PublishedRecord | None:
         """Re-fetch the cited paper from a STRUCTURED source to vet an AUTHOR_MISMATCH.
 
         Called only when the candidate that produced an AUTHOR_MISMATCH came from
@@ -2519,9 +2514,7 @@ class FactChecker:
         if self.openreview is not None:
             sources_queried.append("openreview")
             try:
-                or_notes = self.openreview.search(
-                    query, limit=top_k, title=raw_title, first_author=first_author
-                )
+                or_notes = self.openreview.search(query, limit=top_k, title=raw_title, first_author=first_author)
             except Exception as exc:
                 or_notes = []
                 errors.append(f"OpenReview: {exc}")

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -61,8 +61,10 @@ from bibtex_updater.sources import (
     MAX_TOP_K,
     AuthorIntersectionResult,
     OpenAlexClient,
+    OpenReviewClient,
     cross_source_author_intersection,
     openalex_work_to_candidate_record,
+    openreview_note_to_candidate_record,
     select_top_k_by_title_similarity,
 )
 from bibtex_updater.utils import (
@@ -1626,7 +1628,7 @@ def _doi_resolves(client: httpx.Client, doi: str) -> bool | None:
 class FactChecker:
     """Validates bibliographic entries against external APIs."""
 
-    API_SOURCES = ["crossref", "dblp", "semanticscholar", "openalex"]
+    API_SOURCES = ["crossref", "dblp", "semanticscholar", "openalex", "openreview"]
 
     def __init__(
         self,
@@ -1637,6 +1639,7 @@ class FactChecker:
         logger: logging.Logger,
         openalex: OpenAlexClient | None = None,
         arxiv: ArxivClient | None = None,
+        openreview: OpenReviewClient | None = None,
     ):
         self.crossref = crossref
         self.dblp = dblp
@@ -1649,6 +1652,10 @@ class FactChecker:
         # OpenAlex client is optional; tests can pass a fake. The cascade falls
         # back to creating a default client if not provided.
         self.openalex: OpenAlexClient | None = openalex
+        # OpenReview client is optional and lazily built from the shared HTTP
+        # client inside the cascade (mirroring OpenAlex). It is the authoritative
+        # source for ICLR/NeurIPS/TMLR submissions the other sources miss.
+        self.openreview: OpenReviewClient | None = openreview
         # Per-entry verification state (cross-source author intersection,
         # per-source records) is NOT stored on the shared instance: check_entry
         # runs concurrently across a ThreadPoolExecutor, so a sibling entry would
@@ -2372,7 +2379,7 @@ class FactChecker:
         sources_with_hits: list[str],
         errors: list[str],
     ) -> list[tuple[float, PublishedRecord, str]]:
-        """Cascading source order: CrossRef -> OpenAlex -> DBLP -> Semantic Scholar.
+        """Source order: CrossRef -> OpenAlex -> DBLP -> OpenReview -> Semantic Scholar.
 
         Item 1 (CheckIfExist Algorithm 1, Abbonato 2026). Each step retrieves
         ``config.top_k`` candidates and re-ranks them by Levenshtein title
@@ -2391,9 +2398,10 @@ class FactChecker:
         Order rationale (throughput): the fast, broad sources come first so the
         slow specialist is only reached on hard entries. OpenAlex runs on the
         polite pool (~100 req/min) and aggregates Crossref + others; DBLP
-        (~30 req/min) is the CS-conference authority; a keyless Semantic Scholar
-        is throttled to ~10 req/min, so querying it last keeps it off the hot
-        path for the easy majority of entries.
+        (~30 req/min) is the CS-conference authority; OpenReview (~30 req/min) is
+        the ICLR/NeurIPS/TMLR submission authority queried before the slow
+        keyless Semantic Scholar (~10 req/min), which is queried last to keep it
+        off the hot path for the easy majority of entries.
 
         Returns:
             List of ``(score, record, source_name)`` tuples, possibly from
@@ -2494,7 +2502,41 @@ class FactChecker:
             if max(best_cr, best_oa, best_dblp) >= self.config.cascade_high_confidence:
                 return all_candidates
 
-        # ----- Step 4: Semantic Scholar (preprint coverage; slowest w/o key) -----
+        # ----- Step 4: OpenReview (authoritative ICLR/NeurIPS/TMLR registry) -----
+        # OpenReview owns the submission record for most ML conferences, which the
+        # DOI/CS-index sources above frequently fail to *positively* confirm
+        # (these land in the "could-not-verify" bucket). It exposes ~Given_Family
+        # profile handles, yielding authoritative family names. Queried before the
+        # slow keyless Semantic Scholar so the ML-venue authority is consulted
+        # first. Lazily built from the shared HTTP client (reachable via Crossref),
+        # mirroring the OpenAlex step; skipped if no shared client is available so
+        # tests stay hermetic and no impolite off-pool traffic is created.
+        best_or = 0.0
+        if self.openreview is None:
+            shared_http = getattr(self.crossref, "http", None)
+            if shared_http is not None:
+                self.openreview = OpenReviewClient(http=shared_http)
+        if self.openreview is not None:
+            sources_queried.append("openreview")
+            try:
+                or_notes = self.openreview.search(
+                    query, limit=top_k, title=raw_title, first_author=first_author
+                )
+            except Exception as exc:
+                or_notes = []
+                errors.append(f"OpenReview: {exc}")
+            or_records: list[PublishedRecord] = []
+            for note in or_notes or []:
+                rec = openreview_note_to_candidate_record(note)
+                if rec:
+                    or_records.append(rec)
+            if or_records:
+                sources_with_hits.append("openreview")
+            best_or = _ingest("openreview", or_records)
+            if max(best_cr, best_oa, best_dblp, best_or) >= self.config.cascade_high_confidence:
+                return all_candidates
+
+        # ----- Step 5: Semantic Scholar (preprint coverage; slowest w/o key) -----
         sources_queried.append("semanticscholar")
         try:
             # Title-led query keeps S2 relevance focused on the paper title.
@@ -3480,6 +3522,7 @@ def main() -> int:
             "crossref": max(10, int(50 * rate_scale)),
             "semanticscholar": 60 if s2_api_key else max(5, int(10 * rate_scale)),
             "dblp": max(10, int(30 * rate_scale)),
+            "openreview": max(10, int(30 * rate_scale)),
             "openlibrary": max(10, int(30 * rate_scale)),
             "google_books": max(10, int(30 * rate_scale)),
         }

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -6,8 +6,10 @@ This tool validates that bibliographic entries in BibTeX files:
 2. Have matching metadata (title, authors, year, venue)
 
 It outputs detailed reports categorizing mismatches:
-- VERIFIED: Entry matches an external record
+- VERIFIED: Every claimed field positively confirmed against an external record
 - NOT_FOUND: No matching record found in any database
+- UNCONFIRMED: Record found and nothing contradicted, but a claimed field could
+  not be positively confirmed (e.g. preprint-only venue, incomplete authors)
 - HALLUCINATED: Very low match score, likely fabricated
 - TITLE_MISMATCH: Title differs significantly
 - AUTHOR_MISMATCH: Author list differs
@@ -44,6 +46,7 @@ from rapidfuzz.fuzz import token_sort_ratio
 from bibtex_updater.calibration import calibrate_result
 from bibtex_updater.matching import (
     EXPANDED_VENUE_ALIASES,
+    MatchOutcome,
     get_canonical_venue,
     is_near_miss_title,
     is_preprint_or_series_venue,
@@ -188,6 +191,13 @@ class FactCheckStatus(Enum):
     # Academic verification statuses
     VERIFIED = "verified"
     NOT_FOUND = "not_found"
+    # A matching record was found and nothing contradicts the entry, but at
+    # least one claimed field could not be POSITIVELY CONFIRMED (e.g. only a
+    # preprint record was found so the claimed published venue is unconfirmable,
+    # or the cited author list is a consistent-but-incomplete subset). This is a
+    # "could not fully confirm / needs review" verdict -- abstention, NOT a
+    # problem and NOT a verification.
+    UNCONFIRMED = "unconfirmed"
     TITLE_MISMATCH = "title_mismatch"
     AUTHOR_MISMATCH = "author_mismatch"
     YEAR_MISMATCH = "year_mismatch"
@@ -231,6 +241,10 @@ class FactCheckStatus(Enum):
 ABSTAINED_STATUS_VALUES = frozenset(
     {
         FactCheckStatus.NOT_FOUND.value,
+        # A record was found but a claimed field could not be positively
+        # confirmed (preprint-only venue, incomplete author list). "Could not
+        # fully confirm" is abstention, not a problem.
+        FactCheckStatus.UNCONFIRMED.value,
         FactCheckStatus.BOOK_NOT_FOUND.value,
         FactCheckStatus.WORKING_PAPER_NOT_FOUND.value,
         FactCheckStatus.URL_NOT_FOUND.value,
@@ -245,7 +259,14 @@ def _is_abstained_status(status: FactCheckStatus) -> bool:
 
 @dataclass
 class FieldComparison:
-    """Result of comparing a single field between entry and API record."""
+    """Result of comparing a single field between entry and API record.
+
+    ``matches`` is the legacy two-valued flag (kept for reporting/JSONL and
+    backward compatibility): True only for a positive confirmation (MATCH).
+    ``outcome`` carries the three-valued verdict so the status gate can tell a
+    real MISMATCH apart from a NON_COMPARABLE / PARTIAL ("could not confirm").
+    When ``outcome`` is None it defaults to MATCH if ``matches`` else MISMATCH.
+    """
 
     field_name: str
     entry_value: str | None
@@ -253,6 +274,33 @@ class FieldComparison:
     similarity_score: float
     matches: bool
     note: str | None = None
+    outcome: MatchOutcome | None = None
+
+    @property
+    def resolved_outcome(self) -> MatchOutcome:
+        """Three-valued verdict, defaulting from ``matches`` when unset."""
+        if self.outcome is not None:
+            return self.outcome
+        return MatchOutcome.MATCH if self.matches else MatchOutcome.MISMATCH
+
+    @property
+    def is_confirmed(self) -> bool:
+        """True only for a positive confirmation (MATCH)."""
+        return self.resolved_outcome is MatchOutcome.MATCH
+
+    @property
+    def is_mismatch(self) -> bool:
+        """True only for a real contradiction (MISMATCH)."""
+        return self.resolved_outcome is MatchOutcome.MISMATCH
+
+    @property
+    def is_non_confirming(self) -> bool:
+        """True when the field is neither confirmed nor a mismatch.
+
+        i.e. NON_COMPARABLE or PARTIAL: a record was found and nothing is
+        contradicted, but the claimed field could not be positively confirmed.
+        """
+        return self.resolved_outcome in (MatchOutcome.NON_COMPARABLE, MatchOutcome.PARTIAL)
 
 
 @dataclass
@@ -1419,31 +1467,53 @@ def _find_canonical_venue(norm_venue: str) -> str | None:
     return None
 
 
-def venues_match(venue_a: str, venue_b: str, threshold: float = 0.70) -> tuple[bool, float]:
-    """Check if two venue names match, considering aliases. Returns (matches, score).
+@dataclass(frozen=True)
+class VenueMatchResult:
+    """Trichotomy result of :func:`venues_match`.
 
-    P2.5: Now uses EXPANDED_VENUE_ALIASES from matching.py for better venue coverage.
-
-    FIX E-venue: venue comparison is non-refuting in two symmetric cases, so it
-    never produces a false mismatch for a correctly cited paper:
-
-    - EMPTY on EITHER side -> non-comparable. (Previously empty *entry* matched
-      but empty *API* hard-failed; arXiv-indexed records routinely have a blank
-      venue.)
-    - PREPRINT / publisher-series on either side (arXiv/CoRR, bioRxiv, PMLR,
-      JMLR W&CP) -> non-comparable. A preprint venue says nothing about the
-      published venue the entry cites.
-
-    A genuine mismatch (both sides populated, both canonicalize to two DIFFERENT
-    real venues) is still reported.
+    ``outcome`` is one of MATCH / MISMATCH / NON_COMPARABLE. NON_COMPARABLE means
+    the claimed published venue cannot be *confirmed* (blank on a side, or the
+    matched record is only a preprint/series) -- it is NOT a match.
     """
-    # Empty on either side: nothing to compare -> neutral match.
-    if not venue_a or not venue_b:
-        return (True, 1.0)
 
-    # Preprint / non-specific series on either side: non-comparable -> neutral.
+    outcome: MatchOutcome
+    score: float
+
+    @property
+    def is_confirmed(self) -> bool:
+        return self.outcome is MatchOutcome.MATCH
+
+    @property
+    def is_mismatch(self) -> bool:
+        return self.outcome is MatchOutcome.MISMATCH
+
+
+def venues_match(venue_a: str, venue_b: str, threshold: float = 0.70) -> VenueMatchResult:
+    """Compare two venue names (alias-aware) into a three-valued outcome.
+
+    P2.5: Uses EXPANDED_VENUE_ALIASES from matching.py for venue coverage.
+
+    The comparison is three-valued so a blank/preprint record can no longer
+    masquerade as positive confirmation:
+
+    - NON_COMPARABLE when either side is empty, OR when the matched record's
+      venue is a preprint/publisher-series (arXiv/CoRR, bioRxiv, PMLR, JMLR
+      W&CP). A preprint record cannot *confirm* the published venue the entry
+      claims -- it says nothing about it -- so it must not read as a match.
+    - MATCH when both sides are populated real venues that canonicalize equal
+      (or fuzzy >= threshold).
+    - MISMATCH when both sides are populated real venues that differ.
+
+    Returns a :class:`VenueMatchResult`.
+    """
+    # Empty on either side: nothing to confirm -> non-comparable.
+    if not venue_a or not venue_b:
+        return VenueMatchResult(MatchOutcome.NON_COMPARABLE, 1.0)
+
+    # Preprint / non-specific series on either side: the published venue the
+    # entry cites cannot be confirmed from a preprint record -> non-comparable.
     if is_preprint_or_series_venue(venue_a) or is_preprint_or_series_venue(venue_b):
-        return (True, 1.0)
+        return VenueMatchResult(MatchOutcome.NON_COMPARABLE, 1.0)
 
     norm_a = normalize_venue(venue_a)
     norm_b = normalize_venue(venue_b)
@@ -1453,12 +1523,14 @@ def venues_match(venue_a: str, venue_b: str, threshold: float = 0.70) -> tuple[b
     canonical_b = get_canonical_venue(norm_b, EXPANDED_VENUE_ALIASES)
     if canonical_a and canonical_b:
         if canonical_a == canonical_b:
-            return (True, 0.95)
-        return (False, 0.0)  # Known different venues
+            return VenueMatchResult(MatchOutcome.MATCH, 0.95)
+        return VenueMatchResult(MatchOutcome.MISMATCH, 0.0)  # Known different venues
 
     # Fall back to fuzzy matching
     score = token_sort_ratio(normalize_title_for_match(norm_a), normalize_title_for_match(norm_b)) / 100.0
-    return (score >= threshold, score)
+    if score >= threshold:
+        return VenueMatchResult(MatchOutcome.MATCH, score)
+    return VenueMatchResult(MatchOutcome.MISMATCH, score)
 
 
 def _doi_resolves(client: httpx.Client, doi: str) -> bool | None:
@@ -1754,8 +1826,15 @@ class FactChecker:
         field_comparisons = self._compare_all_fields(entry, best_match)
         status = self._determine_status(best_score, field_comparisons, sources_with_hits)
 
-        # Post-match: check preprint status
-        if status in (FactCheckStatus.VERIFIED, FactCheckStatus.VENUE_MISMATCH):
+        # Post-match: check preprint status. UNCONFIRMED is included because a
+        # venue we could not confirm is exactly the case where an independent
+        # preprint-only signal (arXiv-only, no DOI/venue) upgrades the verdict to
+        # the positive-evidence PREPRINT_ONLY.
+        if status in (
+            FactCheckStatus.VERIFIED,
+            FactCheckStatus.VENUE_MISMATCH,
+            FactCheckStatus.UNCONFIRMED,
+        ):
             preprint_status = self._check_preprint_status(entry, best_match)
             if preprint_status is not None:
                 status = preprint_status
@@ -2321,16 +2400,36 @@ class FactChecker:
         entry_authors = entry.get("author", "")
         entry_names = authors_last_names(entry_authors, limit=10_000)
         api_names = record.surname_keys(limit=10_000)
-        author_matches, author_score = symmetric_author_match(
-            entry_names, api_names, threshold=cfg.author_threshold
-        )
+        author_result = symmetric_author_match(entry_names, api_names, threshold=cfg.author_threshold)
         api_authors_str = " and ".join(f"{a.get('given', '')} {a.get('family', '')}".strip() for a in record.authors)
+        # Mirror the venue "no claim" rule: if the entry lists no authors there is
+        # nothing to confirm (vacuously MATCH). A PARTIAL (consistent-but-
+        # incomplete) confirmation is NOT a full confirmation and routes to
+        # UNCONFIRMED; a NON_COMPARABLE result with authors on the entry side but
+        # none in the record also could-not-confirm.
+        if not entry_names:
+            author_outcome = MatchOutcome.MATCH
+            author_confirmed = True
+            author_note = "No authors claimed"
+        else:
+            author_outcome = author_result.outcome
+            author_confirmed = author_result.is_confirmed
+            if author_result.outcome is MatchOutcome.PARTIAL:
+                author_note = "Authors consistent but incomplete"
+            elif author_result.outcome is MatchOutcome.NON_COMPARABLE:
+                author_note = "Authors could not be confirmed (no author data in record)"
+            else:
+                author_note = None
         comparisons["author"] = FieldComparison(
             "author",
             entry_authors,
             api_authors_str,
-            author_score,
-            author_matches,
+            author_result.score,
+            # ``matches`` is positive-confirmation only: a PARTIAL/NON_COMPARABLE
+            # author check is not a full confirmation, so it is not "matched".
+            author_confirmed,
+            note=author_note,
+            outcome=author_outcome,
         )
 
         # Year
@@ -2353,16 +2452,38 @@ class FactChecker:
             f"Tolerance: ±{cfg.year_tolerance}",
         )
 
-        # Venue (alias-aware matching)
+        # Venue (alias-aware matching, three-valued).
         entry_venue = entry.get("journal") or entry.get("booktitle") or ""
         api_venue = record.journal or ""
-        venue_matches, venue_score = venues_match(entry_venue, api_venue, cfg.venue_threshold)
+        venue_result = venues_match(entry_venue, api_venue, cfg.venue_threshold)
+        # Positive-confirmation gate distinguishes "no claim" from "claim we
+        # could not confirm":
+        #  - The entry makes NO venue claim (preprint @misc/@article with no
+        #    journal/booktitle) -> there is nothing to confirm, so the field is
+        #    vacuously confirmed (MATCH) and must not block VERIFIED.
+        #  - The entry CLAIMS a published venue but the matched record is blank
+        #    or preprint-only -> the claim cannot be confirmed -> NON_COMPARABLE,
+        #    which routes the verdict to UNCONFIRMED (could not verify).
+        if not entry_venue:
+            venue_outcome = MatchOutcome.MATCH
+            venue_confirmed = True
+            venue_note = "No venue claimed"
+        else:
+            venue_outcome = venue_result.outcome
+            venue_confirmed = venue_result.is_confirmed
+            venue_note = (
+                "Claimed venue could not be confirmed (preprint/blank record)"
+                if venue_result.outcome is MatchOutcome.NON_COMPARABLE
+                else None
+            )
         comparisons["venue"] = FieldComparison(
             "venue",
             entry_venue,
             api_venue,
-            venue_score,
-            venue_matches,
+            venue_result.score,
+            venue_confirmed,
+            note=venue_note,
+            outcome=venue_outcome,
         )
 
         return comparisons
@@ -2373,9 +2494,22 @@ class FactChecker:
         comparisons: dict[str, FieldComparison],
         sources_with_hits: list[str],
     ) -> FactCheckStatus:
-        """Determine final status from score and comparisons.
+        """Determine final status from score and field comparisons.
 
-        P2.6: Venue mismatch is prioritized when title+author match.
+        VERIFIED means POSITIVE CONFIRMATION of every claimed field, not merely
+        "nothing was contradicted". Each field comparison is three-valued
+        (MATCH / MISMATCH / NON_COMPARABLE|PARTIAL), and the gate routes them:
+
+        - Any MISMATCH (two different real venues, a swapped/wrong author, a
+          different title/year) is positive evidence of a problem -> the usual
+          PROBLEMATIC statuses (VENUE_MISMATCH / AUTHOR_MISMATCH / ... /
+          PARTIAL_MATCH).
+        - No MISMATCH but some field is NON_COMPARABLE or PARTIAL (preprint-only
+          venue, incomplete author list) -> UNCONFIRMED: a record was found and
+          nothing conflicts, but a claimed field could not be positively
+          confirmed. This is abstention ("could not fully confirm / needs
+          review"), distinct from both VERIFIED and PROBLEMATIC.
+        - Every field CONFIRMED -> VERIFIED.
 
         Fix B (abstention): a weak best candidate means the title search returned
         an *unrelated* paper -- the tool simply could not find the real one. That
@@ -2395,35 +2529,43 @@ class FactChecker:
         title_cmp = comparisons.get("title")
         author_cmp = comparisons.get("author")
         title_score = title_cmp.similarity_score if title_cmp else 0.0
-        title_ok = bool(title_cmp and title_cmp.matches)
-        author_ok = bool(author_cmp and author_cmp.matches)
-        wrong_paper_signature = title_score < 0.30 and not title_ok and not author_ok
+        title_confirmed = bool(title_cmp and title_cmp.is_confirmed)
+        author_confirmed = bool(author_cmp and author_cmp.is_confirmed)
+        wrong_paper_signature = title_score < 0.30 and not title_confirmed and not author_confirmed
 
         if best_score < self.config.abstention_below or wrong_paper_signature:
             return FactCheckStatus.NOT_FOUND
 
-        mismatches = [name for name, c in comparisons.items() if not c.matches]
+        # Positive evidence of a problem: a field that is a real MISMATCH (both
+        # sides populated and conflicting). These take priority over abstention.
+        mismatches = [name for name, c in comparisons.items() if c.is_mismatch]
 
-        if not mismatches:
-            return FactCheckStatus.VERIFIED
-
-        # P2.6: Prioritize venue mismatch when title+author match
-        if "venue" in mismatches:
-            title_ok = comparisons.get("title") and comparisons["title"].matches
-            author_ok = comparisons.get("author") and comparisons["author"].matches
-            if title_ok and author_ok:
+        if mismatches:
+            # P2.6: Prioritize venue mismatch when title+author are confirmed.
+            if "venue" in mismatches and title_confirmed and author_confirmed:
                 return FactCheckStatus.VENUE_MISMATCH
 
-        if len(mismatches) == 1:
-            mismatch_map = {
-                "title": FactCheckStatus.TITLE_MISMATCH,
-                "author": FactCheckStatus.AUTHOR_MISMATCH,
-                "year": FactCheckStatus.YEAR_MISMATCH,
-                "venue": FactCheckStatus.VENUE_MISMATCH,
-            }
-            return mismatch_map.get(mismatches[0], FactCheckStatus.PARTIAL_MATCH)
+            if len(mismatches) == 1:
+                mismatch_map = {
+                    "title": FactCheckStatus.TITLE_MISMATCH,
+                    "author": FactCheckStatus.AUTHOR_MISMATCH,
+                    "year": FactCheckStatus.YEAR_MISMATCH,
+                    "venue": FactCheckStatus.VENUE_MISMATCH,
+                }
+                return mismatch_map.get(mismatches[0], FactCheckStatus.PARTIAL_MATCH)
 
-        return FactCheckStatus.PARTIAL_MATCH
+            return FactCheckStatus.PARTIAL_MATCH
+
+        # No mismatch, but require POSITIVE confirmation of every claimed field.
+        # A NON_COMPARABLE venue (preprint/blank record) or a PARTIAL author
+        # confirmation (consistent-but-incomplete) is not a full confirmation:
+        # the claim could not be verified, so abstain with UNCONFIRMED rather
+        # than reporting VERIFIED.
+        non_confirming = [name for name, c in comparisons.items() if c.is_non_confirming]
+        if non_confirming:
+            return FactCheckStatus.UNCONFIRMED
+
+        return FactCheckStatus.VERIFIED
 
 
 class AcademicVerifier(BaseVerifier):
@@ -2727,6 +2869,10 @@ class FactCheckProcessor:
             "author_mismatch",
             "year_mismatch",
             "venue_mismatch",
+            # Multiple confirmed mismatches -> positive evidence of a problem.
+            # (Previously omitted, so PARTIAL_MATCH entries fell through all three
+            # buckets and the bucket counts under-summed.)
+            "partial_match",
             "url_content_mismatch",
             "future_date",
             "invalid_year",

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -3038,6 +3038,73 @@ class FactCheckProcessor:
 
         return results
 
+    def _batch_warm_crossref_records(self, entries: list[dict[str, Any]]) -> int:
+        """Pre-fetch every entry DOI's Crossref ``/works`` record in parallel.
+
+        Latency optimization (mirrors :meth:`_batch_validate_dois`). The per-entry
+        DOI checks (``_check_doi_consistency`` and the structured-name author
+        recheck) each call ``CrossrefClient.get_by_doi`` for the entry's DOI. Run
+        serially across the worker pool, those round-trips are gated by the
+        crossref rate limiter (50/min) and dominate wall-clock on large
+        bibliographies.
+
+        Here we issue the SAME ``get_by_doi`` calls once, up front, in a bounded
+        thread pool. ``get_by_doi`` routes through the shared ``HttpClient``, whose
+        responses are stored in the thread-safe SqliteCache keyed by request URL.
+        Warming that cache turns the later per-entry ``get_by_doi`` calls into
+        cache hits, so the same records are used for the same comparisons -- this
+        is purely a change to WHEN the fetch happens, never WHICH record is used
+        (verdict-neutral).
+
+        Thread-safety: this runs BEFORE the main worker pool starts and writes
+        only to the SqliteCache (already thread-safe). It adds no mutable state on
+        ``self`` or the checker, so concurrent ``check_entry`` calls only ever READ
+        the warmed cache.
+
+        Fallback: a DOI whose pre-fetch fails (network error / non-200) is simply
+        not cached. The per-entry ``get_by_doi`` then performs its own fetch
+        exactly as before -- correct result, no speedup for that one DOI.
+
+        Returns:
+            Number of distinct DOIs warmed (best-effort; for logging/tests).
+        """
+        # Only FactChecker has a crossref client whose cache we can warm.
+        if not isinstance(self.checker, FactChecker):
+            return 0
+        crossref = self.checker.crossref
+        # No shared response cache -> warming would not be observed by the
+        # per-entry calls, so skip (each call would re-fetch anyway).
+        if getattr(crossref.http, "cache", None) is None:
+            return 0
+
+        # Dedupe DOIs across entries: identical DOIs share one cache key.
+        dois: set[str] = set()
+        for entry in entries:
+            doi = (entry.get("doi", "") or "").strip()
+            if doi:
+                dois.add(doi)
+        if not dois:
+            return 0
+
+        def _warm_one(doi: str) -> None:
+            # Same call the per-entry path uses; result lands in the shared
+            # cache. Swallow everything so one bad DOI never aborts warming.
+            try:
+                crossref.get_by_doi(doi)
+            except Exception:
+                pass
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=16) as executor:
+            futures = [executor.submit(_warm_one, doi) for doi in dois]
+            for future in concurrent.futures.as_completed(futures):
+                # Results are written straight to the cache; nothing to collect.
+                try:
+                    future.result()
+                except Exception:
+                    pass
+
+        return len(dois)
+
     def process_entries(
         self, entries: list[dict[str, Any]], jsonl_path: str | None = None, max_workers: int = 8
     ) -> list[FactCheckResult]:
@@ -3060,6 +3127,15 @@ class FactCheckProcessor:
             self.logger.info(
                 "DOI pre-validation complete: %d checked, %d failed", len(pre_validated_dois), failed_count
             )
+
+        # Latency: warm the Crossref /works response cache for all entry DOIs in
+        # parallel up front, so the per-entry DOI checks (consistency + structured
+        # author recheck) hit the cache instead of each making a serial,
+        # rate-limited round-trip. Verdict-neutral; failures fall back to the
+        # existing per-entry fetch. (Mirrors _batch_validate_dois.)
+        warmed = self._batch_warm_crossref_records(entries)
+        if warmed:
+            self.logger.info("Pre-fetched Crossref records for %d DOIs", warmed)
 
         results: list[FactCheckResult | None] = [None] * len(entries)  # Pre-allocate to preserve order
 

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -76,6 +76,7 @@ from bibtex_updater.utils import (
     arxiv_atom_to_record,
     authors_last_names,
     crossref_message_to_record,
+    dblp_hit_to_candidate_record,
     dblp_hit_to_record,
     first_author_surname,
     is_valid_arxiv_id,
@@ -1197,9 +1198,36 @@ class CrossrefClient:
     def __init__(self, http: HttpClient):
         self.http = http
 
-    def search(self, query: str, rows: int = 10) -> list[dict[str, Any]]:
-        """Search Crossref for bibliographic records."""
-        params = {"query.bibliographic": query, "rows": rows}
+    def search(
+        self,
+        query: str,
+        rows: int = 10,
+        title: str | None = None,
+        author: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search Crossref for bibliographic records.
+
+        Args:
+            query: Free-text bibliographic query (``"<title> <author>"`` blob).
+                Used as the ``query.bibliographic`` fallback.
+            rows: Max records to retrieve.
+            title: Raw (un-normalized, author-free) title. When provided, the
+                client uses Crossref's *fielded* ``query.title`` instead of the
+                generic ``query.bibliographic`` blob, which keeps DOI-less
+                ML-conference titles ranked correctly rather than letting the
+                appended surname pull in unrelated records.
+            author: First-author surname, sent as ``query.author`` to tighten
+                the fielded result set. Only used when ``title`` is supplied.
+
+        Returns:
+            List of Crossref message items, never None. Empty on any error.
+        """
+        if title and title.strip():
+            params: dict[str, Any] = {"query.title": title.strip(), "rows": rows}
+            if author and author.strip():
+                params["query.author"] = author.strip()
+        else:
+            params = {"query.bibliographic": query, "rows": rows}
         try:
             resp = self.http._request("GET", CROSSREF_API, params=params, accept="application/json", service="crossref")
             if resp.status_code != 200:
@@ -1949,24 +1977,36 @@ class FactChecker:
         sources_with_hits: list[str],
         errors: list[str],
     ) -> list[tuple[float, PublishedRecord, str]]:
-        """Cascading source order: CrossRef -> OpenAlex -> Semantic Scholar.
+        """Cascading source order: CrossRef -> OpenAlex -> DBLP -> Semantic Scholar.
 
         Item 1 (CheckIfExist Algorithm 1, Abbonato 2026). Each step retrieves
         ``config.top_k`` candidates and re-ranks them by Levenshtein title
         similarity (Item 2). The cascade short-circuits as soon as a source
         returns a candidate at or above ``cascade_high_confidence``.
 
+        Retrieval (this fix): Crossref and OpenAlex are queried with *fielded
+        title* searches (``query.title`` / ``filter=title.search:``) using the
+        raw, author-free title rather than the normalized ``"title + surname"``
+        blob. The blob fed to the free-text BM25 endpoints returned unrelated
+        papers for DOI-less ML-conference titles (ICML/ICLR/NeurIPS), causing
+        ~61% of valid references to be falsely flagged. DBLP -- which
+        authoritatively indexes those venues -- is added as a cascade step
+        after OpenAlex.
+
         Order rationale (throughput): the fast, broad sources come first so the
         slow specialist is only reached on hard entries. OpenAlex runs on the
-        polite pool (~100 req/min) and aggregates Crossref + others; a keyless
-        Semantic Scholar is throttled to ~10 req/min, so querying it last keeps
-        it off the hot path for the easy majority of entries.
+        polite pool (~100 req/min) and aggregates Crossref + others; DBLP
+        (~30 req/min) is the CS-conference authority; a keyless Semantic Scholar
+        is throttled to ~10 req/min, so querying it last keeps it off the hot
+        path for the easy majority of entries.
 
         Returns:
             List of ``(score, record, source_name)`` tuples, possibly from
             multiple sources if intermediate matches were below threshold.
         """
-        title_norm = normalize_title_for_match(entry.get("title", ""))
+        raw_title = entry.get("title", "") or ""
+        title_norm = normalize_title_for_match(raw_title)
+        first_author = first_author_surname(entry)
         authors_ref = authors_last_names(entry.get("author", ""), limit=3)
         top_k = max(1, min(int(self.config.top_k), MAX_TOP_K))
 
@@ -1983,10 +2023,10 @@ class FactChecker:
                     best_local = score
             return best_local
 
-        # ----- Step 1: CrossRef -----
+        # ----- Step 1: CrossRef (fielded query.title + query.author) -----
         sources_queried.append("crossref")
         try:
-            cr_items = self.crossref.search(query, rows=top_k)
+            cr_items = self.crossref.search(query, rows=top_k, title=raw_title, author=first_author)
         except Exception as exc:
             cr_items = []
             errors.append(f"Crossref: {exc}")
@@ -2018,7 +2058,8 @@ class FactChecker:
         if self.openalex is not None:
             sources_queried.append("openalex")
             try:
-                oa_items = self.openalex.search(query, limit=top_k)
+                # Fielded filter=title.search:<raw title>, free-text fallback.
+                oa_items = self.openalex.search(query, limit=top_k, title=raw_title)
             except Exception as exc:
                 oa_items = []
                 errors.append(f"OpenAlex: {exc}")
@@ -2033,10 +2074,37 @@ class FactChecker:
             if max(best_cr, best_oa) >= self.config.cascade_high_confidence:
                 return all_candidates
 
-        # ----- Step 3: Semantic Scholar (preprint coverage; slowest w/o key) -----
+        # ----- Step 3: DBLP (authoritative ICML/ICLR/NeurIPS index) -----
+        # DBLP's q= is a token-AND matcher (not BM25 relevance), so the raw
+        # title + surname locates the exact paper. Uses the permissive
+        # dblp_hit_to_candidate_record so DOI-less / CoRR conference hits are
+        # kept as scorable candidates (the strict resolver converter drops them).
+        best_dblp = 0.0
+        if self.dblp is not None:
+            sources_queried.append("dblp")
+            dblp_query = f"{raw_title} {first_author}".strip()
+            try:
+                dblp_hits = self.dblp.search(dblp_query, max_hits=top_k)
+            except Exception as exc:
+                dblp_hits = []
+                errors.append(f"DBLP: {exc}")
+            dblp_records: list[PublishedRecord] = []
+            for hit in dblp_hits or []:
+                rec = dblp_hit_to_candidate_record(hit)
+                if rec:
+                    dblp_records.append(rec)
+            if dblp_records:
+                sources_with_hits.append("dblp")
+            best_dblp = _ingest("dblp", dblp_records)
+            if max(best_cr, best_oa, best_dblp) >= self.config.cascade_high_confidence:
+                return all_candidates
+
+        # ----- Step 4: Semantic Scholar (preprint coverage; slowest w/o key) -----
         sources_queried.append("semanticscholar")
         try:
-            s2_data = self.s2.search(query, limit=top_k)
+            # Title-led query keeps S2 relevance focused on the paper title.
+            s2_query = f"{raw_title} {first_author}".strip() or query
+            s2_data = self.s2.search(s2_query, limit=top_k)
         except Exception as exc:
             s2_data = []
             errors.append(f"Semantic Scholar: {exc}")

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -34,7 +34,7 @@ import re
 import sys
 import threading
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
@@ -321,6 +321,14 @@ class FactCheckResult:
     category: EntryCategory | None = None
     url_check: URLCheckResult | None = None
     book_match: BookRecord | None = None
+    # Per-entry verification state carried on the result instead of stashed on
+    # the shared ``FactChecker`` instance. ``check_entry`` runs concurrently
+    # across a ThreadPoolExecutor, so any per-entry value written to ``self``
+    # would be clobbered by sibling entries. These let a caller build a rich
+    # :class:`VerificationResult` from THIS entry's run without re-querying and
+    # without racing on shared mutable state.
+    author_intersection: AuthorIntersectionResult | None = None
+    source_records: dict[str, PublishedRecord | None] = field(default_factory=dict)
 
 
 @dataclass
@@ -470,18 +478,34 @@ def build_verification_result(
     Item 5: callers that want per-field similarity scores plus the cross-source
     author intersection get them here without the legacy JSONL output changing.
 
+    The per-entry intersection and source records are carried on ``fc_result``
+    itself (``fc_result.author_intersection`` / ``fc_result.source_records``),
+    so the default is to read them off the result -- this is thread-safe because
+    ``check_entry`` runs concurrently and no longer stashes per-entry state on
+    the shared ``FactChecker`` instance. The explicit ``intersection`` /
+    ``source_records`` arguments still override for callers that compute them
+    separately.
+
     Args:
         fc_result: The classic fact-check result from ``FactChecker.check_entry``.
-        intersection: Optional cross-source author intersection -- normally
-            ``FactChecker.last_author_intersection`` from the same run.
-        source_records: Optional ``source_name -> PublishedRecord`` mapping --
-            normally ``FactChecker.last_source_records``.
+        intersection: Optional cross-source author intersection. Defaults to
+            ``fc_result.author_intersection`` (the value from the SAME run that
+            produced ``fc_result``).
+        source_records: Optional ``source_name -> PublishedRecord`` mapping.
+            Defaults to ``fc_result.source_records`` from the same run.
 
     Returns:
         :class:`VerificationResult`. The numeric ``confidence_score`` falls
         back to ``getattr(fc_result, "confidence_score", overall_confidence*100)``
         so older paths still get a sensible score.
     """
+    # Default to the per-entry state carried on the result itself (thread-safe:
+    # it belongs to THIS entry's run, not to shared instance state).
+    if intersection is None:
+        intersection = fc_result.author_intersection
+    if source_records is None:
+        source_records = fc_result.source_records or None
+
     # Per-field similarity breakdown (0-100 scale, more useful for display).
     breakdown: dict[str, float] = {}
     issues: list[str] = []
@@ -1625,26 +1649,44 @@ class FactChecker:
         # OpenAlex client is optional; tests can pass a fake. The cascade falls
         # back to creating a default client if not provided.
         self.openalex: OpenAlexClient | None = openalex
-        # The most recent cross-source author intersection (set by check_entry).
-        self.last_author_intersection: AuthorIntersectionResult | None = None
-        # Per-source records from the most recent check (used by the rich
-        # VerificationResult builder).
-        self.last_source_records: dict[str, PublishedRecord | None] = {}
+        # Per-entry verification state (cross-source author intersection,
+        # per-source records) is NOT stored on the shared instance: check_entry
+        # runs concurrently across a ThreadPoolExecutor, so a sibling entry would
+        # clobber it. It is returned on the FactCheckResult instead. See
+        # FactCheckResult.author_intersection / .source_records.
+        #
         # Memoize fetched+parsed arXiv records by ID: the consistency pre-check
         # and the by-ID candidate query both look up the entry's arXiv ID in one
         # verification pass, so this avoids a duplicate network fetch + parse.
+        # This IS a cross-entry cache (not per-entry verdict state), shared by
+        # all concurrent check_entry calls, so its dict mutation is guarded by a
+        # lock. The actual fetch happens OUTSIDE the lock (double-checked insert)
+        # so a slow network call never serializes the other workers.
         self._arxiv_record_cache: dict[str, PublishedRecord | None] = {}
+        self._arxiv_cache_lock = threading.Lock()
 
     def _arxiv_record(self, arxiv_id: str) -> PublishedRecord | None:
-        """Fetch + parse the arXiv record for an ID, memoized per checker."""
-        if arxiv_id in self._arxiv_record_cache:
-            return self._arxiv_record_cache[arxiv_id]
+        """Fetch + parse the arXiv record for an ID, memoized per checker.
+
+        Thread-safe: the cache dict is shared across concurrent ``check_entry``
+        workers. We read/insert under ``_arxiv_cache_lock`` but perform the
+        network fetch+parse outside it (double-checked locking) so a slow arXiv
+        request does not stall sibling workers.
+        """
+        with self._arxiv_cache_lock:
+            if arxiv_id in self._arxiv_record_cache:
+                return self._arxiv_record_cache[arxiv_id]
         rec: PublishedRecord | None = None
         if self.arxiv is not None:
             xml = self.arxiv.fetch_atom(arxiv_id)
             if xml:
                 rec = arxiv_atom_to_record(xml)
-        self._arxiv_record_cache[arxiv_id] = rec
+        with self._arxiv_cache_lock:
+            # Another worker may have populated the same ID while we fetched;
+            # keep the first cached value so the memo stays a stable cache.
+            if arxiv_id in self._arxiv_record_cache:
+                return self._arxiv_record_cache[arxiv_id]
+            self._arxiv_record_cache[arxiv_id] = rec
         return rec
 
     def _validate_year(self, entry: dict[str, Any]) -> FactCheckStatus | None:
@@ -1810,8 +1852,9 @@ class FactChecker:
 
         if not candidates:
             status = FactCheckStatus.API_ERROR if errors else FactCheckStatus.NOT_FOUND
-            self.last_author_intersection = None
-            self.last_source_records = {}
+            # No candidates -> no per-entry intersection/source records. These
+            # ride on the result (not self) so concurrent entries don't clobber
+            # each other.
             return FactCheckResult(
                 entry_key=entry_key,
                 entry_type=entry_type,
@@ -1822,12 +1865,12 @@ class FactChecker:
                 api_sources_queried=sources_queried,
                 api_sources_with_hits=sources_with_hits,
                 errors=errors,
+                author_intersection=None,
+                source_records={},
             )
 
         # P2.4: Detect chimeric titles before sorting
         if self._detect_chimeric_title(entry, candidates):
-            self.last_author_intersection = None
-            self.last_source_records = {}
             return FactCheckResult(
                 entry_key=entry_key,
                 entry_type=entry_type,
@@ -1838,6 +1881,8 @@ class FactChecker:
                 api_sources_queried=sources_queried,
                 api_sources_with_hits=sources_with_hits,
                 errors=["Chimeric title detected: tokens borrowed from multiple different papers"],
+                author_intersection=None,
+                source_records={},
             )
 
         # Sort candidates by score descending
@@ -1845,17 +1890,17 @@ class FactChecker:
         best_score, best_match, _source = candidates[0]
 
         # Item 3: cross-source author intersection -- pick the best record from
-        # each source and intersect their author lists. Stored on the checker
-        # so callers can build a rich VerificationResult without re-querying.
+        # each source and intersect their author lists. Carried on the returned
+        # FactCheckResult (NOT on self) so callers can build a rich
+        # VerificationResult without re-querying and without racing concurrent
+        # check_entry calls.
         best_per_source: dict[str, PublishedRecord | None] = {}
         for _cand_score, cand_rec, cand_source in candidates:
             current = best_per_source.get(cand_source)
             if current is None:
                 best_per_source[cand_source] = cand_rec
             # The list is already sorted desc; first entry per source wins.
-        self.last_source_records = best_per_source
         intersection = cross_source_author_intersection(best_per_source, multi_source_bonus=MULTI_SOURCE_BONUS)
-        self.last_author_intersection = intersection
 
         field_comparisons = self._compare_all_fields(entry, best_match)
         status = self._determine_status(best_score, field_comparisons, sources_with_hits)
@@ -1942,6 +1987,10 @@ class FactChecker:
             api_sources_queried=sources_queried,
             api_sources_with_hits=sources_with_hits,
             errors=errors,
+            # Per-entry state carried on the result (not stashed on self) so
+            # concurrent check_entry calls don't clobber each other.
+            author_intersection=intersection,
+            source_records=best_per_source,
         )
         # Stash the numeric (0-100) confidence as an attribute -- additive only,
         # not part of the JSONL schema so existing consumers keep working.

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -44,9 +44,10 @@ from rapidfuzz.fuzz import token_sort_ratio
 from bibtex_updater.calibration import calibrate_result
 from bibtex_updater.matching import (
     EXPANDED_VENUE_ALIASES,
-    combined_author_score,
     get_canonical_venue,
     is_near_miss_title,
+    is_preprint_or_series_venue,
+    symmetric_author_match,
     title_edit_distance,
 )
 from bibtex_updater.sources import (
@@ -82,6 +83,8 @@ from bibtex_updater.utils import (
     is_valid_arxiv_id,
     # Matching
     jaccard_similarity,
+    # DOI normalization (arXiv-version-aware)
+    normalize_doi_for_resolution,
     # Text normalization
     normalize_title_for_match,
     s2_data_to_record,
@@ -1394,9 +1397,27 @@ def venues_match(venue_a: str, venue_b: str, threshold: float = 0.70) -> tuple[b
     """Check if two venue names match, considering aliases. Returns (matches, score).
 
     P2.5: Now uses EXPANDED_VENUE_ALIASES from matching.py for better venue coverage.
+
+    FIX E-venue: venue comparison is non-refuting in two symmetric cases, so it
+    never produces a false mismatch for a correctly cited paper:
+
+    - EMPTY on EITHER side -> non-comparable. (Previously empty *entry* matched
+      but empty *API* hard-failed; arXiv-indexed records routinely have a blank
+      venue.)
+    - PREPRINT / publisher-series on either side (arXiv/CoRR, bioRxiv, PMLR,
+      JMLR W&CP) -> non-comparable. A preprint venue says nothing about the
+      published venue the entry cites.
+
+    A genuine mismatch (both sides populated, both canonicalize to two DIFFERENT
+    real venues) is still reported.
     """
+    # Empty on either side: nothing to compare -> neutral match.
     if not venue_a or not venue_b:
-        return (True, 1.0) if not venue_a else (False, 0.0)
+        return (True, 1.0)
+
+    # Preprint / non-specific series on either side: non-comparable -> neutral.
+    if is_preprint_or_series_venue(venue_a) or is_preprint_or_series_venue(venue_b):
+        return (True, 1.0)
 
     norm_a = normalize_venue(venue_a)
     norm_b = normalize_venue(venue_b)
@@ -1412,6 +1433,38 @@ def venues_match(venue_a: str, venue_b: str, threshold: float = 0.70) -> tuple[b
     # Fall back to fuzzy matching
     score = token_sort_ratio(normalize_title_for_match(norm_a), normalize_title_for_match(norm_b)) / 100.0
     return (score >= threshold, score)
+
+
+def _doi_resolves(client: httpx.Client, doi: str) -> bool | None:
+    """Probe whether a DOI resolves at doi.org.
+
+    Returns:
+        False  -- the DOI definitively does not exist (404/410, confirmed by a
+                  GET retry to rule out HEAD-hostile hosts).
+        True   -- it resolves (2xx/3xx) or is blocked by a publisher (418/403/
+                  429): a block is not evidence of an invalid DOI.
+        None   -- network error; the caller should treat this as non-evidence
+                  (do not penalize).
+    """
+    url = doi if doi.startswith("http") else f"https://doi.org/{doi}"
+    headers = {"User-Agent": "BibtexFactChecker/1.0"}
+    try:
+        resp = client.head(url, headers=headers)
+    except Exception:
+        return None  # Network errors are not DOI validation failures.
+    # Only 404/410 indicate a DOI that truly doesn't exist. Other 4xx (418
+    # bot-detection, 403 access control, 429 rate limit) are publisher-side
+    # blocks, not evidence of an invalid DOI.
+    if resp.status_code not in (404, 410):
+        return True
+    # Some hosts are HEAD-hostile (return 404/410 to HEAD but resolve to GET).
+    # Retry once with a tiny ranged GET before concluding the DOI is missing.
+    try:
+        retry = client.get(url, headers={**headers, "Range": "bytes=0-0"})
+    except Exception:
+        return None
+    # Definitively missing only if the GET also returns 404/410.
+    return retry.status_code not in (404, 410)
 
 
 # ------------- Fact Checker Core -------------
@@ -1498,26 +1551,18 @@ class FactChecker:
         if pre_validated is not None and entry_id in pre_validated:
             return None if pre_validated[entry_id] else FactCheckStatus.DOI_NOT_FOUND
 
-        doi = entry.get("doi", "")
-        if not doi:
+        raw_doi = entry.get("doi", "")
+        if not raw_doi:
             return None
-        doi = doi.strip()
-        if doi.startswith("http"):
-            doi = doi.replace("https://doi.org/", "").replace("http://doi.org/", "")
+        # Normalize: strip URL prefix/lowercase, and for arXiv DataCite DOIs drop
+        # a trailing version suffix (the versioned DOI 404s at doi.org but the
+        # unversioned one resolves). Fall back to the raw string if normalization
+        # yields nothing.
+        doi = normalize_doi_for_resolution(raw_doi) or raw_doi.strip()
 
-        # Reuse the shared httpx.Client to avoid per-entry TCP/TLS overhead
-        try:
-            resp = self.crossref.http.client.head(
-                f"https://doi.org/{doi}",
-                headers={"User-Agent": "BibtexFactChecker/1.0"},
-            )
-            # Only 404/410 indicate a DOI that truly doesn't exist.
-            # Other 4xx (418 bot-detection, 403 access control, 429 rate limit)
-            # are publisher-side blocks, not evidence of an invalid DOI.
-            if resp.status_code in (404, 410):
-                return FactCheckStatus.DOI_NOT_FOUND
-        except Exception:
-            pass  # Network errors are not DOI validation failures
+        # Reuse the shared httpx.Client to avoid per-entry TCP/TLS overhead.
+        if _doi_resolves(self.crossref.http.client, doi) is False:
+            return FactCheckStatus.DOI_NOT_FOUND
         return None
 
     def _check_preprint_status(self, entry: dict[str, Any], best_match: PublishedRecord) -> FactCheckStatus | None:
@@ -2240,21 +2285,26 @@ class FactChecker:
             f"Edit distance: {edit_dist}" if near_miss else None,
         )
 
-        # Author (P2.3: Ordered author comparison)
+        # Author (symmetric comparison; see FIX C / symmetric_author_match).
+        # Both sides go through the same canonical surname reduction
+        # (last_name_from_person) with a generous limit, then the matcher slices
+        # both sides symmetrically and applies ordered-containment. The legacy
+        # code sliced the entry side to 10 but left the API side at 10_000, so a
+        # correctly cited paper that lists fewer authors (or "and others") scored
+        # below threshold purely from the length asymmetry.
         entry_authors = entry.get("author", "")
-        entry_names = authors_last_names(entry_authors, limit=10)
-        # Route the API side through the same canonical surname reduction as the
-        # entry side. The API side was previously unsliced; keep that.
+        entry_names = authors_last_names(entry_authors, limit=10_000)
         api_names = record.surname_keys(limit=10_000)
-        # Use combined score (Jaccard + sequence similarity)
-        author_score = combined_author_score(entry_names, api_names, jaccard_weight=0.5, sequence_weight=0.5)
+        author_matches, author_score = symmetric_author_match(
+            entry_names, api_names, threshold=cfg.author_threshold
+        )
         api_authors_str = " and ".join(f"{a.get('given', '')} {a.get('family', '')}".strip() for a in record.authors)
         comparisons["author"] = FieldComparison(
             "author",
             entry_authors,
             api_authors_str,
             author_score,
-            author_score >= cfg.author_threshold,
+            author_matches,
         )
 
         # Year
@@ -2466,21 +2516,13 @@ class FactCheckProcessor:
             return {}
 
         def _check_doi(entry_id: str, doi: str, client: httpx.Client) -> tuple[str, bool]:
-            """Check a single DOI via HEAD request."""
-            try:
-                # Normalize DOI URL
-                if doi.startswith("http"):
-                    url = doi
-                else:
-                    url = f"https://doi.org/{doi}"
-
-                resp = client.head(url, headers={"User-Agent": "BibtexFactChecker/1.0"})
-                # Only 404/410 mean the DOI doesn't exist.
-                # 418/403/429 are publisher bot-detection, not invalid DOIs.
-                return (entry_id, resp.status_code not in (404, 410))
-            except Exception:
-                # Assume valid on error (don't penalize network issues)
-                return (entry_id, True)
+            """Check a single DOI via HEAD (with a GET fallback)."""
+            # Normalize: strip URL prefix/lowercase, and for arXiv DataCite DOIs
+            # drop a trailing version suffix (the versioned DOI 404s at doi.org
+            # but the unversioned one resolves).
+            normalized = normalize_doi_for_resolution(doi) or doi.strip()
+            # None (network error) -> assume valid (don't penalize network issues).
+            return (entry_id, _doi_resolves(client, normalized) is not False)
 
         results: dict[str, bool] = {}
         # Reuse shared httpx.Client if available (avoids TCP/TLS overhead)

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -329,6 +329,12 @@ class FactCheckerConfig:
 
     title_threshold: float = 0.90
     author_threshold: float = 0.80
+    # Opt-in (default off): treat an author list as confirmed when the author
+    # SET matches, ignoring order. APIs return as-published order reliably, so a
+    # differing order usually signals a real citation error and is flagged by
+    # default; enable this only if author order is not a defect for your use case
+    # (note: it trades away detection of same-authors-reordered hallucinations).
+    ignore_author_order: bool = False
     year_tolerance: int = 1
     venue_threshold: float = 0.70
     hallucination_max_score: float = 0.50
@@ -2009,7 +2015,10 @@ class FactChecker:
         # Nothing comparable on either side -> cannot refute (FPR-safe).
         if not entry_names or not api_names:
             return None
-        author_result = symmetric_author_match(entry_names, api_names, threshold=self.config.author_threshold)
+        author_result = symmetric_author_match(
+            entry_names, api_names, threshold=self.config.author_threshold,
+            ignore_order=self.config.ignore_author_order,
+        )
         if not author_result.is_mismatch:
             return None
 
@@ -2265,7 +2274,10 @@ class FactChecker:
         if not api_names:
             return None
         entry_names = self._entry_surname_keys(entry, structured, limit=10_000)
-        author_result = symmetric_author_match(entry_names, api_names, threshold=self.config.author_threshold)
+        author_result = symmetric_author_match(
+            entry_names, api_names, threshold=self.config.author_threshold,
+            ignore_order=self.config.ignore_author_order,
+        )
         if not author_result.is_confirmed:
             # Still not a positive MATCH (genuine different/swapped/placeholder
             # authors, or only a partial confirmation) -> keep AUTHOR_MISMATCH.
@@ -2614,7 +2626,10 @@ class FactChecker:
         entry_authors = entry.get("author", "")
         entry_names = self._entry_surname_keys(entry, record, limit=10_000)
         api_names = record.surname_keys(limit=10_000)
-        author_result = symmetric_author_match(entry_names, api_names, threshold=cfg.author_threshold)
+        author_result = symmetric_author_match(
+            entry_names, api_names, threshold=cfg.author_threshold,
+            ignore_order=getattr(cfg, "ignore_author_order", False),
+        )
         api_authors_str = " and ".join(f"{a.get('given', '')} {a.get('family', '')}".strip() for a in record.authors)
         # Mirror the venue "no claim" rule: if the entry lists no authors there is
         # nothing to confirm (vacuously MATCH). A PARTIAL (consistent-but-
@@ -3286,6 +3301,16 @@ Examples:
         help="Disable year validation (future dates, implausible years)",
     )
     api_opts.add_argument(
+        "--ignore-author-order",
+        action="store_true",
+        help=(
+            "Treat an author list as confirmed when the author SET matches, "
+            "ignoring order. Off by default: APIs return as-published order, so "
+            "a differing order usually signals a real citation error. Enabling "
+            "this also stops detecting same-authors-reordered hallucinations."
+        ),
+    )
+    api_opts.add_argument(
         "--workers",
         type=int,
         default=8,
@@ -3452,6 +3477,7 @@ def main() -> int:
         venue_threshold=args.venue_threshold,
         check_dois=not args.no_check_dois,
         check_years=not args.no_check_years,
+        ignore_author_order=args.ignore_author_order,
         top_k=top_k,
         openalex_mailto=args.openalex_mailto,
     )

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -270,8 +270,12 @@ class FactCheckerConfig:
     # as pointing to a *different* paper. Deliberately low so only clear
     # different-paper cases trip it, not minor preprint/published title edits.
     arxiv_consistency_min_title: float = 0.50
-    # CheckIfExist additions (Item 1 + 2): explicit cascading + top-K retrieval
-    cascade_mode: bool = False
+    # CheckIfExist additions (Item 1 + 2): explicit cascading + top-K retrieval.
+    # Default on: the cascade (CrossRef -> OpenAlex -> S2) short-circuits on a
+    # high-confidence match, so the slow keyless-S2 / specialist sources stay
+    # off the hot path for easy entries. Set False to fall back to the legacy
+    # parallel CrossRef+DBLP+S2 fan-out (queries every source on every entry).
+    cascade_mode: bool = True
     top_k: int = DEFAULT_TOP_K
     cascade_low_confidence: float = CASCADE_LOW_CONFIDENCE
     cascade_high_confidence: float = CASCADE_HIGH_CONFIDENCE
@@ -1945,12 +1949,18 @@ class FactChecker:
         sources_with_hits: list[str],
         errors: list[str],
     ) -> list[tuple[float, PublishedRecord, str]]:
-        """Cascading source order: CrossRef -> Semantic Scholar -> OpenAlex.
+        """Cascading source order: CrossRef -> OpenAlex -> Semantic Scholar.
 
         Item 1 (CheckIfExist Algorithm 1, Abbonato 2026). Each step retrieves
         ``config.top_k`` candidates and re-ranks them by Levenshtein title
         similarity (Item 2). The cascade short-circuits as soon as a source
         returns a candidate at or above ``cascade_high_confidence``.
+
+        Order rationale (throughput): the fast, broad sources come first so the
+        slow specialist is only reached on hard entries. OpenAlex runs on the
+        polite pool (~100 req/min) and aggregates Crossref + others; a keyless
+        Semantic Scholar is throttled to ~10 req/min, so querying it last keeps
+        it off the hot path for the easy majority of entries.
 
         Returns:
             List of ``(score, record, source_name)`` tuples, possibly from
@@ -1991,7 +2001,39 @@ class FactChecker:
         if best_cr >= self.config.cascade_high_confidence:
             return all_candidates
 
-        # ----- Step 2: Semantic Scholar (preprint coverage) -----
+        # ----- Step 2: OpenAlex (high-rate aggregator, broad coverage) -----
+        best_oa = 0.0
+        if self.openalex is None:
+            # Lazily build a default OpenAlex client, reusing the shared HTTP
+            # client reachable through the Crossref client. Without a shared
+            # client we skip OpenAlex rather than fabricate a bare, unthrottled
+            # connection -- this keeps tests hermetic and avoids impolite
+            # off-pool traffic.
+            shared_http = getattr(self.crossref, "http", None)
+            if shared_http is not None:
+                self.openalex = OpenAlexClient(
+                    http=shared_http,
+                    mailto=self.config.openalex_mailto,
+                )
+        if self.openalex is not None:
+            sources_queried.append("openalex")
+            try:
+                oa_items = self.openalex.search(query, limit=top_k)
+            except Exception as exc:
+                oa_items = []
+                errors.append(f"OpenAlex: {exc}")
+            oa_records: list[PublishedRecord] = []
+            for item in oa_items or []:
+                rec = openalex_work_to_candidate_record(item)
+                if rec:
+                    oa_records.append(rec)
+            if oa_records:
+                sources_with_hits.append("openalex")
+            best_oa = _ingest("openalex", oa_records)
+            if max(best_cr, best_oa) >= self.config.cascade_high_confidence:
+                return all_candidates
+
+        # ----- Step 3: Semantic Scholar (preprint coverage; slowest w/o key) -----
         sources_queried.append("semanticscholar")
         try:
             s2_data = self.s2.search(query, limit=top_k)
@@ -2005,34 +2047,7 @@ class FactChecker:
                 s2_records.append(rec)
         if s2_records:
             sources_with_hits.append("semanticscholar")
-        best_s2 = _ingest("semanticscholar", s2_records)
-        best_so_far = max(best_cr, best_s2)
-        if best_so_far >= self.config.cascade_high_confidence:
-            return all_candidates
-
-        # ----- Step 3: OpenAlex (aggregator catch-all) -----
-        if self.openalex is None:
-            # Lazily build a default OpenAlex client; reuses the shared HTTP
-            # client when one is reachable through the Crossref client.
-            shared_http = getattr(self.crossref, "http", None)
-            self.openalex = OpenAlexClient(
-                http=shared_http,
-                mailto=self.config.openalex_mailto,
-            )
-        sources_queried.append("openalex")
-        try:
-            oa_items = self.openalex.search(query, limit=top_k)
-        except Exception as exc:
-            oa_items = []
-            errors.append(f"OpenAlex: {exc}")
-        oa_records: list[PublishedRecord] = []
-        for item in oa_items or []:
-            rec = openalex_work_to_candidate_record(item)
-            if rec:
-                oa_records.append(rec)
-        if oa_records:
-            sources_with_hits.append("openalex")
-        _ingest("openalex", oa_records)
+        _ingest("semanticscholar", s2_records)
         return all_candidates
 
     def _score_candidate(self, title_norm: str, authors_ref: list[str], rec: PublishedRecord) -> float:
@@ -2797,9 +2812,13 @@ Examples:
     # CheckIfExist additions
     cascade_opts = p.add_argument_group("cascading source order (CheckIfExist)")
     cascade_opts.add_argument(
-        "--cascade",
+        "--no-cascade",
         action="store_true",
-        help="Use explicit CrossRef -> Semantic Scholar -> OpenAlex cascade (Item 1).",
+        help=(
+            "Disable the default CrossRef -> OpenAlex -> Semantic Scholar cascade "
+            "and use the legacy parallel CrossRef+DBLP+S2 fan-out (queries every "
+            "source on every entry; slower under rate limits)."
+        ),
     )
     cascade_opts.add_argument(
         "--top-k",
@@ -2908,7 +2927,7 @@ def main() -> int:
         venue_threshold=args.venue_threshold,
         check_dois=not args.no_check_dois,
         check_years=not args.no_check_years,
-        cascade_mode=bool(args.cascade),
+        cascade_mode=not args.no_cascade,
         top_k=top_k,
         openalex_mailto=args.openalex_mailto,
     )

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -329,12 +329,6 @@ class FactCheckerConfig:
 
     title_threshold: float = 0.90
     author_threshold: float = 0.80
-    # Opt-in (default off): treat an author list as confirmed when the author
-    # SET matches, ignoring order. APIs return as-published order reliably, so a
-    # differing order usually signals a real citation error and is flagged by
-    # default; enable this only if author order is not a defect for your use case
-    # (note: it trades away detection of same-authors-reordered hallucinations).
-    ignore_author_order: bool = False
     year_tolerance: int = 1
     venue_threshold: float = 0.70
     hallucination_max_score: float = 0.50
@@ -2015,10 +2009,7 @@ class FactChecker:
         # Nothing comparable on either side -> cannot refute (FPR-safe).
         if not entry_names or not api_names:
             return None
-        author_result = symmetric_author_match(
-            entry_names, api_names, threshold=self.config.author_threshold,
-            ignore_order=self.config.ignore_author_order,
-        )
+        author_result = symmetric_author_match(entry_names, api_names, threshold=self.config.author_threshold)
         if not author_result.is_mismatch:
             return None
 
@@ -2274,10 +2265,7 @@ class FactChecker:
         if not api_names:
             return None
         entry_names = self._entry_surname_keys(entry, structured, limit=10_000)
-        author_result = symmetric_author_match(
-            entry_names, api_names, threshold=self.config.author_threshold,
-            ignore_order=self.config.ignore_author_order,
-        )
+        author_result = symmetric_author_match(entry_names, api_names, threshold=self.config.author_threshold)
         if not author_result.is_confirmed:
             # Still not a positive MATCH (genuine different/swapped/placeholder
             # authors, or only a partial confirmation) -> keep AUTHOR_MISMATCH.
@@ -2626,10 +2614,7 @@ class FactChecker:
         entry_authors = entry.get("author", "")
         entry_names = self._entry_surname_keys(entry, record, limit=10_000)
         api_names = record.surname_keys(limit=10_000)
-        author_result = symmetric_author_match(
-            entry_names, api_names, threshold=cfg.author_threshold,
-            ignore_order=getattr(cfg, "ignore_author_order", False),
-        )
+        author_result = symmetric_author_match(entry_names, api_names, threshold=cfg.author_threshold)
         api_authors_str = " and ".join(f"{a.get('given', '')} {a.get('family', '')}".strip() for a in record.authors)
         # Mirror the venue "no claim" rule: if the entry lists no authors there is
         # nothing to confirm (vacuously MATCH). A PARTIAL (consistent-but-
@@ -3301,16 +3286,6 @@ Examples:
         help="Disable year validation (future dates, implausible years)",
     )
     api_opts.add_argument(
-        "--ignore-author-order",
-        action="store_true",
-        help=(
-            "Treat an author list as confirmed when the author SET matches, "
-            "ignoring order. Off by default: APIs return as-published order, so "
-            "a differing order usually signals a real citation error. Enabling "
-            "this also stops detecting same-authors-reordered hallucinations."
-        ),
-    )
-    api_opts.add_argument(
         "--workers",
         type=int,
         default=8,
@@ -3477,7 +3452,6 @@ def main() -> int:
         venue_threshold=args.venue_threshold,
         check_dois=not args.no_check_dois,
         check_years=not args.no_check_years,
-        ignore_author_order=args.ignore_author_order,
         top_k=top_k,
         openalex_mailto=args.openalex_mailto,
     )

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -1967,6 +1967,68 @@ class FactChecker:
                     return bare
         return None
 
+    def _id_anchored_author_mismatch(
+        self,
+        entry: dict[str, Any],
+        rec: PublishedRecord,
+        source: str,
+        identifier: str,
+        id_kind: str,
+    ) -> FactCheckResult | None:
+        """Flag an ID-resolved record whose title matches but authors are wrong.
+
+        The caller has already confirmed that ``rec`` IS the cited paper (its
+        title matches the entry). This catches the residual case where a
+        hallucinated citation carries a *correct* DOI/arXiv-ID resolving to the
+        exact real paper, but lists SWAPPED or PLACEHOLDER authors.
+
+        Both author sides are reduced to canonical surname keys with the same
+        machinery used everywhere else -- the entry via ``authors_last_names``
+        and the resolved record via ``PublishedRecord.surname_keys`` (both route
+        each name through ``last_name_from_person``) -- then compared with
+        ``symmetric_author_match``.
+
+        FPR-safe gating: a flag fires ONLY on a genuine ``MISMATCH`` (different
+        lead author / transposition / placeholder authors). ``MATCH`` (correct
+        authors), ``PARTIAL`` (consistent-but-incomplete, e.g. "and others"),
+        and ``NON_COMPARABLE`` (missing authors on either side) all return
+        ``None`` so valid citations are never touched.
+        """
+        entry_names = authors_last_names(entry.get("author", ""), limit=10_000)
+        api_names = rec.surname_keys(limit=10_000)
+        # Nothing comparable on either side -> cannot refute (FPR-safe).
+        if not entry_names or not api_names:
+            return None
+        author_result = symmetric_author_match(entry_names, api_names, threshold=self.config.author_threshold)
+        if not author_result.is_mismatch:
+            return None
+
+        self.logger.warning(
+            "%s %s for entry %r resolves to the cited paper but with mismatched "
+            "authors: entry authors %r vs %s authors %r",
+            id_kind,
+            identifier,
+            entry.get("ID", "?"),
+            entry.get("author", ""),
+            source,
+            api_names,
+        )
+        return FactCheckResult(
+            entry_key=entry.get("ID", "unknown"),
+            entry_type=entry.get("ENTRYTYPE", "misc").lower(),
+            status=FactCheckStatus.AUTHOR_MISMATCH,
+            overall_confidence=0.0,
+            field_comparisons=self._compare_all_fields(entry, rec),
+            best_match=rec,
+            api_sources_queried=[source],
+            api_sources_with_hits=[source],
+            errors=[
+                f"{id_kind} {identifier} resolves to the cited paper "
+                f"{rec.title!r}, but the entry's authors do not match the "
+                f"record's authors ({api_names})"
+            ],
+        )
+
     def _check_arxiv_id_consistency(self, entry: dict[str, Any]) -> FactCheckResult | None:
         """Flag entries whose cited arXiv ID resolves to a *different* paper.
 
@@ -2000,7 +2062,13 @@ class FactChecker:
         arxiv_title = normalize_title_for_match(rec.title)
         title_score = token_sort_ratio(entry_title, arxiv_title) / 100.0
         if title_score >= self.config.arxiv_consistency_min_title:
-            return None
+            # Title confirms this IS the cited paper. The arXiv ID is the entry's
+            # OWN identifier, so a genuine author mismatch here is positive
+            # evidence of ID-anchored author fabrication (swapped/placeholder
+            # authors on an otherwise-correct preprint).
+            return self._id_anchored_author_mismatch(
+                entry, rec, source="arxiv", identifier=arxiv_id, id_kind="arXiv ID"
+            )
 
         self.logger.warning(
             "arXiv ID %s for entry %r points to a different paper: entry title "
@@ -2067,7 +2135,13 @@ class FactChecker:
         doi_title = normalize_title_for_match(rec.title)
         title_score = token_sort_ratio(entry_title, doi_title) / 100.0
         if title_score >= self.config.doi_consistency_min_title:
-            return None
+            # Title confirms this IS the cited paper. The DOI is the entry's OWN
+            # identifier, so a genuine author mismatch here is positive evidence
+            # of ID-anchored author fabrication (swapped/placeholder authors on
+            # an entry that otherwise carries the correct DOI).
+            return self._id_anchored_author_mismatch(
+                entry, rec, source="crossref", identifier=raw_doi, id_kind="DOI"
+            )
 
         self.logger.warning(
             "DOI %s for entry %r points to a different paper: entry title "

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -81,6 +81,7 @@ from bibtex_updater.utils import (
     authors_last_names,
     crossref_message_to_record,
     dblp_hit_to_candidate_record,
+    entry_surnames_against_structured,
     first_author_surname,
     is_valid_arxiv_id,
     # Matching
@@ -1859,6 +1860,23 @@ class FactChecker:
         field_comparisons = self._compare_all_fields(entry, best_match)
         status = self._determine_status(best_score, field_comparisons, sources_with_hits)
 
+        # FPR guard (Task 2b): an AUTHOR_MISMATCH driven by a candidate from a
+        # source WITHOUT authoritative given/family names (S2 flat names, a DBLP
+        # hit, an OpenAlex display_name) may be a NAME-PARSING artifact rather
+        # than a real author discrepancy. Before trusting it, re-check the SAME
+        # paper against a STRUCTURED source (Crossref by DOI, else Crossref title
+        # search). If the structured comparison MATCHES, the mismatch was a parse
+        # artifact -> recompute the comparison/status against the structured
+        # record. If it still mismatches (or no structured source is reachable),
+        # the AUTHOR_MISMATCH stands. This only changes WHICH surname tokens are
+        # compared; it never relaxes ordering or the match threshold.
+        if status is FactCheckStatus.AUTHOR_MISMATCH and not best_match.structured_names:
+            structured_rec = self._structured_author_recheck(entry, best_match)
+            if structured_rec is not None:
+                best_match = structured_rec
+                field_comparisons = self._compare_all_fields(entry, best_match)
+                status = self._determine_status(best_score, field_comparisons, sources_with_hits)
+
         # Post-match: check preprint status. UNCONFIRMED is included because a
         # venue we could not confirm is exactly the case where an independent
         # preprint-only signal (arXiv-only, no DOI/venue) upgrades the verdict to
@@ -1986,7 +2004,7 @@ class FactChecker:
         and ``NON_COMPARABLE`` (missing authors on either side) all return
         ``None`` so valid citations are never touched.
         """
-        entry_names = authors_last_names(entry.get("author", ""), limit=10_000)
+        entry_names = self._entry_surname_keys(entry, rec, limit=10_000)
         api_names = rec.surname_keys(limit=10_000)
         # Nothing comparable on either side -> cannot refute (FPR-safe).
         if not entry_names or not api_names:
@@ -2113,14 +2131,8 @@ class FactChecker:
         if not entry_title:
             return None
 
-        try:
-            msg = self.crossref.get_by_doi(raw_doi)
-        except Exception:
-            return None
+        rec = self._structured_record_by_doi(raw_doi)
         # Cannot determine -> do NOT flag (keeps FPR low).
-        if msg is None:
-            return None
-        rec = crossref_message_to_record(msg)
         if rec is None or not rec.title:
             return None
 
@@ -2158,6 +2170,116 @@ class FactChecker:
                 f"match entry title {entry.get('title', '')!r}"
             ],
         )
+
+    def _structured_record_by_doi(self, raw_doi: str) -> PublishedRecord | None:
+        """Fetch the Crossref ``message`` for ``raw_doi`` as a structured record.
+
+        Shared by ``_check_doi_consistency`` (DOI-target consistency) and
+        ``_structured_author_recheck`` (Task 2b name-parse FPR guard) so the
+        ``get_by_doi`` round-trip is never duplicated. Crossref returns
+        authoritative ``given``/``family`` fields, so the resulting record has
+        ``structured_names=True``. Returns ``None`` on any non-200 / parse / no
+        DOI so callers treat "cannot determine" as no evidence (FPR-safe).
+        """
+        if not raw_doi:
+            return None
+        try:
+            msg = self.crossref.get_by_doi(raw_doi)
+        except Exception:
+            return None
+        if msg is None:
+            return None
+        return crossref_message_to_record(msg)
+
+    def _structured_author_recheck(
+        self, entry: dict[str, Any], best_match: PublishedRecord
+    ) -> PublishedRecord | None:
+        """Re-fetch the cited paper from a STRUCTURED source to vet an AUTHOR_MISMATCH.
+
+        Called only when the candidate that produced an AUTHOR_MISMATCH came from
+        a source WITHOUT authoritative given/family names (``best_match`` has
+        ``structured_names`` False). A family-first CJK name flattened by such a
+        source can be mis-tokenized (entry "Chen Xing" vs a flat "Xing Chen"
+        record), so the mismatch may be a parsing artifact rather than a real
+        author discrepancy.
+
+        Strategy (reuses existing fetch paths, no duplicate work):
+          1. If the entry carries a DOI, fetch the structured Crossref record via
+             the shared ``_structured_record_by_doi`` (same call
+             ``_check_doi_consistency`` uses).
+          2. Otherwise, if the entry has a confident title, run a fielded
+             Crossref title+author search and take the single best
+             title-matching hit.
+
+        The returned structured record is handed back ONLY when (a) its title
+        confirms it is the cited paper and (b) the author comparison against its
+        authoritative given/family names is a positive MATCH. In every other
+        case (no structured source reachable, title doesn't confirm, or authors
+        STILL mismatch) we return ``None`` so the original AUTHOR_MISMATCH stands.
+        This narrows surname tokenization only; it never relaxes author ordering
+        or the match threshold.
+        """
+        entry_title = normalize_title_for_match(entry.get("title", ""))
+        if not authors_last_names(entry.get("author", ""), limit=10_000):
+            return None
+
+        # ----- Path 1: DOI present -> authoritative Crossref record. -----
+        raw_doi = entry.get("doi", "") or ""
+        structured: PublishedRecord | None = None
+        if raw_doi:
+            rec = self._structured_record_by_doi(raw_doi)
+            if rec is not None and rec.structured_names and rec.title and entry_title:
+                doi_title = normalize_title_for_match(rec.title)
+                if token_sort_ratio(entry_title, doi_title) / 100.0 >= self.config.doi_consistency_min_title:
+                    structured = rec
+
+        # ----- Path 2: no usable DOI hit -> confident-title Crossref search. -----
+        if structured is None and entry_title:
+            raw_title = entry.get("title", "") or ""
+            first_author = first_author_surname(entry)
+            try:
+                items = self.crossref.search(raw_title, rows=5, title=raw_title, author=first_author)
+            except Exception:
+                items = []
+            best_struct: PublishedRecord | None = None
+            best_title_score = 0.0
+            for item in items or []:
+                rec = crossref_message_to_record(item)
+                if rec is None or not rec.structured_names or not rec.title:
+                    continue
+                ts = token_sort_ratio(entry_title, normalize_title_for_match(rec.title)) / 100.0
+                if ts > best_title_score:
+                    best_title_score, best_struct = ts, rec
+            # Require a CONFIDENT title to be sure we re-checked the same paper.
+            if best_struct is not None and best_title_score >= self.config.title_threshold:
+                structured = best_struct
+
+        if structured is None:
+            return None
+
+        # Re-run the author comparison against authoritative given/family keys.
+        # Same matcher, same threshold, same ordering rules -- only the surname
+        # tokens are now trustworthy. The entry side is disambiguated against the
+        # structured family set (resolving family-first CJK names).
+        api_names = structured.surname_keys(limit=10_000)
+        if not api_names:
+            return None
+        entry_names = self._entry_surname_keys(entry, structured, limit=10_000)
+        author_result = symmetric_author_match(entry_names, api_names, threshold=self.config.author_threshold)
+        if not author_result.is_confirmed:
+            # Still not a positive MATCH (genuine different/swapped/placeholder
+            # authors, or only a partial confirmation) -> keep AUTHOR_MISMATCH.
+            return None
+
+        self.logger.debug(
+            "Author mismatch for entry %r suppressed: structured Crossref record "
+            "confirms authors %r match entry %r (was mis-tokenized by an "
+            "unstructured source)",
+            entry.get("ID", "?"),
+            api_names,
+            entry_names,
+        )
+        return structured
 
     def _query_arxiv_by_id(
         self,
@@ -2440,6 +2562,24 @@ class FactChecker:
 
         return False
 
+    @staticmethod
+    def _entry_surname_keys(entry: dict[str, Any], record: PublishedRecord, limit: int = 10_000) -> list[str]:
+        """Entry surname keys to compare against ``record``.
+
+        When ``record`` has AUTHORITATIVE given/family names (Crossref), use the
+        record's family set to disambiguate order-ambiguous comma-less entry
+        names (family-first CJK names): ``entry_surnames_against_structured``
+        picks the entry token that matches a known family. Otherwise the record
+        cannot disambiguate anything, so use the plain ``authors_last_names``
+        heuristic. Either way each entry author maps to one surname at its own
+        position -- ordering/first-author checks downstream are untouched.
+        """
+        if record.structured_names:
+            family_keys = set(record.surname_keys(limit=limit))
+            if family_keys:
+                return entry_surnames_against_structured(entry.get("author", ""), family_keys, limit=limit)
+        return authors_last_names(entry.get("author", ""), limit=limit)
+
     def _compare_all_fields(self, entry: dict[str, Any], record: PublishedRecord) -> dict[str, FieldComparison]:
         """Compare all relevant fields between entry and record."""
         comparisons: dict[str, FieldComparison] = {}
@@ -2472,7 +2612,7 @@ class FactChecker:
         # correctly cited paper that lists fewer authors (or "and others") scored
         # below threshold purely from the length asymmetry.
         entry_authors = entry.get("author", "")
-        entry_names = authors_last_names(entry_authors, limit=10_000)
+        entry_names = self._entry_surname_keys(entry, record, limit=10_000)
         api_names = record.surname_keys(limit=10_000)
         author_result = symmetric_author_match(entry_names, api_names, threshold=cfg.author_threshold)
         api_authors_str = " and ".join(f"{a.get('given', '')} {a.get('family', '')}".strip() for a in record.authors)

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -224,6 +224,25 @@ class FactCheckStatus(Enum):
     SKIPPED = "skipped"  # Entry type not verifiable
 
 
+# Fix B: statuses that mean "could not verify" (abstention) rather than
+# "positive evidence of a problem". These are NOT hallucinations -- the tool
+# simply failed to locate a matching record. Kept module-level so the JSONL
+# writer and the summary buckets stay in sync.
+ABSTAINED_STATUS_VALUES = frozenset(
+    {
+        FactCheckStatus.NOT_FOUND.value,
+        FactCheckStatus.BOOK_NOT_FOUND.value,
+        FactCheckStatus.WORKING_PAPER_NOT_FOUND.value,
+        FactCheckStatus.URL_NOT_FOUND.value,
+    }
+)
+
+
+def _is_abstained_status(status: FactCheckStatus) -> bool:
+    """True when ``status`` is an abstention (could-not-verify), not a problem."""
+    return status.value in ABSTAINED_STATUS_VALUES
+
+
 @dataclass
 class FieldComparison:
     """Result of comparing a single field between entry and API record."""
@@ -264,6 +283,13 @@ class FactCheckerConfig:
     year_tolerance: int = 1
     venue_threshold: float = 0.70
     hallucination_max_score: float = 0.50
+    # Fix B (abstention): when the best title-search candidate scores below this,
+    # the tool could not find the real paper -- it has *no* positive evidence of
+    # fabrication. Such cases ABSTAIN (NOT_FOUND) instead of asserting
+    # HALLUCINATED. Reserve HALLUCINATED for positive-evidence signals
+    # (fabricated DOI, future/invalid year, arXiv-ID misattribution, chimeric
+    # title) that fire *before* the score gate.
+    abstention_below: float = 0.50
     max_candidates_per_source: int = 10
     check_years: bool = True
     check_dois: bool = True
@@ -2350,9 +2376,31 @@ class FactChecker:
         """Determine final status from score and comparisons.
 
         P2.6: Venue mismatch is prioritized when title+author match.
+
+        Fix B (abstention): a weak best candidate means the title search returned
+        an *unrelated* paper -- the tool simply could not find the real one. That
+        is "I couldn't verify this", NOT "this is fabricated", so we ABSTAIN with
+        NOT_FOUND rather than asserting HALLUCINATED. This sits AFTER the
+        positive-evidence checks in ``check_entry`` (``_validate_year``,
+        ``_validate_doi``, ``_check_arxiv_id_consistency``, ``_detect_chimeric_title``),
+        each of which ``return``s before ``_determine_status`` is ever reached --
+        so abstention can never suppress a true HALLUCINATED verdict backed by
+        positive evidence.
         """
-        if best_score < self.config.hallucination_max_score:
-            return FactCheckStatus.HALLUCINATED
+        # Wrong-paper signature: the best match is too weak to trust. Either the
+        # blended score is below the abstention threshold, or the title itself is
+        # essentially unrelated (very low title score) AND neither title nor
+        # author corroborate the entry. In both cases there is no positive
+        # evidence of fabrication, only a failed lookup -> abstain.
+        title_cmp = comparisons.get("title")
+        author_cmp = comparisons.get("author")
+        title_score = title_cmp.similarity_score if title_cmp else 0.0
+        title_ok = bool(title_cmp and title_cmp.matches)
+        author_ok = bool(author_cmp and author_cmp.matches)
+        wrong_paper_signature = title_score < 0.30 and not title_ok and not author_ok
+
+        if best_score < self.config.abstention_below or wrong_paper_signature:
+            return FactCheckStatus.NOT_FOUND
 
         mismatches = [name for name, c in comparisons.items() if not c.matches]
 
@@ -2607,6 +2655,10 @@ class FactCheckProcessor:
                                 "key": result.entry_key,
                                 "category": result.category.value if result.category else None,
                                 "status": result.status.value,
+                                # Fix B: distinct flag so abstentions ("could not
+                                # verify") are unambiguously identifiable and never
+                                # read as confirmed hallucinations downstream.
+                                "abstained": _is_abstained_status(result.status),
                                 "confidence": result.overall_confidence,
                                 # Additive: 0-100 numeric confidence (Item 4).
                                 "confidence_score": float(getattr(result, "confidence_score", 0.0)),
@@ -2661,27 +2713,32 @@ class FactCheckProcessor:
                 if not c.matches:
                     field_mismatches[name] = field_mismatches.get(name, 0) + 1
 
-        # Include new problematic statuses
+        # Three buckets (Fix B). ABSTAINED ("could not verify") is reported
+        # separately from PROBLEMATIC ("positive evidence of a problem"): a
+        # not-found / uncertain entry is the tool failing to locate a record, NOT
+        # evidence of fabrication, so it must never read as a confirmed
+        # hallucination.
+        abstained_statuses = sorted(ABSTAINED_STATUS_VALUES)
+        # Positive-evidence problems only. (not_found / *_not_found moved to the
+        # abstained bucket above.)
         problematic_statuses = [
-            "not_found",
             "hallucinated",
             "title_mismatch",
             "author_mismatch",
             "year_mismatch",
             "venue_mismatch",
-            "url_not_found",
             "url_content_mismatch",
-            "book_not_found",
-            "working_paper_not_found",
             "future_date",
             "invalid_year",
             "doi_not_found",
+            "arxiv_id_mismatch",
             "preprint_only",
         ]
 
         # Calculate verified rate including new verified statuses
         verified_statuses = ["verified", "url_verified", "url_accessible", "book_verified", "working_paper_verified"]
         verified_count = sum(counts.get(s, 0) for s in verified_statuses)
+        abstained_count = sum(counts.get(s, 0) for s in abstained_statuses)
 
         return {
             "total": len(results),
@@ -2689,6 +2746,10 @@ class FactCheckProcessor:
             "by_category": category_counts,
             "field_mismatch_counts": field_mismatches,
             "verified_rate": verified_count / len(results) if results else 0,
+            "verified_count": verified_count,
+            # Distinct "could not verify" bucket -- abstentions, not hallucinations.
+            "could_not_verify_rate": abstained_count / len(results) if results else 0,
+            "abstained_count": abstained_count,
             "problematic_count": sum(counts.get(s, 0) for s in problematic_statuses),
         }
 
@@ -2764,6 +2825,8 @@ class FactCheckProcessor:
                         "key": r.entry_key,
                         "category": r.category.value if r.category else None,
                         "status": r.status.value,
+                        # Fix B: distinct abstention flag (see process_entries).
+                        "abstained": _is_abstained_status(r.status),
                         "confidence": r.overall_confidence,
                         # Additive: 0-100 numeric confidence (Item 4).
                         "confidence_score": float(getattr(r, "confidence_score", 0.0)),
@@ -3111,9 +3174,39 @@ def main() -> int:
         if count > 0:
             logger.info("  %s: %d", status.upper(), count)
 
+    # Three clearly distinct buckets (Fix B): VERIFIED, COULD NOT VERIFY
+    # (abstained -- no matching record found, NOT evidence of fabrication), and
+    # PROBLEMATIC (positive evidence of a problem). "Could not verify" must never
+    # be lumped in with either "verified" or "hallucinated".
+    total = summary["total"]
+    verified_n = summary.get("verified_count", 0)
+    abstained_n = summary.get("abstained_count", 0)
+    problematic_n = summary.get("problematic_count", 0)
+    logger.info("Results by bucket:")
+    logger.info(
+        "  (1) VERIFIED:            %d  (%.1f%%)",
+        verified_n,
+        summary["verified_rate"] * 100,
+    )
+    logger.info(
+        "  (2) COULD NOT VERIFY:    %d  (%.1f%%)  -- no matching record found; not evidence of fabrication",
+        abstained_n,
+        summary["could_not_verify_rate"] * 100,
+    )
+    logger.info(
+        "  (3) PROBLEMATIC:         %d  (%.1f%%)  -- positive evidence of a problem",
+        problematic_n,
+        (problematic_n / total * 100) if total else 0.0,
+    )
     logger.info("Verified rate: %.1f%%", summary["verified_rate"] * 100)
-    if summary["problematic_count"] > 0:
-        logger.warning("Problematic entries: %d", summary["problematic_count"])
+    logger.info("Could-not-verify rate: %.1f%%", summary["could_not_verify_rate"] * 100)
+    if problematic_n > 0:
+        logger.warning("Problematic entries (positive evidence): %d", problematic_n)
+    if abstained_n > 0:
+        logger.info(
+            "Could-not-verify entries (abstained, no matching record found): %d",
+            abstained_n,
+        )
 
     # Item 4: numeric confidence summary in the text report.
     numeric_scores = [float(getattr(r, "confidence_score", 0.0)) for r in results]
@@ -3139,9 +3232,17 @@ def main() -> int:
 
     # Exit code
     if args.strict:
-        problem_count = summary["status_counts"].get("not_found", 0) + summary["status_counts"].get("hallucinated", 0)
+        # Fix B: only POSITIVE-evidence problems gate the exit code. Abstentions
+        # (could-not-verify) are reported on their own line and do NOT count as
+        # confirmed hallucinations, so they no longer fail strict mode.
+        problem_count = summary["problematic_count"]
+        if abstained_n > 0:
+            logger.info(
+                "Strict mode: %d could-not-verify entries (abstained; not counted as failures)",
+                abstained_n,
+            )
         if problem_count > 0:
-            logger.warning("Strict mode: %d NOT_FOUND or HALLUCINATED entries found", problem_count)
+            logger.warning("Strict mode: %d PROBLEMATIC entries (positive evidence of a problem)", problem_count)
             return 4
 
     return 0

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -81,7 +81,6 @@ from bibtex_updater.utils import (
     authors_last_names,
     crossref_message_to_record,
     dblp_hit_to_candidate_record,
-    dblp_hit_to_record,
     first_author_surname,
     is_valid_arxiv_id,
     # Matching
@@ -359,12 +358,10 @@ class FactCheckerConfig:
     # treated as a *different* paper. Deliberately low (mirrors arXiv) so only
     # clear different-paper cases trip it.
     doi_consistency_min_title: float = 0.50
-    # CheckIfExist additions (Item 1 + 2): explicit cascading + top-K retrieval.
-    # Default on: the cascade (CrossRef -> OpenAlex -> S2) short-circuits on a
-    # high-confidence match, so the slow keyless-S2 / specialist sources stay
-    # off the hot path for easy entries. Set False to fall back to the legacy
-    # parallel CrossRef+DBLP+S2 fan-out (queries every source on every entry).
-    cascade_mode: bool = True
+    # CheckIfExist additions (Item 1 + 2): cascading + top-K retrieval.
+    # Verification uses the CrossRef -> OpenAlex -> DBLP -> Semantic Scholar
+    # cascade, which short-circuits on a high-confidence match so the slow
+    # keyless-S2 / specialist sources stay off the hot path for easy entries.
     top_k: int = DEFAULT_TOP_K
     cascade_low_confidence: float = CASCADE_LOW_CONFIDENCE
     cascade_high_confidence: float = CASCADE_HIGH_CONFIDENCE
@@ -1625,9 +1622,7 @@ class FactChecker:
         # and tests that don't need preprint verification keep working.
         self.arxiv: ArxivClient | None = arxiv
         # OpenAlex client is optional; tests can pass a fake. The cascade falls
-        # back to creating a default client if not provided but only when
-        # cascade_mode is on -- otherwise legacy parallel-search keeps current
-        # CrossRef/DBLP/S2 behavior.
+        # back to creating a default client if not provided.
         self.openalex: OpenAlexClient | None = openalex
         # The most recent cross-source author intersection (set by check_entry).
         self.last_author_intersection: AuthorIntersectionResult | None = None
@@ -1804,11 +1799,8 @@ class FactChecker:
                 return doi_consistency_status
 
         query = f"{title_norm} {first_author}".strip()
-        # Item 1: explicit cascade vs. legacy parallel search.
-        if self.config.cascade_mode:
-            candidates = self._query_cascade(entry, query, sources_queried, sources_with_hits, errors)
-        else:
-            candidates = self._query_all_sources(entry, query, sources_queried, sources_with_hits, errors)
+        # Item 1: cascading source order (CrossRef -> OpenAlex -> DBLP -> S2).
+        candidates = self._query_cascade(entry, query, sources_queried, sources_with_hits, errors)
 
         # Authoritative arXiv-by-ID lookup. Added as an extra candidate so valid
         # but not-yet-indexed preprints verify instead of being flagged
@@ -2200,106 +2192,6 @@ class FactChecker:
         authors_ref = authors_last_names(entry.get("author", ""), limit=3)
         score = self._score_candidate(title_norm, authors_ref, rec)
         return [(score, rec, "arxiv")]
-
-    def _query_all_sources(
-        self,
-        entry: dict[str, Any],
-        query: str,
-        sources_queried: list[str],
-        sources_with_hits: list[str],
-        errors: list[str],
-    ) -> list[tuple[float, PublishedRecord, str]]:
-        """Query all API sources and collect scored candidates (parallel version with early exit).
-
-        P2.1: Early-exit optimization - if any source returns a very high-confidence match (>= 0.95),
-        cancel remaining searches.
-        """
-        candidates: list[tuple[float, PublishedRecord, str]] = []
-        title_norm = normalize_title_for_match(entry.get("title", ""))
-        authors_ref = authors_last_names(entry.get("author", ""), limit=3)
-
-        HIGH_CONFIDENCE_THRESHOLD = 0.95
-
-        def _search_crossref() -> tuple[str, list[tuple[float, PublishedRecord, str]], bool, str | None]:
-            """Search Crossref API."""
-            local_candidates = []
-            had_hits = False
-            error = None
-            try:
-                items = self.crossref.search(query, rows=self.config.max_candidates_per_source)
-                if items:
-                    had_hits = True
-                    for item in items:
-                        rec = crossref_message_to_record(item)
-                        if rec:
-                            score = self._score_candidate(title_norm, authors_ref, rec)
-                            local_candidates.append((score, rec, "crossref"))
-            except Exception as e:
-                error = f"Crossref: {e}"
-            return ("crossref", local_candidates, had_hits, error)
-
-        def _search_dblp() -> tuple[str, list[tuple[float, PublishedRecord, str]], bool, str | None]:
-            """Search DBLP API."""
-            local_candidates = []
-            had_hits = False
-            error = None
-            try:
-                hits = self.dblp.search(query, max_hits=self.config.max_candidates_per_source)
-                if hits:
-                    had_hits = True
-                    for hit in hits:
-                        rec = dblp_hit_to_record(hit)
-                        if rec:
-                            score = self._score_candidate(title_norm, authors_ref, rec)
-                            local_candidates.append((score, rec, "dblp"))
-            except Exception as e:
-                error = f"DBLP: {e}"
-            return ("dblp", local_candidates, had_hits, error)
-
-        def _search_s2() -> tuple[str, list[tuple[float, PublishedRecord, str]], bool, str | None]:
-            """Search Semantic Scholar API."""
-            local_candidates = []
-            had_hits = False
-            error = None
-            try:
-                data = self.s2.search(query, limit=self.config.max_candidates_per_source)
-                if data:
-                    had_hits = True
-                    for item in data:
-                        rec = s2_data_to_record(item)
-                        if rec:
-                            score = self._score_candidate(title_norm, authors_ref, rec)
-                            local_candidates.append((score, rec, "semanticscholar"))
-            except Exception as e:
-                error = f"Semantic Scholar: {e}"
-            return ("semanticscholar", local_candidates, had_hits, error)
-
-        # P2.1: Execute searches in parallel with early exit on high-confidence match
-        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
-            futures = {
-                executor.submit(_search_crossref): "crossref",
-                executor.submit(_search_dblp): "dblp",
-                executor.submit(_search_s2): "s2",
-            }
-
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    source, cands, had_hits, error = future.result()
-                    sources_queried.append(source)
-                    candidates.extend(cands)
-                    if had_hits:
-                        sources_with_hits.append(source)
-                    if error:
-                        errors.append(error)
-
-                    # Note: With max_workers=3 and 3 tasks, all start immediately.
-                    # The break skips processing remaining future results but doesn't stop running tasks.
-                    if any(score >= HIGH_CONFIDENCE_THRESHOLD for score, _, _ in cands):
-                        break
-                except Exception:
-                    pass  # Errors already captured in individual search functions
-
-        return candidates
 
     def _query_cascade(
         self,
@@ -3314,15 +3206,6 @@ Examples:
     # CheckIfExist additions
     cascade_opts = p.add_argument_group("cascading source order (CheckIfExist)")
     cascade_opts.add_argument(
-        "--no-cascade",
-        action="store_true",
-        help=(
-            "Disable the default CrossRef -> OpenAlex -> Semantic Scholar cascade "
-            "and use the legacy parallel CrossRef+DBLP+S2 fan-out (queries every "
-            "source on every entry; slower under rate limits)."
-        ),
-    )
-    cascade_opts.add_argument(
         "--top-k",
         type=int,
         default=DEFAULT_TOP_K,
@@ -3429,7 +3312,6 @@ def main() -> int:
         venue_threshold=args.venue_threshold,
         check_dois=not args.no_check_dois,
         check_years=not args.no_check_years,
-        cascade_mode=not args.no_cascade,
         top_k=top_k,
         openalex_mailto=args.openalex_mailto,
     )

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -206,6 +206,7 @@ class FactCheckStatus(Enum):
     HALLUCINATED = "hallucinated"
     API_ERROR = "api_error"
     ARXIV_ID_MISMATCH = "arxiv_id_mismatch"  # Entry's cited arXiv ID resolves to a different paper
+    DOI_MISMATCH = "doi_mismatch"  # Entry's cited DOI resolves to a different paper
 
     # Pre-API validation statuses
     FUTURE_DATE = "future_date"  # Year is in the future
@@ -348,6 +349,16 @@ class FactCheckerConfig:
     # as pointing to a *different* paper. Deliberately low so only clear
     # different-paper cases trip it, not minor preprint/published title edits.
     arxiv_consistency_min_title: float = 0.50
+    # Verify the entry's own DOI points to the entry's paper. Today _validate_doi
+    # only checks the DOI *resolves* (doi.org HEAD); it never checks the DOI
+    # points to the CITED paper. A copy-paste DOI that resolves to a different
+    # work otherwise survives because title/author search VERIFIES the entry
+    # against its real record.
+    check_doi_consistency: bool = True
+    # Below this normalized title score (0-1), the DOI's Crossref record is
+    # treated as a *different* paper. Deliberately low (mirrors arXiv) so only
+    # clear different-paper cases trip it.
+    doi_consistency_min_title: float = 0.50
     # CheckIfExist additions (Item 1 + 2): explicit cascading + top-K retrieval.
     # Default on: the cascade (CrossRef -> OpenAlex -> S2) short-circuits on a
     # high-confidence match, so the slow keyless-S2 / specialist sources stay
@@ -1314,6 +1325,28 @@ class CrossrefClient:
         except Exception:
             return []
 
+    def get_by_doi(self, doi: str) -> dict[str, Any] | None:
+        """Fetch the Crossref ``message`` record a DOI resolves to.
+
+        Uses the Crossref REST ``/works/{doi}`` endpoint for reliable metadata
+        (unlike a doi.org HEAD, which only tells you the DOI resolves). Returns
+        ``None`` on any non-200 / parse failure / network error so callers can
+        treat "cannot determine" as no evidence (FPR-safe), never a flag.
+        """
+        from urllib.parse import quote
+
+        doi = normalize_doi_for_resolution(doi) or (doi or "").strip()
+        if not doi:
+            return None
+        url = f"{CROSSREF_API}/{quote(doi, safe='')}"
+        try:
+            resp = self.http._request("GET", url, accept="application/json", service="crossref")
+            if resp.status_code != 200:
+                return None
+            return resp.json().get("message", {}) or None
+        except Exception:
+            return None
+
 
 class DBLPClient:
     """DBLP API client for computer science publications."""
@@ -1762,6 +1795,14 @@ class FactChecker:
             if arxiv_status is not None:
                 return arxiv_status
 
+        # Pre-search consistency: the entry's own DOI must point to *this* paper.
+        # A copy-paste DOI that resolves to a different work otherwise survives
+        # because title/author search VERIFIES the entry against its real record.
+        if self.config.check_doi_consistency:
+            doi_consistency_status = self._check_doi_consistency(entry)
+            if doi_consistency_status is not None:
+                return doi_consistency_status
+
         query = f"{title_norm} {first_author}".strip()
         # Item 1: explicit cascade vs. legacy parallel search.
         if self.config.cascade_mode:
@@ -1981,6 +2022,73 @@ class FactChecker:
             api_sources_with_hits=["arxiv"],
             errors=[
                 f"arXiv ID {arxiv_id} resolves to {rec.title!r}, which does not "
+                f"match entry title {entry.get('title', '')!r}"
+            ],
+        )
+
+    def _check_doi_consistency(self, entry: dict[str, Any]) -> FactCheckResult | None:
+        """Flag entries whose cited DOI resolves to a *different* paper.
+
+        ``_validate_doi`` only checks that the DOI *resolves* (doi.org HEAD); it
+        never checks that the DOI points to the CITED paper. Title/author search
+        then happily VERIFIES a misattributed entry against its real record, so a
+        copy-paste DOI (e.g. "IBRNet" carrying the DOI of a 3D-detection paper)
+        survives unnoticed. Here we fetch the DOI's Crossref record and require
+        its title to match the entry; a clear mismatch is reported as
+        :class:`FactCheckStatus.DOI_MISMATCH`.
+
+        FPR-safe: returns ``None`` (no flag) when there is nothing to check (no
+        DOI, feature off) OR the determination is uncertain (Crossref fetch
+        failed / non-200 / no record / no title -- e.g. IEEE bot-block or a DOI
+        Crossref doesn't index). Only a SUCCESSFULLY fetched record whose title
+        CLEARLY differs (score below ``doi_consistency_min_title``) trips it.
+        """
+        if not self.config.check_doi_consistency:
+            return None
+        raw_doi = entry.get("doi", "")
+        if not raw_doi:
+            return None
+
+        entry_title = normalize_title_for_match(entry.get("title", ""))
+        if not entry_title:
+            return None
+
+        try:
+            msg = self.crossref.get_by_doi(raw_doi)
+        except Exception:
+            return None
+        # Cannot determine -> do NOT flag (keeps FPR low).
+        if msg is None:
+            return None
+        rec = crossref_message_to_record(msg)
+        if rec is None or not rec.title:
+            return None
+
+        doi_title = normalize_title_for_match(rec.title)
+        title_score = token_sort_ratio(entry_title, doi_title) / 100.0
+        if title_score >= self.config.doi_consistency_min_title:
+            return None
+
+        self.logger.warning(
+            "DOI %s for entry %r points to a different paper: entry title "
+            "%r vs DOI title %r (title score %.2f)",
+            raw_doi,
+            entry.get("ID", "?"),
+            entry.get("title", ""),
+            rec.title,
+            title_score,
+        )
+        return FactCheckResult(
+            entry_key=entry.get("ID", "unknown"),
+            entry_type=entry.get("ENTRYTYPE", "misc").lower(),
+            status=FactCheckStatus.DOI_MISMATCH,
+            overall_confidence=0.0,
+            field_comparisons={},
+            best_match=rec,
+            api_sources_queried=["crossref"],
+            api_sources_with_hits=["crossref"],
+            errors=[
+                f"DOI {raw_doi} resolves to {rec.title!r}, which does not "
                 f"match entry title {entry.get('title', '')!r}"
             ],
         )
@@ -2878,6 +2986,7 @@ class FactCheckProcessor:
             "invalid_year",
             "doi_not_found",
             "arxiv_id_mismatch",
+            "doi_mismatch",
             "preprint_only",
         ]
 

--- a/src/bibtex_updater/matching.py
+++ b/src/bibtex_updater/matching.py
@@ -332,11 +332,18 @@ EXPANDED_VENUE_ALIASES: dict[str, set[str]] = {
         "neural information processing systems",
         "conference on neural information processing systems",
         "annual conference on neural information processing systems",
+        # Numbered proceedings, e.g. "The 36th Conference on Neural ..." -- the
+        # ordinal/year is stripped during normalization, leaving these forms.
+        "th conference on neural information processing systems",
+        "th annual conference on neural information processing systems",
     },
     "icml": {
         "international conference on machine learning",
         "proceedings of the international conference on machine learning",
+        # "Proceedings of the Nth International Conference on Machine Learning":
+        # the ordinal year is removed by normalization, leaving "th ...".
         "proceedings of the th international conference on machine learning",
+        "th international conference on machine learning",
     },
     "iclr": {
         "international conference on learning representations",
@@ -344,34 +351,84 @@ EXPANDED_VENUE_ALIASES: dict[str, set[str]] = {
     },
     "aaai": {
         "association for the advancement of artificial intelligence",
+        "aaai conference on artificial intelligence",
         "proceedings of the aaai conference on artificial intelligence",
     },
     "cvpr": {
         "computer vision and pattern recognition",
         "ieee conference on computer vision and pattern recognition",
         "ieee/cvf conference on computer vision and pattern recognition",
+        "conference on computer vision and pattern recognition",
     },
     "iccv": {
         "international conference on computer vision",
         "ieee international conference on computer vision",
         "ieee/cvf international conference on computer vision",
     },
-    "eccv": {"european conference on computer vision"},
+    "eccv": {
+        "european conference on computer vision",
+    },
     "acl": {
         "association for computational linguistics",
         "annual meeting of the association for computational linguistics",
+        # Findings track of ACL -- a distinct track of the SAME venue.
+        "findings of acl",
+        "findings of the association for computational linguistics: acl",
     },
     "emnlp": {
         "empirical methods in natural language processing",
         "conference on empirical methods in natural language processing",
+        # Findings track of EMNLP. The exact-match pass resolves these before
+        # the substring fallback would otherwise collapse them into "acl".
+        "findings of emnlp",
+        "findings of the association for computational linguistics: emnlp",
     },
-    "naacl": {"north american chapter of the association for computational linguistics"},
-    "kdd": {"knowledge discovery and data mining"},
-    "ijcai": {"international joint conference on artificial intelligence"},
-    "uai": {"uncertainty in artificial intelligence"},
-    "aistats": {"artificial intelligence and statistics"},
-    "jmlr": {"journal of machine learning research"},
-    "tmlr": {"transactions on machine learning research"},
+    "naacl": {
+        "north american chapter of the association for computational linguistics",
+        "annual conference of the north american chapter of the association for computational linguistics",
+        "naacl-hlt",
+        "naacl hlt",
+        "findings of naacl",
+        "findings of the association for computational linguistics: naacl",
+    },
+    "kdd": {
+        "knowledge discovery and data mining",
+        "sigkdd",
+        "acm sigkdd",
+        "acm sigkdd conference on knowledge discovery and data mining",
+        "acm sigkdd international conference on knowledge discovery and data mining",
+    },
+    "ijcai": {
+        "international joint conference on artificial intelligence",
+    },
+    "uai": {
+        "uncertainty in artificial intelligence",
+        "conference on uncertainty in artificial intelligence",
+    },
+    "aistats": {
+        "artificial intelligence and statistics",
+        "international conference on artificial intelligence and statistics",
+    },
+    "colt": {
+        "conference on learning theory",
+        "annual conference on learning theory",
+        "annual conference on computational learning theory",
+    },
+    "interspeech": {
+        "conference of the international speech communication association",
+        "annual conference of the international speech communication association",
+    },
+    "icassp": {
+        "international conference on acoustics, speech and signal processing",
+        "ieee international conference on acoustics, speech and signal processing",
+        "ieee international conference on acoustics, speech, and signal processing",
+    },
+    "jmlr": {
+        "journal of machine learning research",
+    },
+    "tmlr": {
+        "transactions on machine learning research",
+    },
     # Systems/DB (new)
     "sigmod": {
         "acm sigmod",
@@ -406,10 +463,12 @@ EXPANDED_VENUE_ALIASES: dict[str, set[str]] = {
     },
     "www": {
         "the web conference",
+        "thewebconf",
         "world wide web",
         "international world wide web conference",
         "international conference on world wide web",
         "proceedings of the web conference",
+        "acm web conference",
     },
     "wsdm": {
         "web search and data mining",
@@ -453,6 +512,9 @@ EXPANDED_VENUE_ALIASES: dict[str, set[str]] = {
     "eacl": {
         "european chapter of the association for computational linguistics",
         "proceedings of the european chapter of the association for computational linguistics",
+        "conference of the european chapter of the association for computational linguistics",
+        "findings of eacl",
+        "findings of the association for computational linguistics: eacl",
     },
     "conll": {
         "conference on computational natural language learning",
@@ -539,13 +601,24 @@ def get_canonical_venue(venue: str, aliases: dict[str, set[str]] | None = None) 
     if not venue_norm:
         return None
 
+    # Pass 1: exact equality against every canonical key and alias, including
+    # short acronyms (len <= 3). This must run before any substring matching so
+    # that a bare acronym ("ACL", "KDD", "UAI") maps to its own canonical venue
+    # instead of substring-colliding with a *different* acronym that merely
+    # contains it ("acl" is a substring of "naacl"). Exact match is always safe.
+    for canonical, alias_set in aliases.items():
+        if venue_norm == canonical or venue_norm in alias_set:
+            return canonical
+
+    # Pass 2: substring matching for spelled-out / decorated forms. Skip names
+    # <= 3 chars here: short acronyms are substrings of longer venue names and of
+    # each other, so substring-matching them produces false collisions (handled
+    # exactly by Pass 1 above).
     for canonical, alias_set in aliases.items():
         all_names = alias_set | {canonical}
         for name in all_names:
             if len(name) <= 3:
                 continue
-            if name == venue_norm:
-                return canonical
             # Generic single-word *journal* names ("nature"/"science") are
             # prefixes of distinct sibling journals ("Nature Physics", "Science
             # Robotics"), so substring matching would wrongly collapse them and

--- a/src/bibtex_updater/matching.py
+++ b/src/bibtex_updater/matching.py
@@ -252,6 +252,7 @@ def symmetric_author_match(
     api_names: list[str],
     threshold: float = 0.80,
     prefix_n: int = 5,
+    ignore_order: bool = False,
 ) -> AuthorMatchResult:
     """Compare entry vs API author surnames on a *symmetric* basis (trichotomy).
 
@@ -284,6 +285,15 @@ def symmetric_author_match(
     # If either side has no usable names, there is nothing to confirm or refute.
     if not a or not b:
         return AuthorMatchResult(MatchOutcome.NON_COMPARABLE, 1.0)
+
+    # Opt-in (off by default): when the author SETS are identical, ignore order
+    # and confirm. Scholarly APIs reliably return as-published author order, so a
+    # differing order normally signals a real citation error and is flagged --
+    # hence this is NOT the default. With it on, only a *set* match confirms, so
+    # a genuinely different/added/missing author (different set) still MISMATCHes;
+    # this trades away swapped-same-authors detection, which is why it is opt-in.
+    if ignore_order and set(a) == set(b):
+        return AuthorMatchResult(MatchOutcome.MATCH, 1.0)
 
     # Hard first-author signal: an outright different lead author is a real
     # mismatch. Both sides are already canonicalized surname keys.

--- a/src/bibtex_updater/matching.py
+++ b/src/bibtex_updater/matching.py
@@ -11,6 +11,8 @@ These functions are standalone and can be used by fact_checker.py or other modul
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from enum import Enum
 
 from rapidfuzz.distance import Levenshtein
 
@@ -22,11 +24,51 @@ __all__ = [
     "word_level_diff",
     "author_sequence_similarity",
     "combined_author_score",
+    "MatchOutcome",
+    "AuthorMatchResult",
     "symmetric_author_match",
     "EXPANDED_VENUE_ALIASES",
     "get_canonical_venue",
     "is_preprint_or_series_venue",
 ]
+
+
+class MatchOutcome(Enum):
+    """Three-valued result of a field comparison.
+
+    The verifier distinguishes positive confirmation from mere absence of
+    contradiction. A field is only allowed to contribute to a VERIFIED verdict
+    when it is CONFIRMED (MATCH); a real contradiction is a MISMATCH; and
+    "I had nothing comparable / could not positively confirm" is NON_COMPARABLE
+    (no data either side) or PARTIAL (consistent-but-incomplete confirmation).
+    """
+
+    MATCH = "match"  # both sides populated and positively agree
+    MISMATCH = "mismatch"  # both sides populated real values that conflict
+    NON_COMPARABLE = "non_comparable"  # empty/blank, or a preprint/series record
+    PARTIAL = "partial"  # consistent but incomplete (e.g. dropped authors)
+
+
+@dataclass(frozen=True)
+class AuthorMatchResult:
+    """Trichotomy result of :func:`symmetric_author_match`.
+
+    ``outcome`` carries the three-valued verdict; ``score`` is the legacy
+    0-1 similarity for confidence/reporting. ``is_confirmed`` is true only for
+    a full positive confirmation (exact match or a leading subset explicitly
+    elided with an "and others"/"et al" sentinel).
+    """
+
+    outcome: MatchOutcome
+    score: float
+
+    @property
+    def is_confirmed(self) -> bool:
+        return self.outcome is MatchOutcome.MATCH
+
+    @property
+    def is_mismatch(self) -> bool:
+        return self.outcome is MatchOutcome.MISMATCH
 
 
 # ------------- P2.2: Near-Miss Title Detection -------------
@@ -182,6 +224,11 @@ def combined_author_score(
 _AUTHOR_SENTINELS: frozenset[str] = frozenset({"others", "et al", "etal", "al"})
 
 
+def _has_author_sentinel(names: list[str]) -> bool:
+    """True if a surname list contains an elision sentinel ("others"/"et al")."""
+    return any(n and n.lower() in _AUTHOR_SENTINELS for n in names)
+
+
 def _strip_author_sentinels(names: list[str]) -> list[str]:
     """Drop "others"/"et al" sentinels from a surname list."""
     return [n for n in names if n and n.lower() not in _AUTHOR_SENTINELS]
@@ -195,55 +242,84 @@ def _is_ordered_subsequence(short: list[str], long: list[str]) -> bool:
     return all(name in it for name in short)
 
 
+def _is_leading_prefix(short: list[str], long: list[str]) -> bool:
+    """True if ``short`` is a contiguous *leading* prefix of ``long``."""
+    return len(short) <= len(long) and short == long[: len(short)]
+
+
 def symmetric_author_match(
     entry_names: list[str],
     api_names: list[str],
     threshold: float = 0.80,
     prefix_n: int = 5,
-) -> tuple[bool, float]:
-    """Compare entry vs API author surnames on a *symmetric* basis.
+) -> AuthorMatchResult:
+    """Compare entry vs API author surnames on a *symmetric* basis (trichotomy).
 
-    The legacy comparison sliced the entry side to a small limit but left the
-    API side effectively unbounded, so a correctly cited paper that lists fewer
-    authors (or elides them with "and others") scored far below threshold purely
-    from the length asymmetry. This restores symmetry:
+    Containment proves the cited authors are *consistent with* the real list, not
+    that the citation is *complete*. We therefore distinguish a full positive
+    confirmation from a consistent-but-incomplete one:
 
-    1. Strip "others"/"et al" sentinels from both sides.
-    2. First-author surname is a HARD signal: a genuinely different first author
-       fails immediately (so a swapped/wrong lead author is still caught).
-    3. ORDERED-CONTAINMENT: if one side's (sentinel-stripped) surnames are an
-       in-order subsequence of the other -- i.e. the citation lists a leading
-       subset of the real author list -- treat it as a match.
-    4. Otherwise score on a symmetric slice: both sides truncated to the same
-       ``min(len, prefix_n)`` length, combining unordered (Jaccard) and ordered
-       (LCS) similarity.
+    1. Strip "others"/"et al" sentinels from both sides (but remember whether a
+       sentinel was present -- it signals a deliberate elision).
+    2. NON_COMPARABLE: either side has no usable surnames -- nothing to confirm
+       or refute.
+    3. MISMATCH: first-author surnames differ (a swapped/wrong lead author).
+    4. MATCH (CONFIRMED): the sentinel-stripped surname lists are EQUAL, OR one
+       side is a *leading prefix* of the other AND the shorter side carried an
+       explicit elision sentinel ("and others"/"et al"). The author claim is then
+       positively confirmed (exactly, or as an explicitly-truncated head).
+    5. PARTIAL: the shorter side is an in-order subsequence (or leading prefix)
+       of the longer WITHOUT a sentinel -- authors are consistent but the claim
+       silently drops interior/trailing authors, so it is not a full confirmation.
+    6. Otherwise score a symmetric slice (Jaccard + LCS): >= threshold is a MATCH,
+       below is a MISMATCH (real conflict beyond the shared lead author).
 
-    Returns ``(matches, score)``.
+    Returns an :class:`AuthorMatchResult` carrying the trichotomy and a 0-1 score.
     """
+    a_has_sentinel = _has_author_sentinel(entry_names)
+    b_has_sentinel = _has_author_sentinel(api_names)
     a = _strip_author_sentinels(entry_names)
     b = _strip_author_sentinels(api_names)
 
-    # If either side has no usable names, treat as non-comparable (neutral pass):
-    # the author field can't refute a match it has no data for.
+    # If either side has no usable names, there is nothing to confirm or refute.
     if not a or not b:
-        return (True, 1.0)
+        return AuthorMatchResult(MatchOutcome.NON_COMPARABLE, 1.0)
 
     # Hard first-author signal: an outright different lead author is a real
-    # mismatch. Both sides are already canonicalized surname keys, so compare by
-    # equality.
+    # mismatch. Both sides are already canonicalized surname keys.
     if a[0] != b[0]:
-        return (False, 0.0)
+        return AuthorMatchResult(MatchOutcome.MISMATCH, 0.0)
 
-    # Ordered-containment: one side's surnames are an in-order subsequence of the
-    # other. This is the common "citation lists first k of n authors" case.
+    # Exact (sentinel-stripped) equality: full positive confirmation.
+    if a == b:
+        return AuthorMatchResult(MatchOutcome.MATCH, 1.0)
+
+    # Leading-prefix containment: one side is a contiguous head of the other.
+    # An explicit elision sentinel on the SHORTER side means the citation
+    # deliberately truncated a leading run ("first k authors, and others") --
+    # that is a confirmation, not a silent drop.
+    if _is_leading_prefix(a, b):  # entry is a head of the (longer) api list
+        if a_has_sentinel:
+            return AuthorMatchResult(MatchOutcome.MATCH, 1.0)
+        return AuthorMatchResult(MatchOutcome.PARTIAL, 1.0)
+    if _is_leading_prefix(b, a):  # api is a head of the (longer) entry list
+        if b_has_sentinel:
+            return AuthorMatchResult(MatchOutcome.MATCH, 1.0)
+        return AuthorMatchResult(MatchOutcome.PARTIAL, 1.0)
+
+    # In-order subsequence (but not a contiguous leading prefix): interior or
+    # trailing authors are dropped. Consistent, never a full confirmation, even
+    # with a sentinel -- the elision is not a simple leading truncation.
     if _is_ordered_subsequence(a, b) or _is_ordered_subsequence(b, a):
-        return (True, 1.0)
+        return AuthorMatchResult(MatchOutcome.PARTIAL, 1.0)
 
     # Symmetric slice + combined (Jaccard + LCS) score.
     n = min(len(a), len(b), prefix_n)
     a_slice, b_slice = a[:n], b[:n]
     score = combined_author_score(a_slice, b_slice, jaccard_weight=0.5, sequence_weight=0.5)
-    return (score >= threshold, score)
+    if score >= threshold:
+        return AuthorMatchResult(MatchOutcome.MATCH, score)
+    return AuthorMatchResult(MatchOutcome.MISMATCH, score)
 
 
 # ------------- P2.5: Expanded Venue Aliases -------------

--- a/src/bibtex_updater/matching.py
+++ b/src/bibtex_updater/matching.py
@@ -252,7 +252,6 @@ def symmetric_author_match(
     api_names: list[str],
     threshold: float = 0.80,
     prefix_n: int = 5,
-    ignore_order: bool = False,
 ) -> AuthorMatchResult:
     """Compare entry vs API author surnames on a *symmetric* basis (trichotomy).
 
@@ -285,15 +284,6 @@ def symmetric_author_match(
     # If either side has no usable names, there is nothing to confirm or refute.
     if not a or not b:
         return AuthorMatchResult(MatchOutcome.NON_COMPARABLE, 1.0)
-
-    # Opt-in (off by default): when the author SETS are identical, ignore order
-    # and confirm. Scholarly APIs reliably return as-published author order, so a
-    # differing order normally signals a real citation error and is flagged --
-    # hence this is NOT the default. With it on, only a *set* match confirms, so
-    # a genuinely different/added/missing author (different set) still MISMATCHes;
-    # this trades away swapped-same-authors detection, which is why it is opt-in.
-    if ignore_order and set(a) == set(b):
-        return AuthorMatchResult(MatchOutcome.MATCH, 1.0)
 
     # Hard first-author signal: an outright different lead author is a real
     # mismatch. Both sides are already canonicalized surname keys.

--- a/src/bibtex_updater/matching.py
+++ b/src/bibtex_updater/matching.py
@@ -22,8 +22,10 @@ __all__ = [
     "word_level_diff",
     "author_sequence_similarity",
     "combined_author_score",
+    "symmetric_author_match",
     "EXPANDED_VENUE_ALIASES",
     "get_canonical_venue",
+    "is_preprint_or_series_venue",
 ]
 
 
@@ -173,6 +175,77 @@ def combined_author_score(
     return jaccard_weight * jaccard_score + sequence_weight * sequence_score
 
 
+#: Sentinel surnames that BibTeX/citation tooling inserts for elided author
+#: lists ("and others" -> "others"; "et al."). They are not real authors and
+#: must be stripped before any author-set comparison, otherwise a correctly
+#: cited paper that uses "and others" is punished for a phantom mismatch.
+_AUTHOR_SENTINELS: frozenset[str] = frozenset({"others", "et al", "etal", "al"})
+
+
+def _strip_author_sentinels(names: list[str]) -> list[str]:
+    """Drop "others"/"et al" sentinels from a surname list."""
+    return [n for n in names if n and n.lower() not in _AUTHOR_SENTINELS]
+
+
+def _is_ordered_subsequence(short: list[str], long: list[str]) -> bool:
+    """True if ``short`` appears in ``long`` in order (not necessarily contiguous)."""
+    if not short:
+        return True
+    it = iter(long)
+    return all(name in it for name in short)
+
+
+def symmetric_author_match(
+    entry_names: list[str],
+    api_names: list[str],
+    threshold: float = 0.80,
+    prefix_n: int = 5,
+) -> tuple[bool, float]:
+    """Compare entry vs API author surnames on a *symmetric* basis.
+
+    The legacy comparison sliced the entry side to a small limit but left the
+    API side effectively unbounded, so a correctly cited paper that lists fewer
+    authors (or elides them with "and others") scored far below threshold purely
+    from the length asymmetry. This restores symmetry:
+
+    1. Strip "others"/"et al" sentinels from both sides.
+    2. First-author surname is a HARD signal: a genuinely different first author
+       fails immediately (so a swapped/wrong lead author is still caught).
+    3. ORDERED-CONTAINMENT: if one side's (sentinel-stripped) surnames are an
+       in-order subsequence of the other -- i.e. the citation lists a leading
+       subset of the real author list -- treat it as a match.
+    4. Otherwise score on a symmetric slice: both sides truncated to the same
+       ``min(len, prefix_n)`` length, combining unordered (Jaccard) and ordered
+       (LCS) similarity.
+
+    Returns ``(matches, score)``.
+    """
+    a = _strip_author_sentinels(entry_names)
+    b = _strip_author_sentinels(api_names)
+
+    # If either side has no usable names, treat as non-comparable (neutral pass):
+    # the author field can't refute a match it has no data for.
+    if not a or not b:
+        return (True, 1.0)
+
+    # Hard first-author signal: an outright different lead author is a real
+    # mismatch. Both sides are already canonicalized surname keys, so compare by
+    # equality.
+    if a[0] != b[0]:
+        return (False, 0.0)
+
+    # Ordered-containment: one side's surnames are an in-order subsequence of the
+    # other. This is the common "citation lists first k of n authors" case.
+    if _is_ordered_subsequence(a, b) or _is_ordered_subsequence(b, a):
+        return (True, 1.0)
+
+    # Symmetric slice + combined (Jaccard + LCS) score.
+    n = min(len(a), len(b), prefix_n)
+    a_slice, b_slice = a[:n], b[:n]
+    score = combined_author_score(a_slice, b_slice, jaccard_weight=0.5, sequence_weight=0.5)
+    return (score >= threshold, score)
+
+
 # ------------- P2.5: Expanded Venue Aliases -------------
 
 EXPANDED_VENUE_ALIASES: dict[str, set[str]] = {
@@ -181,12 +254,18 @@ EXPANDED_VENUE_ALIASES: dict[str, set[str]] = {
         "nips",
         "advances in neural information processing systems",
         "neural information processing systems",
+        "conference on neural information processing systems",
+        "annual conference on neural information processing systems",
     },
     "icml": {
         "international conference on machine learning",
         "proceedings of the international conference on machine learning",
+        "proceedings of the th international conference on machine learning",
     },
-    "iclr": {"international conference on learning representations"},
+    "iclr": {
+        "international conference on learning representations",
+        "proceedings of the international conference on learning representations",
+    },
     "aaai": {
         "association for the advancement of artificial intelligence",
         "proceedings of the aaai conference on artificial intelligence",
@@ -408,3 +487,49 @@ def get_canonical_venue(venue: str, aliases: dict[str, set[str]] | None = None) 
                 return canonical
 
     return None
+
+
+#: Substrings that mark a venue as a preprint server or a publisher *series*
+#: rather than a specific published venue. An arXiv-indexed record often carries
+#: a blank or preprint venue while the entry cites the real conference, so a
+#: preprint venue on EITHER side must never produce a hard mismatch. "PMLR" /
+#: "proceedings of machine learning research" is the umbrella series for many
+#: distinct conferences (ICML, AISTATS, CoRL, ...), so it cannot pin a single
+#: venue and is likewise treated as non-comparable.
+#: Preprint-server markers, matched as substrings of the lowercased raw venue.
+_PREPRINT_SERVER_MARKERS: tuple[str, ...] = (
+    "arxiv",
+    "biorxiv",
+    "medrxiv",
+    "chemrxiv",
+    "preprint",
+    "corr",  # arXiv's "Computing Research Repository" DBLP label
+)
+
+#: Publisher-*series* markers (matched against the lowercased raw venue). These
+#: name an umbrella series that spans many distinct conferences, so they cannot
+#: pin a single venue. Matched on the RAW venue (not the prefix-stripped form)
+#: so "Proceedings of Machine Learning Research" (PMLR) is caught while the
+#: distinct journal "Journal of Machine Learning Research" (JMLR) is NOT.
+_SERIES_MARKERS: tuple[str, ...] = (
+    "proceedings of machine learning research",
+    "pmlr",
+    "jmlr workshop and conference proceedings",
+    "w&cp",
+)
+
+
+def is_preprint_or_series_venue(venue: str) -> bool:
+    """True if ``venue`` names a preprint server or non-specific publisher series.
+
+    Such venues (arXiv/CoRR, bioRxiv, "Proceedings of Machine Learning Research",
+    PMLR/JMLR W&CP) cannot pin a single published venue, so a venue comparison
+    against them is *non-comparable* rather than a mismatch. The distinct journal
+    "Journal of Machine Learning Research" (JMLR) is deliberately NOT matched.
+    """
+    if not venue:
+        return False
+    raw = venue.lower().strip()
+    if not raw:
+        return False
+    return any(m in raw for m in _PREPRINT_SERVER_MARKERS) or any(m in raw for m in _SERIES_MARKERS)

--- a/src/bibtex_updater/sources.py
+++ b/src/bibtex_updater/sources.py
@@ -29,7 +29,9 @@ from rapidfuzz.fuzz import token_sort_ratio
 
 from bibtex_updater.utils import (
     OPENALEX_API,
+    OPENREVIEW_API,
     PublishedRecord,
+    last_name_from_person,
     normalize_title_for_match,
     strip_diacritics,
 )
@@ -37,6 +39,9 @@ from bibtex_updater.utils import (
 __all__ = [
     "OpenAlexClient",
     "openalex_work_to_candidate_record",
+    "OpenReviewClient",
+    "openreview_note_to_candidate_record",
+    "build_openreview_paperhash",
     "select_top_k_by_title_similarity",
     "cross_source_author_intersection",
     "AuthorIntersectionResult",
@@ -219,6 +224,225 @@ def openalex_work_to_candidate_record(work: dict[str, Any]) -> PublishedRecord |
         journal=journal,
         year=year,
         type=work_type,
+    )
+
+
+# ------------- OpenReview client -------------
+
+
+#: OpenReview "tilde" profile-id pattern, e.g. ``~Diederik_P_Kingma1`` or
+#: ``~Aidan_N._Gomez1`` (a middle initial may carry a trailing period). The
+#: family name is the underscore token immediately before the trailing digits.
+_OPENREVIEW_TILDE_ID = re.compile(r"^~([A-Za-z][\w.]*?)(\d+)$")
+
+
+def _content_value(content: dict[str, Any], key: str) -> Any:
+    """Read an OpenReview note ``content`` field across API v1/v2 shapes.
+
+    API v2 wraps every field as ``{"value": <v>}``; API v1 stores the bare
+    value. This returns the inner value either way (or ``None`` if absent).
+    """
+    raw = content.get(key)
+    if isinstance(raw, dict) and "value" in raw:
+        return raw.get("value")
+    return raw
+
+
+def build_openreview_paperhash(title: str, first_author_last_name: str) -> str | None:
+    """Construct OpenReview's ``paperhash`` exact-match key for a paper.
+
+    OpenReview indexes every note under ``<firstauthor_lastname>|<title>`` where
+    the title is lowercased, stripped of all non-alphanumeric characters (colons,
+    hyphens, apostrophes are *removed*, not spaced -- "Few-Shot" -> "fewshot",
+    "BERT:" -> "bert"), whitespace-collapsed, and spaces become underscores. The
+    author prefix is the first author's last name, lowercased + diacritics-free.
+    Verified live against the Kingma/He/Vaswani/Devlin/Brown/Ho papers.
+
+    Returns ``None`` when either component is empty (an un-hashable entry).
+    """
+    last = strip_diacritics(first_author_last_name or "").lower().strip()
+    last = re.sub(r"[^a-z0-9]", "", last)
+    norm_title = strip_diacritics(title or "").lower()
+    norm_title = re.sub(r"[^a-z0-9\s]", "", norm_title)
+    norm_title = "_".join(norm_title.split())
+    if not last or not norm_title:
+        return None
+    return f"{last}|{norm_title}"
+
+
+class OpenReviewClient:
+    """Minimal OpenReview lookup client (legacy ``api.openreview.net``).
+
+    OpenReview is the authoritative submission registry for ICLR, NeurIPS, TMLR
+    and many other ML venues, which the rest of the cascade (CrossRef/OpenAlex/
+    DBLP/S2) frequently fails to *positively* confirm. The legacy ``/notes``
+    endpoint exposes a ``paperhash`` filter that does an exact title + first-author
+    match -- far more precise than the full-text ``term=``/``query=`` search,
+    which returns reviews and unrelated public articles. ``content.authors`` is a
+    flat name list, but ``content.authorids`` carries ``~Given_Family<N>`` profile
+    handles from which an authoritative family name is recoverable.
+
+    Mirrors :class:`OpenAlexClient`: optional shared ``http`` (rate limiting +
+    caching via ``service="openreview"``), bare ``httpx`` fallback for hermetic
+    use, and ``[]`` on any error / non-200.
+    """
+
+    def __init__(self, http: Any | None = None, timeout: float = 20.0) -> None:
+        self.http = http
+        self.timeout = timeout
+
+    def search(
+        self,
+        query: str,
+        limit: int = DEFAULT_TOP_K,
+        title: str | None = None,
+        first_author: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Look up OpenReview notes by exact ``paperhash`` (title + first author).
+
+        Args:
+            query: Free-text blob (unused by the paperhash path; accepted for a
+                signature symmetric with the other cascade clients).
+            limit: Max notes to retrieve (capped at ``MAX_TOP_K``).
+            title: Raw paper title. Required to build the ``paperhash``.
+            first_author: First author's *last* name (already reduced). Required
+                to build the ``paperhash``; without it no lookup is possible.
+
+        Returns:
+            List of OpenReview note dicts (never ``None``). Empty on any error,
+            on a missing title/author, or when nothing matches.
+        """
+        per_page = max(1, min(int(limit), MAX_TOP_K))
+        paperhash = build_openreview_paperhash(title or "", first_author or "")
+        if not paperhash:
+            return []
+        params = {"paperhash": paperhash, "limit": per_page}
+        return self._fetch(params)
+
+    def _fetch(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        """Issue a single OpenReview ``/notes`` request, return the note list.
+
+        Preserves shared-HttpClient-vs-bare-httpx routing (rate limiting + caching
+        on the shared path). Returns ``[]`` on any non-200 status or exception.
+        """
+        url = f"{OPENREVIEW_API}/notes"
+        try:
+            if self.http is not None and hasattr(self.http, "_request"):
+                resp = self.http._request(
+                    "GET",
+                    url,
+                    params=params,
+                    accept="application/json",
+                    service="openreview",
+                )
+                if resp.status_code != 200:
+                    return []
+                data = resp.json() or {}
+            else:
+                with httpx.Client(timeout=self.timeout) as client:
+                    resp = client.get(url, params=params)
+                    if resp.status_code != 200:
+                        return []
+                    data = resp.json() or {}
+        except Exception:
+            return []
+        notes = data.get("notes") or []
+        if not isinstance(notes, list):
+            return []
+        return notes
+
+
+def _family_from_tilde_id(authorid: str) -> str | None:
+    """Recover an authoritative family name from a ``~Given_Family<N>`` handle.
+
+    OpenReview profile ids encode the name as underscore-separated tokens with a
+    trailing disambiguation digit, e.g. ``~Diederik_P_Kingma1`` -> ``Kingma``,
+    ``~Aidan_N._Gomez1`` -> ``Gomez``. Non-tilde ids (raw emails, DBLP-search
+    URLs) yield ``None`` so the caller can fall back to the flat display name.
+    """
+    if not authorid or not authorid.startswith("~"):
+        return None
+    m = _OPENREVIEW_TILDE_ID.match(authorid)
+    if not m:
+        return None
+    tokens = [t for t in m.group(1).split("_") if t]
+    if not tokens:
+        return None
+    return tokens[-1]
+
+
+def openreview_note_to_candidate_record(note: dict[str, Any]) -> PublishedRecord | None:
+    """Convert an OpenReview note to a ``PublishedRecord`` for cascade scoring.
+
+    Authors come from the flat ``content.authors`` list; whenever the parallel
+    ``content.authorids`` entry is a ``~Given_Family<N>`` profile handle we lift
+    the AUTHORITATIVE family name out of it and set ``structured_names=True`` so
+    ``surname_keys`` trusts the family verbatim. If *any* author lacks a usable
+    tilde id we leave ``structured_names=False`` and the synthesized last-token
+    family is used (and the verdict logic stays conservative). The venue is taken
+    from ``content.venue`` (falling back to ``content.venueid``).
+
+    Returns ``None`` if the note has no usable title.
+    """
+    if not note:
+        return None
+    content = note.get("content") or {}
+    if not isinstance(content, dict):
+        return None
+
+    title = _content_value(content, "title")
+    if not title or not str(title).strip():
+        return None
+    title = re.sub(r"<[^>]*>", "", str(title)).strip()
+
+    raw_authors = _content_value(content, "authors") or []
+    raw_authorids = _content_value(content, "authorids") or []
+    if not isinstance(raw_authors, list):
+        raw_authors = []
+    if not isinstance(raw_authorids, list):
+        raw_authorids = []
+
+    authors: list[dict[str, str]] = []
+    all_structured = bool(raw_authors)
+    for idx, full_name in enumerate(raw_authors):
+        if not isinstance(full_name, str) or not full_name.strip():
+            continue
+        authorid = raw_authorids[idx] if idx < len(raw_authorids) else ""
+        family = _family_from_tilde_id(authorid if isinstance(authorid, str) else "")
+        if family:
+            parts = full_name.strip().split()
+            given = " ".join(parts[:-1]) if len(parts) > 1 else ""
+            authors.append({"given": given, "family": family})
+        else:
+            # No authoritative handle: synthesize a family via the same last-token
+            # heuristic the entry side uses, and mark the record unstructured.
+            all_structured = False
+            family = last_name_from_person(full_name)
+            parts = full_name.strip().split()
+            given = " ".join(parts[:-1]) if len(parts) > 1 else ""
+            authors.append({"given": given, "family": family})
+
+    if not authors:
+        all_structured = False
+
+    venue = _content_value(content, "venue") or _content_value(content, "venueid")
+
+    year = None
+    raw_year = _content_value(content, "year")
+    try:
+        if raw_year is not None:
+            year = int(str(raw_year)[:4])
+    except (ValueError, TypeError):
+        year = None
+
+    return PublishedRecord(
+        doi=None,
+        title=title,
+        authors=authors,
+        journal=venue,
+        year=year,
+        type="conference",
+        structured_names=all_structured,
     )
 
 

--- a/src/bibtex_updater/sources.py
+++ b/src/bibtex_updater/sources.py
@@ -89,28 +89,61 @@ class OpenAlexClient:
         self.mailto = mailto
         self.timeout = timeout
 
-    def search(self, query: str, limit: int = DEFAULT_TOP_K) -> list[dict[str, Any]]:
+    def search(
+        self,
+        query: str,
+        limit: int = DEFAULT_TOP_K,
+        title: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Search OpenAlex works.
 
         Args:
             query: Free-text search string (typically ``"<title> <author>"``).
+                Used for the ``?search=`` fallback path.
             limit: Max records to retrieve (capped at ``MAX_TOP_K``).
+            title: Raw (un-normalized, author-free) title. When provided, the
+                client first issues a *fielded* ``filter=title.search:<title>``
+                query, which matches the exact paper at rank #1 far more often
+                than the BM25 ``?search=`` relevance endpoint -- the latter
+                returns unrelated papers for DOI-less ML-conference titles.
+                The free-text ``?search=`` path is used only as a fallback when
+                the fielded query yields zero results.
 
         Returns:
             List of OpenAlex work dicts, never None. Empty on any error.
         """
+        per_page = max(1, min(int(limit), MAX_TOP_K))
+
+        # ----- Fielded title.search path (preferred) -----
+        if title and title.strip():
+            fielded_params = {
+                "filter": f"title.search:{title.strip()}",
+                "per-page": per_page,
+                "mailto": self.mailto,
+            }
+            fielded = self._fetch(fielded_params)
+            if fielded:
+                return fielded
+            # Zero fielded results -> fall through to free-text below.
+
+        # ----- Free-text ?search= path (fallback / legacy) -----
         if not query:
             return []
-        per_page = max(1, min(int(limit), MAX_TOP_K))
         params = {
             "search": query,
             "per-page": per_page,
             "mailto": self.mailto,
         }
-        url = f"{OPENALEX_API}/works"
+        return self._fetch(params)
 
-        # Prefer the shared HttpClient if available -- it carries rate limiting,
-        # caching, and the polite User-Agent. Fall back to bare httpx otherwise.
+    def _fetch(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        """Issue a single OpenAlex /works request and return the result list.
+
+        Preserves the shared-HttpClient-vs-bare-httpx routing (rate limiting,
+        caching, polite User-Agent on the shared path; hermetic fallback
+        otherwise). Returns ``[]`` on any non-200 status or exception.
+        """
+        url = f"{OPENALEX_API}/works"
         try:
             if self.http is not None and hasattr(self.http, "_request"):
                 resp = self.http._request(

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -100,9 +100,24 @@ def safe_lower(x: str | None) -> str:
 # This only equates variant spellings of one name; it never merges distinct names.
 _NONDECOMPOSING_FOLD = str.maketrans(
     {
-        "ß": "ss", "ẞ": "ss", "ø": "o", "Ø": "O", "đ": "d", "Đ": "D",
-        "ł": "l", "Ł": "L", "æ": "ae", "Æ": "AE", "œ": "oe", "Œ": "OE",
-        "ð": "d", "Ð": "D", "þ": "th", "Þ": "TH", "ı": "i", "ŧ": "t",
+        "ß": "ss",
+        "ẞ": "ss",
+        "ø": "o",
+        "Ø": "O",
+        "đ": "d",
+        "Đ": "D",
+        "ł": "l",
+        "Ł": "L",
+        "æ": "ae",
+        "Æ": "AE",
+        "œ": "oe",
+        "Œ": "OE",
+        "ð": "d",
+        "Ð": "D",
+        "þ": "th",
+        "Þ": "TH",
+        "ı": "i",
+        "ŧ": "t",
     }
 )
 
@@ -254,9 +269,7 @@ def _name_tokens(name: str) -> list[str]:
     return [t for t in name.split() if t and len(t) > 1 and not re.fullmatch(r"\d{4}", t)]
 
 
-def entry_surnames_against_structured(
-    author_field: str, family_keys: set[str], limit: int = 3
-) -> list[str]:
+def entry_surnames_against_structured(author_field: str, family_keys: set[str], limit: int = 3) -> list[str]:
     """Entry surname keys, disambiguated by an AUTHORITATIVE family-name set.
 
     The comma-less entry name "Chen Xing" is order-ambiguous: ``last_name_from_person``

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -1260,6 +1260,93 @@ def dblp_hit_to_record(hit: dict[str, Any]) -> PublishedRecord | None:
     )
 
 
+def dblp_hit_to_candidate_record(hit: dict[str, Any]) -> PublishedRecord | None:
+    """Permissive DBLP hit -> ``PublishedRecord`` for cascade candidate search.
+
+    Unlike :func:`dblp_hit_to_record` (which is preprint-strict for
+    publication-*resolution*: it drops hits lacking a DOI/``ee`` URL, lacking a
+    venue/year, or labelled with an arXiv/CoRR venue), this converter is built
+    for the fact-checker *cascade*, which only needs candidates to *score*
+    against. DBLP authoritatively indexes ICML/ICLR/NeurIPS papers that are
+    frequently DOI-less, so we keep any hit with a clear title + authors and we
+    retain the arXiv/CoRR copy rather than discarding it outright.
+
+    Args:
+        hit: A DBLP search ``hit`` dict (``{"info": {...}}``).
+
+    Returns:
+        ``PublishedRecord`` or ``None`` if the hit lacks a usable title or any
+        author.
+    """
+    if not hit:
+        return None
+    info = hit.get("info", {}) or {}
+    title = info.get("title") or ""
+    title = re.sub(r"<[^>]*>", "", title).strip()  # strip HTML tags
+    if not title:
+        return None
+
+    # Parse authors (same logic as dblp_hit_to_record, including the 4-digit
+    # homonym-disambiguation-suffix stripping).
+    authors_field = info.get("authors", {}).get("author")
+    authors_list: list[str] = []
+    if isinstance(authors_field, list):
+        for a in authors_field:
+            if isinstance(a, dict):
+                authors_list.append(a.get("text") or a.get("name") or "")
+            elif isinstance(a, str):
+                authors_list.append(a)
+    elif isinstance(authors_field, dict):
+        authors_list.append(authors_field.get("text") or authors_field.get("name") or "")
+
+    authors: list[dict[str, str]] = []
+    for full in authors_list:
+        full = full.strip()
+        if not full:
+            continue
+        parts = full.split()
+        if len(parts) >= 2 and re.fullmatch(r"\d{4}", parts[-1]):
+            parts = parts[:-1]
+        if len(parts) >= 2:
+            authors.append({"given": " ".join(parts[:-1]), "family": parts[-1]})
+        else:
+            authors.append({"given": "", "family": parts[0]})
+
+    if not authors:
+        return None
+
+    venue = info.get("journal") or info.get("venue")
+    year = None
+    try:
+        year = int(info.get("year")) if info.get("year") else None
+    except Exception:
+        pass
+
+    doi = doi_normalize(info.get("doi"))
+    ee = info.get("ee")
+    venue_lower = safe_lower(venue) if venue else ""
+    typ = safe_lower(info.get("type"))
+    is_conference = (
+        "conference" in typ
+        or "proceedings" in typ
+        or re.search(r"proceedings|conference|workshop|symposium", venue_lower)
+    )
+    record_type = "proceedings-article" if is_conference else "journal-article"
+
+    return PublishedRecord(
+        doi=doi or "",
+        url=ee,
+        title=title or None,
+        authors=authors,
+        journal=venue,
+        year=year,
+        volume=info.get("volume"),
+        number=info.get("number"),
+        pages=info.get("pages"),
+        type=record_type,
+    )
+
+
 def s2_data_to_record(data: dict[str, Any]) -> PublishedRecord | None:
     """Convert Semantic Scholar data to a PublishedRecord."""
     doi = doi_normalize(data.get("doi") or (data.get("externalIds") or {}).get("DOI"))

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -210,6 +210,31 @@ def doi_normalize(doi: str | None) -> str | None:
     return d.lower()
 
 
+#: arXiv DataCite DOI prefix. arXiv mints versioned DOIs
+#: (``10.48550/arXiv.2010.11929v1``), but only the *unversioned* DOI
+#: (``10.48550/arXiv.2010.11929``) resolves via doi.org -- the versioned form
+#: 404s. Stripping the version suffix is therefore safe ONLY for this prefix;
+#: other DOIs may legitimately end in a letter+digit token.
+_ARXIV_DOI_PREFIX = "10.48550/arxiv."
+
+
+def normalize_doi_for_resolution(doi: str | None) -> str | None:
+    """Normalize a DOI for resolution against doi.org.
+
+    Builds on ``doi_normalize`` (strips URL prefix, lowercases). Additionally,
+    for arXiv DataCite DOIs (prefix ``10.48550/arXiv.``) strips a trailing
+    version suffix (``v1``, ``v2``, ...): the versioned DOI 404s at doi.org but
+    the unversioned one resolves (302). The version strip is scoped to the arXiv
+    prefix so non-arXiv DOIs that legitimately end in ``vN`` are left untouched.
+    """
+    normalized = doi_normalize(doi)
+    if not normalized:
+        return normalized
+    if normalized.startswith(_ARXIV_DOI_PREFIX):
+        normalized = re.sub(r"v\d+$", "", normalized)
+    return normalized
+
+
 def doi_url(doi: str) -> str:
     """Convert a DOI to a URL."""
     return f"https://doi.org/{doi}"

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -59,6 +59,11 @@ ACL_DOI_PREFIX = "10.18653/v1/"
 ACL_ANTHOLOGY_ID_RE = re.compile(r"https?://aclanthology\.org/([A-Z0-9][\w.-]+?)(?:\.pdf|\.bib)?/?$", re.IGNORECASE)
 OPENALEX_API = "https://api.openalex.org"
 EUROPEPMC_API = "https://www.ebi.ac.uk/europepmc/webservices/rest"
+# Legacy OpenReview API. The v2 host (api2.openreview.net) does NOT serve the
+# ``paperhash`` exact-match filter, but the legacy ``api.openreview.net/notes``
+# endpoint does -- and that is the authoritative title+first-author lookup the
+# cascade relies on. Public read is keyless.
+OPENREVIEW_API = "https://api.openreview.net"
 
 
 # ------------- Atomic File Replace -------------
@@ -601,6 +606,7 @@ class RateLimiterRegistry:
         "aclanthology": 30,  # ACL Anthology: 30/min (conservative)
         "openalex": 100,  # OpenAlex: polite pool (~10 req/sec max)
         "europepmc": 20,  # Europe PMC: conservative rate limit
+        "openreview": 30,  # OpenReview: 30/min (conservative; keyless public read)
     }
 
     def __init__(self, limits: dict[str, int] | None = None) -> None:
@@ -1917,6 +1923,7 @@ class AsyncRateLimiterRegistry:
         "aclanthology": 30,  # ACL Anthology: 30/min (conservative)
         "openalex": 100,  # OpenAlex: polite pool (~10 req/sec max)
         "europepmc": 20,  # Europe PMC: conservative rate limit
+        "openreview": 30,  # OpenReview: 30/min (conservative; keyless public read)
     }
 
     def __init__(self, limits: dict[str, int] | None = None) -> None:

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -183,6 +183,42 @@ def last_name_from_person(name: str) -> str:
     return last
 
 
+def _normalize_surname_key(family: str) -> str:
+    """Normalize an AUTHORITATIVE structured ``family`` field to a comparison key.
+
+    The key insight versus :func:`last_name_from_person` is the INPUT, not the
+    reduction. ``last_name_from_person`` takes a *flattened* "Given Family"
+    string and must guess which token is the surname by taking the LAST one --
+    that guess is wrong for family-first CJK names ("Chen Xing" -> "xing"). Here
+    the input is ALREADY just the family component the source split out, so we
+    never have to strip a given name. We apply the SAME character normalization
+    and the SAME trailing-token reduction the entry side uses (drop 4-digit DBLP
+    homonym suffixes and single-letter initials, then keep the last token), so a
+    multi-token Western family ("van den Oord") still reduces to "oord" -- which
+    is exactly what the entry side ``last_name_from_person`` produces for
+    "Aaron van den Oord". A single-token CJK family ("Chen") is a no-op and
+    stays "chen". This makes the authoritative side symmetric with the entry
+    side WITHOUT inheriting the family-first misparse.
+    """
+    family = latex_to_plain(family or "")
+    # A structured family may itself arrive comma-first ("Chen, ...") on rare
+    # malformed inputs; take the part before the comma defensively.
+    if "," in family:
+        family = family.split(",", 1)[0].strip()
+    key = strip_diacritics(family).lower()
+    key = re.sub(r"[^a-z0-9\s-]", "", key).strip()
+    tokens = key.split()
+    # Drop trailing junk (4-digit DBLP suffix / single-letter initial) then take
+    # the distinctive last family token -- identical reduction to
+    # ``last_name_from_person``, but applied to a family-only string so the lead
+    # given name of a CJK name can never masquerade as the surname.
+    while len(tokens) > 1 and (re.fullmatch(r"\d{4}", tokens[-1]) or len(tokens[-1]) == 1):
+        tokens.pop()
+    if tokens:
+        return tokens[-1]
+    return ""
+
+
 def authors_last_names(author_field: str, limit: int = 3) -> list[str]:
     """Extract last names from BibTeX author field.
 
@@ -196,6 +232,72 @@ def authors_last_names(author_field: str, limit: int = 3) -> list[str]:
     authors = split_authors_bibtex(author_field)
     last_names = [last_name_from_person(a) for a in authors][:limit]
     return [ln for ln in last_names if ln]
+
+
+def _name_tokens(name: str) -> list[str]:
+    """Normalized comparable tokens of a single person name (no last-token pick).
+
+    Splits a "Family, Given" or "Given Family" string into individual
+    normalized tokens (diacritics stripped, lowercased, punctuation removed,
+    4-digit DBLP suffixes and bare single letters dropped). Used to disambiguate
+    which token is the surname when an authoritative family set is available.
+    """
+    name = latex_to_plain(name or "")
+    name = name.replace(",", " ")
+    name = strip_diacritics(name).lower()
+    name = re.sub(r"[^a-z0-9\s-]", " ", name)
+    return [t for t in name.split() if t and len(t) > 1 and not re.fullmatch(r"\d{4}", t)]
+
+
+def entry_surnames_against_structured(
+    author_field: str, family_keys: set[str], limit: int = 3
+) -> list[str]:
+    """Entry surname keys, disambiguated by an AUTHORITATIVE family-name set.
+
+    The comma-less entry name "Chen Xing" is order-ambiguous: ``last_name_from_person``
+    must guess the surname is the LAST token ("xing"), which is wrong for a
+    family-first CJK name whose family is "Chen". When we hold an authoritative
+    family set (the ``family`` keys of a structured Crossref record for the SAME
+    paper), we can resolve the ambiguity *per author*: if exactly one of an
+    entry author's normalized tokens is a known family key, that token is the
+    surname; otherwise fall back to ``last_name_from_person``.
+
+    This is NOT order-insensitive matching across authors -- each entry author
+    still maps to exactly one surname at its own position, and the downstream
+    ``symmetric_author_match`` still enforces first-author identity and ordering.
+    It only fixes WHICH token within a single ambiguous name is treated as the
+    surname, using the authoritative record as the disambiguator. A genuinely
+    different author cannot be rescued: none of "John Smith"'s tokens are in a
+    {"chen"} family set, so it still reduces to "smith" and still mismatches.
+
+    Args:
+        author_field: BibTeX author string.
+        family_keys: Set of authoritative normalized family keys (from a
+            structured record's ``surname_keys``).
+        limit: Max authors to extract.
+
+    Returns:
+        List of normalized surname keys, disambiguated where possible.
+    """
+    authors = split_authors_bibtex(author_field)[:limit]
+    resolved: list[str] = []
+    for a in authors:
+        default_key = last_name_from_person(a)
+        # A comma-form name ("Chen, Xing") is already unambiguous -- the family
+        # precedes the comma -- so only disambiguate comma-less names.
+        if "," not in a and family_keys:
+            tokens = _name_tokens(a)
+            matches = [t for t in tokens if t in family_keys]
+            # Use the authoritative token only when it is UNAMBIGUOUS: exactly
+            # one token of this name is a known family key. (Two matches would be
+            # ambiguous; zero means this author isn't in the record -> keep the
+            # heuristic so a genuine extra/different author still surfaces.)
+            if len(matches) == 1:
+                resolved.append(matches[0])
+                continue
+        if default_key:
+            resolved.append(default_key)
+    return [k for k in resolved if k]
 
 
 def first_author_surname(entry: dict[str, Any]) -> str:
@@ -1138,18 +1240,52 @@ class PublishedRecord:
     type: str | None = None
     method: str | None = None  # how found
     confidence: float = 0.0
+    # True when ``authors[*]["family"]`` comes from an AUTHORITATIVE structured
+    # source -- Crossref's separate ``given``/``family`` fields -- False when the
+    # split was SYNTHESIZED by last-token tokenization of a flat name string
+    # (Semantic Scholar, DBLP, OpenAlex ``display_name``, Crossref ``literal``).
+    # OpenAlex exposes only a flat ``display_name`` in the works response (no
+    # given/family split), so it is treated as unstructured here. Drives
+    # ``surname_keys``:
+    # an authoritative ``family`` is trusted verbatim (only normalized), while a
+    # synthesized one is unreliable for CJK/family-first names and is re-derived
+    # from the full name via ``last_name_from_person``.
+    structured_names: bool = False
 
     def surname_keys(self, limit: int = 3) -> list[str]:
         """Canonical surname comparison keys derived from ``self.authors``.
 
-        Single source of truth for turning a record author into a surname key:
-        each ``family`` field is reduced via ``last_name_from_person`` (the same
-        function the BibTeX-entry side uses through ``authors_last_names``), so
-        the entry and record sides are provably symmetric. Mirrors
-        ``authors_last_names`` exactly -- truncate to ``limit`` first, then drop
-        empties -- so neither side can drift from the other.
+        Single source of truth for turning a record author into a surname key.
+        How a key is derived depends on whether the source gave us an
+        AUTHORITATIVE family name:
+
+        * ``structured_names`` is True (Crossref/OpenAlex separate
+          ``given``/``family`` fields): trust the explicit ``family`` verbatim,
+          only NORMALIZING it (strip diacritics, lowercase, drop a trailing
+          4-digit DBLP homonym suffix) -- but WITHOUT the last-token reduction.
+          That reduction corrupts family-first CJK names: e.g. an entry
+          "Chen Xing" reduces to ``xing`` while a Crossref record
+          ``{"given": "Xing", "family": "Chen"}`` is authoritatively ``chen`` --
+          same person, two keys, a false AUTHOR_MISMATCH. Trusting ``family``
+          keeps the authoritative side correct.
+        * Otherwise (flat ``name`` from S2/DBLP that we tokenized ourselves):
+          there is no reliable family split, so reconstruct the full name and
+          route it through ``last_name_from_person`` exactly as the BibTeX-entry
+          side does, so the two sides stay symmetric.
+
+        Truncate to ``limit`` first, then drop empties, mirroring
+        ``authors_last_names`` so neither side can drift.
         """
-        keys = [last_name_from_person(a.get("family", "") or "") for a in self.authors][:limit]
+        keys: list[str] = []
+        for a in self.authors[:limit]:
+            family = (a.get("family") or "").strip()
+            if self.structured_names and family:
+                keys.append(_normalize_surname_key(family))
+            else:
+                # No authoritative family split: rebuild the flattened name and
+                # reduce it with the same last-token heuristic the entry uses.
+                full = f"{a.get('given', '') or ''} {family}".strip()
+                keys.append(last_name_from_person(full))
         return [k for k in keys if k]
 
     @property
@@ -1177,11 +1313,19 @@ def crossref_message_to_record(msg: dict[str, Any]) -> PublishedRecord | None:
     if title:
         title = re.sub(r"<[^>]*>", "", title)  # strip HTML tags
 
-    # Authors - handle given/family and literal formats
+    # Authors - handle given/family and literal formats. Crossref returns
+    # AUTHORITATIVE separate given/family fields, so a real ``family`` is
+    # trusted verbatim by ``surname_keys`` (no last-token misparse). A ``literal``
+    # name we had to split ourselves is NOT authoritative -- if every author came
+    # from a literal we leave ``structured_names`` False and let ``surname_keys``
+    # fall back to ``last_name_from_person``.
     authors = []
+    has_structured_family = False
     for a in msg.get("author", []) or []:
         given = a.get("given") or ""
         family = a.get("family") or ""
+        if family:
+            has_structured_family = True
         # Handle literal name format when given/family are missing
         if not (given or family) and a.get("literal"):
             lit = a["literal"]
@@ -1219,6 +1363,7 @@ def crossref_message_to_record(msg: dict[str, Any]) -> PublishedRecord | None:
         number=issue,
         pages=msg.get("page"),
         type=typ,
+        structured_names=has_structured_family,
     )
 
 

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -90,9 +90,25 @@ def safe_lower(x: str | None) -> str:
     return (x or "").lower().strip()
 
 
+# Letters with no NFKD decomposition (no combining mark) that should still fold
+# to an ASCII base so the SAME name matches across sources, e.g. "Reiß" -> "reiss".
+# This only equates variant spellings of one name; it never merges distinct names.
+_NONDECOMPOSING_FOLD = str.maketrans(
+    {
+        "ß": "ss", "ẞ": "ss", "ø": "o", "Ø": "O", "đ": "d", "Đ": "D",
+        "ł": "l", "Ł": "L", "æ": "ae", "Æ": "AE", "œ": "oe", "Œ": "OE",
+        "ð": "d", "Ð": "D", "þ": "th", "Þ": "TH", "ı": "i", "ŧ": "t",
+    }
+)
+
+
 def strip_diacritics(text: str) -> str:
-    """Remove diacritics from text (e.g., 'café' -> 'cafe')."""
-    nfkd = unicodedata.normalize("NFKD", text)
+    """Remove diacritics from text (e.g., 'café' -> 'cafe').
+
+    Also folds letters that lack an NFKD decomposition (ß, ø, ł, æ, ...) to an
+    ASCII base, so variant spellings of the same name produce the same key.
+    """
+    nfkd = unicodedata.normalize("NFKD", text.translate(_NONDECOMPOSING_FOLD))
     return "".join([c for c in nfkd if not unicodedata.combining(c)])
 
 
@@ -155,10 +171,12 @@ def last_name_from_person(name: str) -> str:
     last = re.sub(r"[^a-z0-9\s-]", "", last).strip()
 
     tokens = last.split()
-    # Drop a trailing 4-digit DBLP homonym-disambiguation suffix ("Sun 0020",
-    # "Li 0001") so the key is the real surname rather than the number. Guarded
-    # by len > 1 so a name that is only digits is never emptied.
-    while len(tokens) > 1 and re.fullmatch(r"\d{4}", tokens[-1]):
+    # Drop trailing junk tokens so the key is the real surname:
+    #   - 4-digit DBLP homonym suffixes ("Sun 0020", "Li 0001")
+    #   - trailing single-letter initials ("Mallikarjun B. R." -> "mallikarjun",
+    #     where naive last-token would give "r")
+    # Guarded by len > 1 so a name that is only an initial/number is never emptied.
+    while len(tokens) > 1 and (re.fullmatch(r"\d{4}", tokens[-1]) or len(tokens[-1]) == 1):
         tokens.pop()
     if tokens:
         last = tokens[-1]

--- a/tests/test_bib_utils.py
+++ b/tests/test_bib_utils.py
@@ -10,6 +10,7 @@ from bibtex_updater.utils import (
     DiskCache,
     RateLimiter,
     crossref_message_to_record,
+    dblp_hit_to_candidate_record,
     dblp_hit_to_record,
     s2_data_to_record,
 )
@@ -262,6 +263,76 @@ class TestDblpHitToRecord:
             }
         }
         assert dblp_hit_to_record(hit) is None
+
+
+class TestDblpHitToCandidateRecord:
+    """FIX E-DBLP: the permissive cascade-candidate converter must keep clean
+    title+author hits that the strict resolver converter drops -- i.e. DOI-less
+    conference papers and arXiv/CoRR copies -- so DBLP can contribute scorable
+    candidates for ICML/ICLR/NeurIPS references.
+    """
+
+    def test_keeps_doi_less_conference_hit(self):
+        """The exact failure case: a DOI-less, ee-less ICLR paper. The strict
+        converter returns None here; the permissive one must keep it."""
+        hit = {
+            "info": {
+                "title": "Context-Aware Sparse Deep Coordination Graphs",
+                "authors": {"author": ["Tonghan Wang", "Liang Zeng"]},
+                "venue": "ICLR",
+                "year": "2022",
+                "type": "Conference and Workshop Papers",
+            }
+        }
+        assert dblp_hit_to_record(hit) is None  # strict drops it
+        rec = dblp_hit_to_candidate_record(hit)  # permissive keeps it
+        assert rec is not None
+        assert rec.title == "Context-Aware Sparse Deep Coordination Graphs"
+        assert rec.type == "proceedings-article"
+        assert [a["family"] for a in rec.authors] == ["Wang", "Zeng"]
+
+    def test_keeps_corr_arxiv_copy(self):
+        """CoRR/arXiv hits are rejected by the strict converter but retained as
+        candidates here (we don't discard the preprint copy outright)."""
+        hit = {
+            "info": {
+                "title": "Some Paper Indexed Under CoRR",
+                "authors": {"author": ["Jane Doe"]},
+                "venue": "CoRR",
+                "year": "2024",
+                "doi": "10.48550/arXiv.2401.00001",
+                "type": "Journal Articles",
+            }
+        }
+        assert dblp_hit_to_record(hit) is None
+        rec = dblp_hit_to_candidate_record(hit)
+        assert rec is not None
+        assert rec.title == "Some Paper Indexed Under CoRR"
+
+    def test_strips_homonym_suffix(self):
+        hit = {
+            "info": {
+                "title": "On Calibration of Modern Neural Networks",
+                "authors": {"author": ["Chuan Guo 0001", "Yu Sun 0020"]},
+                "venue": "ICML",
+                "year": "2017",
+                "type": "Conference and Workshop Papers",
+            }
+        }
+        rec = dblp_hit_to_candidate_record(hit)
+        assert rec is not None
+        assert [a["family"] for a in rec.authors] == ["Guo", "Sun"]
+
+    def test_rejects_missing_title(self):
+        hit = {"info": {"authors": {"author": ["Jane Doe"]}, "venue": "ICML", "year": "2020"}}
+        assert dblp_hit_to_candidate_record(hit) is None
+
+    def test_rejects_no_authors(self):
+        hit = {"info": {"title": "Authorless", "venue": "ICML", "year": "2020"}}
+        assert dblp_hit_to_candidate_record(hit) is None
+
+    def test_empty_hit(self):
+        assert dblp_hit_to_candidate_record({}) is None
 
 
 class TestS2DataToRecord:

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -49,12 +49,7 @@ ABSTAIN_STATUSES = (
     "url_accessible",
 )
 # Every status the calibrator must price (excludes "skipped" = not verifiable).
-ALL_VERDICT_STATUSES = (
-    CORRECT_STATUSES
-    + PROBLEM_STRONG_STATUSES
-    + PROBLEM_SOFT_STATUSES
-    + ABSTAIN_STATUSES
-)
+ALL_VERDICT_STATUSES = CORRECT_STATUSES + PROBLEM_STRONG_STATUSES + PROBLEM_SOFT_STATUSES + ABSTAIN_STATUSES
 
 
 def _end_to_end(status, *, found, match_score):
@@ -86,6 +81,7 @@ def _natural_problem_conf(status):
         return _end_to_end(status, found=True, match_score=0.6)
     # Self-contained problems: no scored candidate.
     return _end_to_end(status, found=False, match_score=None)
+
 
 # ------------- Fixtures -------------
 
@@ -586,10 +582,7 @@ class TestBucketCoherence:
         """Prior invariant: max(abstention) < min(either confident bucket)."""
         max_abstain = max(STATUS_BASE_CONFIDENCE[s] for s in ABSTAIN_STATUSES)
         min_correct = min(STATUS_BASE_CONFIDENCE[s] for s in CORRECT_STATUSES)
-        min_problem = min(
-            STATUS_BASE_CONFIDENCE[s]
-            for s in PROBLEM_STRONG_STATUSES + PROBLEM_SOFT_STATUSES
-        )
+        min_problem = min(STATUS_BASE_CONFIDENCE[s] for s in PROBLEM_STRONG_STATUSES + PROBLEM_SOFT_STATUSES)
         assert max_abstain < min_correct
         assert max_abstain < min_problem
 
@@ -606,9 +599,7 @@ class TestBucketCoherence:
         adjudicate must not report higher confidence than a decided one.
         """
         # Confident verdicts under their natural evidence context.
-        correct_confs = [
-            _end_to_end(s, found=True, match_score=0.95) for s in CORRECT_STATUSES
-        ]
+        correct_confs = [_end_to_end(s, found=True, match_score=0.95) for s in CORRECT_STATUSES]
         strong_confs = [_natural_problem_conf(s) for s in PROBLEM_STRONG_STATUSES]
         soft_confs = [_natural_problem_conf(s) for s in PROBLEM_SOFT_STATUSES]
         # Abstentions: vary found/score to prove neither inflates them.
@@ -619,9 +610,7 @@ class TestBucketCoherence:
 
         worst_confident = min(correct_confs + strong_confs + soft_confs)
         best_abstain = max(abstain_confs)
-        assert best_abstain < worst_confident, (
-            f"abstention {best_abstain:.3f} >= confident {worst_confident:.3f}"
-        )
+        assert best_abstain < worst_confident, f"abstention {best_abstain:.3f} >= confident {worst_confident:.3f}"
 
     def test_strong_problems_ge_soft_problems_end_to_end(self):
         """End-to-end (each status under its natural evidence context):

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -12,6 +12,81 @@ from bibtex_updater.calibration import (
     status_aware_confidence,
 )
 
+# Bucket membership for the three-way verdict model (status .value strings).
+# Kept local so these tests do not depend on the concurrently-edited
+# fact_checker module importing cleanly.
+CORRECT_STATUSES = (
+    "verified",
+    "preprint_only",
+    "published_version_exists",
+    "url_verified",
+    "book_verified",
+    "working_paper_verified",
+)
+PROBLEM_STRONG_STATUSES = (
+    "hallucinated",
+    "future_date",
+    "invalid_year",
+    "doi_mismatch",
+    "arxiv_id_mismatch",
+)
+PROBLEM_SOFT_STATUSES = (
+    "title_mismatch",
+    "author_mismatch",
+    "year_mismatch",
+    "venue_mismatch",
+    "partial_match",
+    "url_content_mismatch",
+)
+ABSTAIN_STATUSES = (
+    "not_found",
+    "unconfirmed",
+    "api_error",
+    "doi_not_found",
+    "url_not_found",
+    "book_not_found",
+    "working_paper_not_found",
+    "url_accessible",
+)
+# Every status the calibrator must price (excludes "skipped" = not verifiable).
+ALL_VERDICT_STATUSES = (
+    CORRECT_STATUSES
+    + PROBLEM_STRONG_STATUSES
+    + PROBLEM_SOFT_STATUSES
+    + ABSTAIN_STATUSES
+)
+
+
+def _end_to_end(status, *, found, match_score):
+    """Run calibrate_result with a neutral, full-coverage context for a status."""
+    if found:
+        sources_with_hits = ["crossref", "dblp", "semanticscholar"]
+    else:
+        sources_with_hits = []
+    return calibrate_result(
+        status=status,
+        best_match_score=match_score,
+        field_comparisons={},
+        sources_queried=["crossref", "dblp", "semanticscholar"],
+        sources_with_hits=sources_with_hits,
+        errors=[],
+    )
+
+
+def _natural_problem_conf(status):
+    """End-to-end confidence for a problem status under its natural evidence.
+
+    hallucinated derives from a low scored candidate (a record was retrieved but
+    badly mismatched), whereas the self-contained problems carry no candidate.
+    Soft single-field mismatches imply a record WAS found and mostly matches.
+    """
+    if status == "hallucinated":
+        return _end_to_end(status, found=True, match_score=0.1)
+    if status in PROBLEM_SOFT_STATUSES:
+        return _end_to_end(status, found=True, match_score=0.6)
+    # Self-contained problems: no scored candidate.
+    return _end_to_end(status, found=False, match_score=None)
+
 # ------------- Fixtures -------------
 
 
@@ -74,17 +149,21 @@ class TestComputeConfidenceFromScores:
         # Should return base confidence for not_found (0.70)
         assert abs(confidence - STATUS_BASE_CONFIDENCE["not_found"]) < 0.01
 
-    def test_not_found_low_score_confirms(self):
-        """Not found with low match score confirms the classification."""
+    def test_not_found_low_score_stays_low(self):
+        """Not found is an abstention: a low match score does NOT inflate it.
+
+        A don't-know verdict must stay near-neutral. Inverting a low match score
+        to manufacture high "confidence it's not found" was the old over-flagging
+        bug; the abstention now holds its low base prior.
+        """
         confidence = compute_confidence_from_scores(
             status="not_found",
             best_match_score=0.25,
             field_comparisons={"title": {"similarity_score": 0.25, "matches": False}},
         )
-        # Low score (0.25) confirms not_found
-        # confidence_in_low_score = 1.0 - 0.25 = 0.75
-        # 0.6 * 0.75 + 0.4 * 0.70 = 0.45 + 0.28 = 0.73
-        assert confidence > 0.7
+        # Holds the low abstention prior, NOT boosted by 1 - score.
+        assert abs(confidence - STATUS_BASE_CONFIDENCE["not_found"]) < 0.01
+        assert confidence < 0.6
 
     def test_not_found_high_score_contradicts(self):
         """Not found with high match score contradicts the status."""
@@ -237,9 +316,14 @@ class TestStatusAwareConfidence:
         assert confidence > 0.85
         assert confidence <= 1.0
 
-    def test_not_found_all_sources(self):
-        """Not found with all sources queried should give high confidence."""
-        confidence = status_aware_confidence(
+    def test_not_found_source_count_does_not_inflate(self):
+        """Abstention confidence must NOT scale with how many sources were queried.
+
+        "Not found in 3 databases" is still a don't-know. Querying more sources
+        cannot push an abstention toward a confident verdict, so 1-source and
+        3-source not_found must report the same (low) confidence.
+        """
+        conf_three = status_aware_confidence(
             status="not_found",
             best_match_score=0.15,
             field_comparisons={},
@@ -247,14 +331,7 @@ class TestStatusAwareConfidence:
             sources_with_hits=[],
             errors=[],
         )
-        # All 3 sources queried, none found -> high confidence
-        # queried_factor = 3/3 = 1.0
-        # coverage_factor = 0.7 + 0.3 * 1.0 = 1.0
-        assert confidence > 0.7
-
-    def test_not_found_one_source(self):
-        """Not found with only one source should give lower confidence."""
-        confidence = status_aware_confidence(
+        conf_one = status_aware_confidence(
             status="not_found",
             best_match_score=0.20,
             field_comparisons={},
@@ -262,10 +339,10 @@ class TestStatusAwareConfidence:
             sources_with_hits=[],
             errors=[],
         )
-        # Only 1 source queried -> lower confidence
-        # queried_factor = 1/3 = 0.333
-        # coverage_factor = 0.7 + 0.3 * 0.333 ≈ 0.8
-        assert confidence < 0.70
+        # Both stay at the low abstention prior; source count is irrelevant.
+        assert conf_three < 0.6
+        assert conf_one < 0.6
+        assert abs(conf_three - conf_one) < 0.01
 
     def test_api_errors_reduce_confidence(self, sample_field_comparisons):
         """API errors should reduce confidence."""
@@ -357,7 +434,11 @@ class TestCalibrateResult:
         assert confidence <= 1.0
 
     def test_not_found_entry(self):
-        """End-to-end test for not found entry."""
+        """End-to-end test for not found entry: abstention stays low.
+
+        not_found is a don't-know verdict; it must report LOW confidence
+        regardless of how many sources were queried.
+        """
         confidence = calibrate_result(
             status="not_found",
             best_match_score=0.10,
@@ -366,9 +447,9 @@ class TestCalibrateResult:
             sources_with_hits=[],
             errors=[],
         )
-        # All sources queried, none found -> high confidence
-        assert confidence > 0.70
-        assert confidence <= 1.0
+        # Near-neutral abstention prior, NOT a high confident verdict.
+        assert confidence < 0.55
+        assert confidence >= 0.0
 
     def test_confidence_range(self):
         """All calibrated confidences should be in [0.0, 1.0]."""
@@ -470,3 +551,98 @@ class TestCalibrateResult:
         # Should use formula: 0.7 * base_confidence + 0.3 * weighted_field_score
         # Both components should be high, so final confidence should be high
         assert confidence > 0.85
+
+
+# ------------- Test three-way bucket coherence -------------
+
+
+class TestBucketCoherence:
+    """The priors must be coherent with the 3-way verdict model.
+
+    Ordering invariant: CLEARLY-CORRECT and CLEARLY-PROBLEM are both HIGH and
+    sit strictly ABOVE the DON'T-KNOW (abstention) bucket; positive-evidence
+    problems sit at or above soft single-field mismatches. This holds both for
+    the raw priors and end-to-end through ``calibrate_result``.
+    """
+
+    def test_every_verdict_status_has_a_prior(self):
+        """No verdict status may be missing from STATUS_BASE_CONFIDENCE."""
+        for status in ALL_VERDICT_STATUSES:
+            assert status in STATUS_BASE_CONFIDENCE, f"missing prior: {status}"
+        # "skipped" (not verifiable) is also present.
+        assert "skipped" in STATUS_BASE_CONFIDENCE
+
+    def test_confident_buckets_are_high(self):
+        """Both confident buckets must be clearly high (>= 0.72)."""
+        for status in CORRECT_STATUSES + PROBLEM_STRONG_STATUSES + PROBLEM_SOFT_STATUSES:
+            assert STATUS_BASE_CONFIDENCE[status] >= 0.72, status
+
+    def test_abstentions_are_low(self):
+        """Abstention priors must be near-neutral and low (<= 0.50)."""
+        for status in ABSTAIN_STATUSES:
+            assert STATUS_BASE_CONFIDENCE[status] <= 0.50, status
+
+    def test_abstention_below_both_confident_buckets_prior(self):
+        """Prior invariant: max(abstention) < min(either confident bucket)."""
+        max_abstain = max(STATUS_BASE_CONFIDENCE[s] for s in ABSTAIN_STATUSES)
+        min_correct = min(STATUS_BASE_CONFIDENCE[s] for s in CORRECT_STATUSES)
+        min_problem = min(
+            STATUS_BASE_CONFIDENCE[s]
+            for s in PROBLEM_STRONG_STATUSES + PROBLEM_SOFT_STATUSES
+        )
+        assert max_abstain < min_correct
+        assert max_abstain < min_problem
+
+    def test_strong_problems_ge_soft_problems_prior(self):
+        """Positive-evidence problems must be >= soft single-field mismatches."""
+        min_strong = min(STATUS_BASE_CONFIDENCE[s] for s in PROBLEM_STRONG_STATUSES)
+        max_soft = max(STATUS_BASE_CONFIDENCE[s] for s in PROBLEM_SOFT_STATUSES)
+        assert min_strong >= max_soft
+
+    def test_abstention_below_both_confident_buckets_end_to_end(self):
+        """End-to-end: every abstention calibrates below every confident verdict.
+
+        This is the key correctness property -- an entry the tool could not
+        adjudicate must not report higher confidence than a decided one.
+        """
+        # Confident verdicts under their natural evidence context.
+        correct_confs = [
+            _end_to_end(s, found=True, match_score=0.95) for s in CORRECT_STATUSES
+        ]
+        strong_confs = [_natural_problem_conf(s) for s in PROBLEM_STRONG_STATUSES]
+        soft_confs = [_natural_problem_conf(s) for s in PROBLEM_SOFT_STATUSES]
+        # Abstentions: vary found/score to prove neither inflates them.
+        abstain_confs = []
+        for s in ABSTAIN_STATUSES:
+            abstain_confs.append(_end_to_end(s, found=False, match_score=0.1))
+            abstain_confs.append(_end_to_end(s, found=False, match_score=None))
+
+        worst_confident = min(correct_confs + strong_confs + soft_confs)
+        best_abstain = max(abstain_confs)
+        assert best_abstain < worst_confident, (
+            f"abstention {best_abstain:.3f} >= confident {worst_confident:.3f}"
+        )
+
+    def test_strong_problems_ge_soft_problems_end_to_end(self):
+        """End-to-end (each status under its natural evidence context):
+        strong positive-evidence problems >= soft single-field mismatches.
+        """
+        min_strong = min(_natural_problem_conf(s) for s in PROBLEM_STRONG_STATUSES)
+        max_soft = max(_natural_problem_conf(s) for s in PROBLEM_SOFT_STATUSES)
+        assert min_strong >= max_soft
+
+    def test_abstention_not_inflated_by_match_or_sources(self):
+        """An abstention with a strong candidate / many sources stays low."""
+        for status in ABSTAIN_STATUSES:
+            # High match score must not lift it above the confident floor (0.72).
+            high = _end_to_end(status, found=True, match_score=0.95)
+            assert high < 0.72, f"{status} inflated to {high:.3f}"
+            # Many sources queried must not lift it either.
+            many = _end_to_end(status, found=False, match_score=0.1)
+            assert many <= STATUS_BASE_CONFIDENCE[status] + 0.01, status
+
+    def test_all_statuses_in_unit_range_end_to_end(self):
+        """Every verdict status calibrates within [0, 1]."""
+        for status in ALL_VERDICT_STATUSES + ("skipped",):
+            conf = _end_to_end(status, found=True, match_score=0.8)
+            assert 0.0 <= conf <= 1.0, f"{status} -> {conf}"

--- a/tests/test_cascade_sources.py
+++ b/tests/test_cascade_sources.py
@@ -1,7 +1,7 @@
 """Tests for the CheckIfExist cascade extensions to bibtex-check.
 
 Covers items 1-6 of the CheckIfExist (Abbonato 2026) port:
-1. Cascading source order (CrossRef -> Semantic Scholar -> OpenAlex)
+1. Cascading source order (CrossRef -> OpenAlex -> Semantic Scholar)
 2. Top-K candidate retrieval before fuzzy match
 3. Cross-source author intersection
 4. Numeric confidence (0-100) with explicit penalties / multi-source bonus
@@ -113,7 +113,7 @@ class TestSelectTopKByTitleSimilarity:
 
 
 class TestQueryCascade:
-    """Verify the cascade order CrossRef -> S2 -> OpenAlex."""
+    """Verify the cascade order CrossRef -> OpenAlex -> S2."""
 
     def _build(self, cr_items=(), s2_items=(), oa_items=(), config_override=None, openalex=None):
         crossref = MagicMock()
@@ -182,7 +182,7 @@ class TestQueryCascade:
         assert "crossref" in sources_queried
         assert "semanticscholar" in sources_queried
 
-    def test_falls_through_to_openalex_when_cr_and_s2_empty(self):
+    def test_falls_through_all_sources_when_empty(self):
         fc, oa = self._build(cr_items=[], s2_items=[], oa_items=[])
         fc.openalex = oa
         entry = {
@@ -194,7 +194,9 @@ class TestQueryCascade:
         }
         sources_queried = []
         fc._query_cascade(entry, "Deep Learning Smith", sources_queried, [], [])
-        assert sources_queried == ["crossref", "semanticscholar", "openalex"]
+        # New order puts the fast, broad aggregator (OpenAlex) before the slow
+        # keyless-S2 specialist.
+        assert sources_queried == ["crossref", "openalex", "semanticscholar"]
 
     def test_top_k_capped_at_max(self):
         fc, _ = self._build(config_override={"top_k": MAX_TOP_K + 100})

--- a/tests/test_cascade_sources.py
+++ b/tests/test_cascade_sources.py
@@ -194,9 +194,11 @@ class TestQueryCascade:
         }
         sources_queried = []
         fc._query_cascade(entry, "Deep Learning Smith", sources_queried, [], [])
-        # New order puts the fast, broad aggregator (OpenAlex) and the
-        # CS-conference authority (DBLP) before the slow keyless-S2 specialist.
-        assert sources_queried == ["crossref", "openalex", "dblp", "semanticscholar"]
+        # New order puts the fast, broad aggregator (OpenAlex), the CS-conference
+        # authority (DBLP), and the ML-venue authority (OpenReview) before the
+        # slow keyless-S2 specialist. OpenReview is lazily built from
+        # ``crossref.http`` (a MagicMock here), so it is reached.
+        assert sources_queried == ["crossref", "openalex", "dblp", "openreview", "semanticscholar"]
 
     def test_top_k_capped_at_max(self):
         fc, _ = self._build(config_override={"top_k": MAX_TOP_K + 100})

--- a/tests/test_cascade_sources.py
+++ b/tests/test_cascade_sources.py
@@ -194,9 +194,9 @@ class TestQueryCascade:
         }
         sources_queried = []
         fc._query_cascade(entry, "Deep Learning Smith", sources_queried, [], [])
-        # New order puts the fast, broad aggregator (OpenAlex) before the slow
-        # keyless-S2 specialist.
-        assert sources_queried == ["crossref", "openalex", "semanticscholar"]
+        # New order puts the fast, broad aggregator (OpenAlex) and the
+        # CS-conference authority (DBLP) before the slow keyless-S2 specialist.
+        assert sources_queried == ["crossref", "openalex", "dblp", "semanticscholar"]
 
     def test_top_k_capped_at_max(self):
         fc, _ = self._build(config_override={"top_k": MAX_TOP_K + 100})
@@ -534,3 +534,146 @@ def test_openalex_client_search_returns_empty_on_http_error():
     # environment), and the client should gracefully return [].
     out = client.search("nonexistent_query_xyz_12345_zzz")
     assert out == [] or isinstance(out, list)
+
+
+# ===========================================================================
+# Fielded title search (FIX A): OpenAlex filter=title.search, Crossref query.title
+# ===========================================================================
+
+
+def _ok(results):
+    """A MagicMock 200 response whose .json() yields {"results": results}."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"results": list(results)}
+    return resp
+
+
+class TestOpenAlexFieldedTitleSearch:
+    """FIX A.1: OpenAlex must issue a fielded ``filter=title.search:<title>``
+    using the RAW title (no appended author) and only fall back to free-text
+    ``?search=`` when the fielded query returns zero results.
+    """
+
+    def test_fielded_filter_used_when_title_given(self):
+        http = MagicMock()
+        http._request.return_value = _ok([{"title": "Context-Aware Sparse Deep Coordination Graphs"}])
+        client = OpenAlexClient(http=http)
+
+        out = client.search(
+            "context aware sparse deep coordination graphs wang",
+            title="Context-Aware Sparse Deep Coordination Graphs",
+        )
+        assert out and out[0]["title"].startswith("Context-Aware")
+        # Exactly one request, and it must be the fielded filter (NOT ?search=).
+        assert http._request.call_count == 1
+        params = http._request.call_args.kwargs["params"]
+        assert params["filter"] == "title.search:Context-Aware Sparse Deep Coordination Graphs"
+        assert "search" not in params  # author-free, no free-text blob
+
+    def test_falls_back_to_free_text_when_fielded_empty(self):
+        http = MagicMock()
+        # First call (fielded) -> empty; second call (free-text) -> a result.
+        http._request.side_effect = [_ok([]), _ok([{"title": "Fallback Hit"}])]
+        client = OpenAlexClient(http=http)
+
+        out = client.search("some title surname", title="Some Title")
+        assert out and out[0]["title"] == "Fallback Hit"
+        assert http._request.call_count == 2
+        # Second (fallback) call uses the free-text ?search= blob.
+        fallback_params = http._request.call_args_list[1].kwargs["params"]
+        assert fallback_params["search"] == "some title surname"
+        assert "filter" not in fallback_params
+
+    def test_no_fallback_when_fielded_has_results(self):
+        http = MagicMock()
+        http._request.return_value = _ok([{"title": "X"}])
+        client = OpenAlexClient(http=http)
+        client.search("x surname", title="X")
+        assert http._request.call_count == 1  # fielded hit -> no free-text call
+
+    def test_free_text_only_when_no_title(self):
+        http = MagicMock()
+        http._request.return_value = _ok([{"title": "Y"}])
+        client = OpenAlexClient(http=http)
+        client.search("y surname")
+        params = http._request.call_args.kwargs["params"]
+        assert params["search"] == "y surname"
+        assert "filter" not in params
+
+
+class TestCrossrefFieldedTitleSearch:
+    """FIX A.2: Crossref must use fielded ``query.title`` (+ ``query.author``)
+    with the raw title instead of the generic ``query.bibliographic`` blob.
+    """
+
+    def _client(self):
+        from bibtex_updater.fact_checker import CrossrefClient
+
+        http = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"message": {"items": [{"title": ["Hit"]}]}}
+        http._request.return_value = resp
+        return CrossrefClient(http), http
+
+    def test_uses_query_title_and_author(self):
+        client, http = self._client()
+        client.search("deep learning smith", title="Deep Learning", author="Smith")
+        params = http._request.call_args.kwargs["params"]
+        assert params["query.title"] == "Deep Learning"
+        assert params["query.author"] == "Smith"
+        assert "query.bibliographic" not in params
+
+    def test_falls_back_to_bibliographic_without_title(self):
+        client, http = self._client()
+        client.search("deep learning smith")
+        params = http._request.call_args.kwargs["params"]
+        assert params["query.bibliographic"] == "deep learning smith"
+        assert "query.title" not in params
+
+
+class TestCascadePassesRawTitle(TestQueryCascade):
+    """FIX A.3: the cascade must forward the RAW title (not the normalized
+    title+surname blob) into the fielded Crossref/OpenAlex searches, and must
+    query DBLP after OpenAlex via the permissive candidate converter.
+    """
+
+    def test_raw_title_forwarded_to_crossref_and_openalex(self):
+        fc, oa = self._build(cr_items=[], s2_items=[], oa_items=[])
+        fc.openalex = oa
+        # DBLP returns a clean conference hit with no DOI (the exact case the
+        # permissive converter must keep).
+        dblp_hit = {
+            "info": {
+                "title": "Context-Aware Sparse Deep Coordination Graphs",
+                "authors": {"author": ["Tonghan Wang", "Liang Zeng"]},
+                "venue": "ICLR",
+                "year": "2022",
+                "type": "Conference and Workshop Papers",
+            }
+        }
+        fc.dblp = MagicMock()
+        fc.dblp.search.return_value = [dblp_hit]
+
+        entry = {
+            "ID": "x",
+            "ENTRYTYPE": "inproceedings",
+            "title": "Context-Aware Sparse Deep Coordination Graphs",
+            "author": "Wang, Tonghan and Zeng, Liang",
+            "year": "2022",
+        }
+        sources_queried: list = []
+        cands = fc._query_cascade(entry, "context aware sparse deep coordination graphs wang", sources_queried, [], [])
+
+        # Crossref received the raw title, not the normalized blob.
+        cr_kwargs = fc.crossref.search.call_args.kwargs
+        assert cr_kwargs["title"] == "Context-Aware Sparse Deep Coordination Graphs"
+        # OpenAlex received the raw title too.
+        oa_kwargs = oa.search.call_args.kwargs
+        assert oa_kwargs["title"] == "Context-Aware Sparse Deep Coordination Graphs"
+        # DBLP is in the cascade after OpenAlex and its DOI-less hit survived.
+        # The exact-title hit scores >= cascade_high_confidence, so the cascade
+        # short-circuits at DBLP and never reaches Semantic Scholar.
+        assert sources_queried == ["crossref", "openalex", "dblp"]
+        assert any(src == "dblp" for _, _, src in cands)

--- a/tests/test_cascade_sources.py
+++ b/tests/test_cascade_sources.py
@@ -122,7 +122,7 @@ class TestQueryCascade:
         dblp = MagicMock()
         s2 = MagicMock()
         s2.search.return_value = list(s2_items)
-        config = FactCheckerConfig(cascade_mode=True, top_k=3)
+        config = FactCheckerConfig(top_k=3)
         if config_override:
             for k, v in config_override.items():
                 setattr(config, k, v)

--- a/tests/test_crossref_prefetch.py
+++ b/tests/test_crossref_prefetch.py
@@ -159,9 +159,7 @@ class TestPrefetchWarmsCache:
                 "Delving into Localization Errors for Monocular 3D Object Detection",
                 "10.1109/CVPR46437.2021.00469",
             ),
-            "CVPR52729.2023.01457": _works_payload(
-                "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
-            ),
+            "CVPR52729.2023.01457": _works_payload("Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"),
         }
         http, transport = _make_http(routes, tmp_path)
         checker = _checker(http, logger)
@@ -238,9 +236,7 @@ class TestVerdictNeutral:
                 "10.1109/CVPR46437.2021.00469",
             ),
             # Wrong DOI -> DOI_MISMATCH for ImageBind.
-            "CVPR52729.2023.01457": _works_payload(
-                "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
-            ),
+            "CVPR52729.2023.01457": _works_payload("Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"),
         }
         http, _ = _make_http(routes, tmp_path)
         checker = _checker(http, logger)
@@ -266,9 +262,7 @@ class TestVerdictNeutral:
                 "Delving into Localization Errors for Monocular 3D Object Detection",
                 "10.1109/CVPR46437.2021.00469",
             ),
-            "CVPR52729.2023.01457": _works_payload(
-                "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
-            ),
+            "CVPR52729.2023.01457": _works_payload("Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"),
         }
         entries = [_ibrnet_entry(), _imagebind_entry()]
 

--- a/tests/test_crossref_prefetch.py
+++ b/tests/test_crossref_prefetch.py
@@ -1,0 +1,428 @@
+"""Tests for the up-front Crossref ``/works`` cache-warming in ``bibtex-check``.
+
+Every entry that carries a DOI triggers per-entry Crossref ``/works/{doi}``
+fetches (``_check_doi_consistency`` and the structured-name author recheck, both
+via ``CrossrefClient.get_by_doi``). Run serially across the worker pool, those
+round-trips are gated by the crossref rate limiter (50/min) and dominate
+wall-clock on large bibliographies.
+
+``FactCheckProcessor._batch_warm_crossref_records`` pre-fetches all entry DOIs
+ONCE, up front, in parallel, calling the SAME ``get_by_doi`` path so the shared
+``HttpClient`` SqliteCache is warmed. The per-entry calls then become cache hits.
+
+These tests prove:
+  (a) warming serves the records -- the underlying HTTP fetch count drops to one
+      per distinct DOI (the warm), and per-entry ``get_by_doi`` calls are hits;
+  (b) verdict-neutrality -- statuses are IDENTICAL with and without warming;
+  (c) a pre-fetch failure for one DOI still yields the correct per-entry result
+      (graceful fallback to the existing per-entry fetch, no behavior change).
+
+All tests are hermetic: the httpx transport is replaced by a counting stub; no
+network access.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from bibtex_updater.fact_checker import (
+    CrossrefClient,
+    DBLPClient,
+    FactChecker,
+    FactCheckerConfig,
+    FactCheckProcessor,
+    FactCheckStatus,
+    SemanticScholarClient,
+)
+from bibtex_updater.utils import HttpClient, RateLimiterRegistry, SqliteCache
+
+
+def _works_payload(title: str, doi: str, authors: list[dict] | None = None) -> dict:
+    """A Crossref ``/works/{doi}`` REST response (``message`` wraps one record)."""
+    return {
+        "message": {
+            "DOI": doi,
+            "type": "proceedings-article",
+            "title": [title],
+            "author": authors or [{"given": "A", "family": "Author"}],
+            "issued": {"date-parts": [[2021]]},
+        }
+    }
+
+
+class _CountingTransport:
+    """Thread-safe httpx.Client stand-in that counts real (uncached) GETs.
+
+    Maps each requested URL to a canned 200 JSON ``message`` payload. Every call
+    is a genuine HTTP round-trip from the client's perspective; the SqliteCache
+    in ``HttpClient._request`` is what eliminates the duplicates. So the call
+    count == number of distinct cache misses, which is exactly what the warming
+    optimization is meant to reduce on the per-entry path.
+    """
+
+    def __init__(self, routes: dict[str, dict]):
+        # Crossref get_by_doi lowercases the DOI before building the /works URL,
+        # so match needles case-insensitively.
+        self._routes = {k.lower(): v for k, v in routes.items()}
+        self.count = 0
+        self._lock = threading.Lock()
+
+    def request(self, method, url, **kwargs):
+        # HttpClient._request calls client.request(..., json=json_body); accept
+        # **kwargs so that keyword (and params/headers) is swallowed without
+        # shadowing the module-level ``json`` used for serialization below.
+        with self._lock:
+            self.count += 1
+        url = str(url).lower()
+        for needle, payload in self._routes.items():
+            if needle in url:
+                return httpx.Response(
+                    200,
+                    content=json.dumps(payload).encode("utf-8"),
+                    headers={"Content-Type": "application/json"},
+                    request=httpx.Request(method, url),
+                )
+        return httpx.Response(
+            404,
+            content=b"{}",
+            headers={"Content-Type": "application/json"},
+            request=httpx.Request(method, url),
+        )
+
+
+def _make_http(routes: dict[str, dict], tmp_path) -> tuple[HttpClient, _CountingTransport]:
+    """Real HttpClient with a real SqliteCache, but a counting transport stub.
+
+    The cache is genuine so warming truly populates it and per-entry calls hit
+    it; only the network layer is faked. Rate limits are set high so the limiter
+    never sleeps for these tiny workloads.
+    """
+    cache = SqliteCache(str(tmp_path / "cache.db"))
+    registry = RateLimiterRegistry(dict.fromkeys(RateLimiterRegistry.DEFAULT_LIMITS, 100_000))
+    http = HttpClient(timeout=5.0, user_agent="test", rate_limiter=registry, cache=cache)
+    transport = _CountingTransport(routes)
+    http.client = transport  # type: ignore[assignment]
+    return http, transport
+
+
+def _ibrnet_entry() -> dict[str, str]:
+    return {
+        "ID": "ibrnet2021",
+        "ENTRYTYPE": "inproceedings",
+        "title": "IBRNet: Learning Multi-View Image-Based Rendering",
+        "author": "Wang, Qianqian and Wang, Zhicheng and Genova, Kyle",
+        "doi": "10.1109/CVPR46437.2021.00469",
+        "year": "2021",
+    }
+
+
+def _imagebind_entry() -> dict[str, str]:
+    return {
+        "ID": "imagebind2023",
+        "ENTRYTYPE": "inproceedings",
+        "title": "ImageBind: One Embedding Space To Bind Them All",
+        "author": "Girdhar, Rohit and El-Nouby, Alaaeldin",
+        "doi": "10.1109/CVPR52729.2023.01457",
+        "year": "2023",
+    }
+
+
+def _checker(http: HttpClient, logger, config: FactCheckerConfig | None = None) -> FactChecker:
+    return FactChecker(
+        CrossrefClient(http),
+        DBLPClient(http),
+        SemanticScholarClient(http),
+        config or FactCheckerConfig(),
+        logger,
+    )
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_crossref_prefetch")
+
+
+class TestPrefetchWarmsCache:
+    """The pre-fetch issues each distinct DOI's /works fetch once; the per-entry
+    get_by_doi calls then read from the warmed SqliteCache (zero extra GETs)."""
+
+    def test_warm_then_per_entry_calls_are_cache_hits(self, logger, tmp_path):
+        # Two entries, each with a wrong DOI (-> DOI_MISMATCH), distinct DOIs.
+        routes = {
+            "CVPR46437.2021.00469": _works_payload(
+                "Delving into Localization Errors for Monocular 3D Object Detection",
+                "10.1109/CVPR46437.2021.00469",
+            ),
+            "CVPR52729.2023.01457": _works_payload(
+                "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
+            ),
+        }
+        http, transport = _make_http(routes, tmp_path)
+        checker = _checker(http, logger)
+
+        # Warm the cache via the processor (no worker pool needed for the count).
+        processor = FactCheckProcessor(checker, logger)
+        entries = [_ibrnet_entry(), _imagebind_entry()]
+        warmed = processor._batch_warm_crossref_records(entries)
+        assert warmed == 2
+        # Exactly one real GET per distinct DOI during warming.
+        assert transport.count == 2
+
+        # Now the per-entry consistency checks must add ZERO further GETs: every
+        # get_by_doi is served from the warmed cache.
+        before = transport.count
+        for entry in entries:
+            checker._check_doi_consistency(entry)
+        assert transport.count == before
+
+    def test_duplicate_dois_warmed_once(self, logger, tmp_path):
+        """Identical DOIs across entries share one cache key -> one GET total."""
+        routes = {
+            "CVPR46437.2021.00469": _works_payload(
+                "Delving into Localization Errors for Monocular 3D Object Detection",
+                "10.1109/CVPR46437.2021.00469",
+            )
+        }
+        http, transport = _make_http(routes, tmp_path)
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+
+        warmed = processor._batch_warm_crossref_records([_ibrnet_entry(), _ibrnet_entry()])
+
+        assert warmed == 1
+        assert transport.count == 1
+
+    def test_no_dois_no_fetch(self, logger, tmp_path):
+        http, transport = _make_http({}, tmp_path)
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+        entry = _ibrnet_entry()
+        del entry["doi"]
+
+        assert processor._batch_warm_crossref_records([entry]) == 0
+        assert transport.count == 0
+
+    def test_warm_noop_without_cache(self, logger):
+        """No shared response cache -> warming is a documented no-op (the per-entry
+        calls would re-fetch regardless, so warming buys nothing)."""
+        http_no_cache = MagicMock()
+        http_no_cache.cache = None
+        checker = FactChecker(
+            CrossrefClient(http_no_cache),
+            DBLPClient(http_no_cache),
+            SemanticScholarClient(http_no_cache),
+            FactCheckerConfig(),
+            logger,
+        )
+        processor = FactCheckProcessor(checker, logger)
+
+        assert processor._batch_warm_crossref_records([_ibrnet_entry()]) == 0
+        http_no_cache._request.assert_not_called()
+
+
+class TestVerdictNeutral:
+    """The verdicts (statuses) must be IDENTICAL with and without the warming;
+    the optimization only changes WHEN the same records are fetched."""
+
+    def _run(self, with_warm: bool, logger, tmp_path) -> list[FactCheckStatus]:
+        routes = {
+            # Wrong DOI -> DOI_MISMATCH for IBRNet.
+            "CVPR46437.2021.00469": _works_payload(
+                "Delving into Localization Errors for Monocular 3D Object Detection",
+                "10.1109/CVPR46437.2021.00469",
+            ),
+            # Wrong DOI -> DOI_MISMATCH for ImageBind.
+            "CVPR52729.2023.01457": _works_payload(
+                "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
+            ),
+        }
+        http, _ = _make_http(routes, tmp_path)
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+        entries = [_ibrnet_entry(), _imagebind_entry()]
+        if with_warm:
+            processor._batch_warm_crossref_records(entries)
+        # Drive the SAME per-entry path both ways.
+        return [checker.check_entry(e).status for e in entries]
+
+    def test_statuses_identical_with_and_without_warm(self, logger, tmp_path):
+        cold = self._run(False, logger, tmp_path / "cold")
+        warm = self._run(True, logger, tmp_path / "warm")
+
+        assert cold == warm
+        assert cold == [FactCheckStatus.DOI_MISMATCH, FactCheckStatus.DOI_MISMATCH]
+
+    def test_process_entries_statuses_match_unwarmed_baseline(self, logger, tmp_path):
+        """End-to-end via process_entries (which warms) vs a cold per-entry run:
+        same statuses in the same order."""
+        routes = {
+            "CVPR46437.2021.00469": _works_payload(
+                "Delving into Localization Errors for Monocular 3D Object Detection",
+                "10.1109/CVPR46437.2021.00469",
+            ),
+            "CVPR52729.2023.01457": _works_payload(
+                "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
+            ),
+        }
+        entries = [_ibrnet_entry(), _imagebind_entry()]
+
+        # Cold baseline: never warm, check each entry directly.
+        http_cold, _ = _make_http(routes, tmp_path / "cold")
+        cold_checker = _checker(http_cold, logger)
+        cold = [cold_checker.check_entry(e).status for e in entries]
+
+        # Warmed path through the real process_entries pipeline.
+        http_warm, _ = _make_http(routes, tmp_path / "warm")
+        warm_checker = _checker(http_warm, logger)
+        warm_proc = FactCheckProcessor(warm_checker, logger)
+        warm_results = warm_proc.process_entries(entries, max_workers=2)
+        warm = [r.status for r in warm_results]
+
+        assert warm == cold
+
+    def test_correct_doi_verifies_identically(self, logger, tmp_path):
+        """A CORRECT DOI (resolves to the cited paper) must VERIFY identically
+        whether or not its record was pre-fetched -- warming never relaxes or
+        tightens the comparison, only moves the fetch."""
+        entry = _ibrnet_entry()
+        authors = [
+            {"given": "Qianqian", "family": "Wang"},
+            {"given": "Zhicheng", "family": "Wang"},
+            {"given": "Kyle", "family": "Genova"},
+        ]
+        # The DOI's /works record (and the title search) both return the cited
+        # paper, so the entry VERIFIES (consistency passes, then full match).
+        record = {
+            "message": {
+                "DOI": entry["doi"],
+                "type": "proceedings-article",
+                "title": [entry["title"]],
+                "author": authors,
+                "issued": {"date-parts": [[2021]]},
+            }
+        }
+        routes = {"CVPR46437.2021.00469": record}
+
+        def run(with_warm: bool, sub: str) -> FactCheckStatus:
+            http, _ = _make_http(routes, tmp_path / sub)
+            checker = _checker(http, logger)
+            # Title search returns the same record so the entry can VERIFY.
+            checker.crossref.search = MagicMock(return_value=[record["message"]])  # type: ignore[method-assign]
+            if with_warm:
+                FactCheckProcessor(checker, logger)._batch_warm_crossref_records([entry])
+            return checker.check_entry(entry).status
+
+        cold = run(False, "cold")
+        warm = run(True, "warm")
+        assert cold == warm
+        assert cold == FactCheckStatus.VERIFIED
+
+    def test_unindexed_doi_identical_verdict(self, logger, tmp_path):
+        """A DOI Crossref does not index (the /works fetch 404s consistently) is
+        'cannot determine' for the consistency check -> no flag, both warmed and
+        unwarmed. Warming the 404 cannot change the verdict because the per-entry
+        fetch would have hit the same 404."""
+
+        def run(with_warm: bool, sub: str) -> FactCheckStatus:
+            # No route for this DOI -> every /works GET 404s.
+            http, _ = _make_http({}, tmp_path / sub)
+            checker = _checker(http, logger)
+            entries = [_ibrnet_entry()]
+            if with_warm:
+                FactCheckProcessor(checker, logger)._batch_warm_crossref_records(entries)
+            return checker.check_entry(entries[0]).status
+
+        cold = run(False, "cold")
+        warm = run(True, "warm")
+        assert cold == warm
+        # No candidates from any source (all 404) and no DOI flag -> NOT_FOUND,
+        # the FPR-safe abstention. Identical with/without warming.
+        assert cold == FactCheckStatus.NOT_FOUND
+
+
+class TestPrefetchFailureFallback:
+    """A DOI whose pre-fetch fails (network error / non-200) is simply not cached;
+    the per-entry get_by_doi then performs its own fetch -- correct result, no
+    behavior change for that DOI."""
+
+    def test_failed_warm_still_correct_per_entry(self, logger, tmp_path):
+        """A DOI whose WARM round-trip transiently fails (raises, nothing cached)
+        still gets its correct per-entry verdict once the endpoint is reachable.
+
+        Models a real transient blip: ImageBind's get_by_doi raises during the
+        up-front warm (so the cache is NOT poisoned), then succeeds on the
+        per-entry call. IBRNet warms normally. Both must still flag DOI_MISMATCH.
+        """
+        http, _ = _make_http(
+            {
+                "CVPR46437.2021.00469": _works_payload(
+                    "Delving into Localization Errors for Monocular 3D Object Detection",
+                    "10.1109/CVPR46437.2021.00469",
+                ),
+                "CVPR52729.2023.01457": _works_payload(
+                    "Segment Anything in High Quality", "10.1109/CVPR52729.2023.01457"
+                ),
+            },
+            tmp_path,
+        )
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+
+        # ImageBind's DOI raises during warming only; restored before per-entry.
+        real_get = checker.crossref.get_by_doi
+        warm_phase = {"active": True}
+
+        def flaky(doi: str):
+            if warm_phase["active"] and "CVPR52729" in doi:
+                raise RuntimeError("transient warm failure")
+            return real_get(doi)
+
+        checker.crossref.get_by_doi = MagicMock(side_effect=flaky)  # type: ignore[method-assign]
+
+        warmed = processor._batch_warm_crossref_records([_ibrnet_entry(), _imagebind_entry()])
+        assert warmed == 2  # both attempted; ImageBind's failure swallowed
+
+        # Per-entry phase: the failed-warm DOI now reaches the endpoint and is
+        # fetched correctly -> same DOI_MISMATCH verdict as the warmed one.
+        warm_phase["active"] = False
+        assert checker.check_entry(_ibrnet_entry()).status == FactCheckStatus.DOI_MISMATCH
+        assert checker.check_entry(_imagebind_entry()).status == FactCheckStatus.DOI_MISMATCH
+
+    def test_warm_swallows_get_by_doi_exception(self, logger, tmp_path):
+        """An exception thrown for one DOI during warming never aborts the batch
+        and the entry still gets its correct per-entry verdict."""
+        http, _ = _make_http(
+            {
+                "CVPR46437.2021.00469": _works_payload(
+                    "Delving into Localization Errors for Monocular 3D Object Detection",
+                    "10.1109/CVPR46437.2021.00469",
+                )
+            },
+            tmp_path,
+        )
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+
+        # Make get_by_doi blow up for ImageBind's DOI only, during warming.
+        real_get = checker.crossref.get_by_doi
+
+        def flaky(doi: str):
+            if "CVPR52729" in doi:
+                raise RuntimeError("transient warm failure")
+            return real_get(doi)
+
+        checker.crossref.get_by_doi = MagicMock(side_effect=flaky)  # type: ignore[method-assign]
+
+        # Warming must not raise even though one DOI errors.
+        warmed = processor._batch_warm_crossref_records([_ibrnet_entry(), _imagebind_entry()])
+        assert warmed == 2
+
+        # IBRNet warmed normally -> mismatch verdict from per-entry path.
+        checker.crossref.get_by_doi.side_effect = lambda doi: real_get(doi)
+        assert checker.check_entry(_ibrnet_entry()).status == FactCheckStatus.DOI_MISMATCH

--- a/tests/test_doi_consistency.py
+++ b/tests/test_doi_consistency.py
@@ -1,0 +1,243 @@
+"""Tests for DOI-target consistency checking in ``bibtex-check``.
+
+Regression coverage for the gap where the tool only verified that an entry's
+DOI *resolves* (doi.org HEAD; 404/410 -> DOI_NOT_FOUND) but never that the DOI
+points to the *cited* paper. A copy-paste DOI that resolves to a completely
+different work (e.g. "IBRNet" carrying DOI 10.1109/CVPR46437.2021.00469, which
+belongs to "Delving into Localization Errors for Monocular 3D Object Detection")
+otherwise survived because title/author search VERIFIES the entry against its
+real record. ``_check_doi_consistency`` fetches the DOI's Crossref record and
+flags a clear title mismatch as ``DOI_MISMATCH``.
+
+All tests are hermetic: the Crossref get-by-DOI is mocked to return a controlled
+title (or a failure), no network access.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from bibtex_updater.fact_checker import (
+    ABSTAINED_STATUS_VALUES,
+    CrossrefClient,
+    DBLPClient,
+    FactChecker,
+    FactCheckerConfig,
+    FactCheckProcessor,
+    FactCheckStatus,
+    SemanticScholarClient,
+)
+
+
+def _crossref_message(title: str, doi: str, authors: list[dict] | None = None) -> dict:
+    """Minimal Crossref ``works`` message for ``crossref_message_to_record``."""
+    return {
+        "DOI": doi,
+        "type": "proceedings-article",
+        "title": [title],
+        "author": authors or [{"given": "A", "family": "Author"}],
+    }
+
+
+def _ibrnet_entry() -> dict[str, str]:
+    """IBRNet entry whose DOI actually belongs to a 3D-detection paper."""
+    return {
+        "ID": "ibrnet2021",
+        "ENTRYTYPE": "inproceedings",
+        "title": "IBRNet: Learning Multi-View Image-Based Rendering",
+        "author": "Wang, Qianqian and Wang, Zhicheng and Genova, Kyle",
+        "doi": "10.1109/CVPR46437.2021.00469",
+        "year": "2021",
+    }
+
+
+def _imagebind_entry() -> dict[str, str]:
+    """ImageBind entry carrying a DOI for a different paper."""
+    return {
+        "ID": "imagebind2023",
+        "ENTRYTYPE": "inproceedings",
+        "title": "ImageBind: One Embedding Space To Bind Them All",
+        "author": "Girdhar, Rohit and El-Nouby, Alaaeldin",
+        "doi": "10.1109/CVPR52729.2023.01457",
+        "year": "2023",
+    }
+
+
+class TestDoiConsistency:
+    """An entry whose cited DOI resolves to a *different* paper must be flagged
+    DOI_MISMATCH (positive evidence), not silently VERIFIED against the real
+    paper found by title/author search.
+    """
+
+    def test_ibrnet_wrong_doi_flagged_mismatch(self, dead_sources, logger):
+        crossref, dblp, s2 = dead_sources
+        # DOI resolves to the 3D-detection paper, not IBRNet.
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(
+                "Delving into Localization Errors for Monocular 3D Object Detection",
+                "10.1109/CVPR46437.2021.00469",
+            )
+        )
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(_ibrnet_entry())
+
+        assert result.status == FactCheckStatus.DOI_MISMATCH
+        crossref.get_by_doi.assert_called_once_with("10.1109/CVPR46437.2021.00469")
+        assert result.best_match is not None
+        assert "Localization Errors" in result.best_match.title
+        assert result.errors and "Localization Errors" in result.errors[0]
+
+    def test_doi_mismatch_in_problematic_bucket(self, dead_sources, logger):
+        """DOI_MISMATCH is positive evidence -> problematic, not abstained."""
+        crossref, dblp, s2 = dead_sources
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(
+                "Delving into Localization Errors for Monocular 3D Object Detection",
+                "10.1109/CVPR46437.2021.00469",
+            )
+        )
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+        processor = FactCheckProcessor(checker, logger)
+
+        result = checker.check_entry(_ibrnet_entry())
+        summary = processor.generate_summary([result])
+
+        # Positive evidence, not abstention.
+        assert FactCheckStatus.DOI_MISMATCH.value not in ABSTAINED_STATUS_VALUES
+        assert summary["problematic_count"] == 1
+        assert summary["abstained_count"] == 0
+        assert summary["verified_count"] == 0
+
+    def test_imagebind_wrong_doi_flagged_mismatch(self, dead_sources, logger):
+        crossref, dblp, s2 = dead_sources
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(
+                "Segment Anything in High Quality",
+                "10.1109/CVPR52729.2023.01457",
+            )
+        )
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(_imagebind_entry())
+
+        assert result.status == FactCheckStatus.DOI_MISMATCH
+        assert result.best_match is not None
+        assert "Segment Anything" in result.best_match.title
+
+    def test_correct_doi_not_flagged(self, dead_sources, logger):
+        """A correct DOI resolves to the cited title -> no flag, entry verifies."""
+        crossref, dblp, s2 = dead_sources
+        entry = _ibrnet_entry()
+        authors = [
+            {"given": "Qianqian", "family": "Wang"},
+            {"given": "Zhicheng", "family": "Wang"},
+            {"given": "Kyle", "family": "Genova"},
+        ]
+        matching = _crossref_message(entry["title"], entry["doi"], authors=authors)
+        matching["issued"] = {"date-parts": [[2021]]}
+        # DOI resolves to the same paper (consistency check passes) and the
+        # title search also returns it so the entry VERIFIES.
+        crossref.get_by_doi = MagicMock(return_value=matching)
+        crossref.search = MagicMock(return_value=[matching])
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(entry)
+
+        assert result.status != FactCheckStatus.DOI_MISMATCH
+        assert result.status == FactCheckStatus.VERIFIED
+
+    def test_no_doi_entry_returns_none(self, dead_sources, logger):
+        """An entry without a DOI is never flagged for DOI mismatch."""
+        crossref, dblp, s2 = dead_sources
+        crossref.get_by_doi = MagicMock(return_value=_crossref_message("X", "10.0/x"))
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+        entry = _ibrnet_entry()
+        del entry["doi"]
+
+        assert checker._check_doi_consistency(entry) is None
+        crossref.get_by_doi.assert_not_called()
+
+    def test_fetch_fails_returns_none(self, dead_sources, logger):
+        """A failed/non-200 Crossref fetch (e.g. IEEE bot-block, un-indexed DOI)
+        is 'cannot determine' -> no flag (FPR-safe)."""
+        crossref, dblp, s2 = dead_sources
+        crossref.get_by_doi = MagicMock(return_value=None)
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker._check_doi_consistency(_ibrnet_entry())
+
+        assert result is None
+
+    def test_consistency_check_disabled_by_config(self, dead_sources, logger):
+        """With the guard disabled the wrong DOI is not flagged (opt-out works)."""
+        crossref, dblp, s2 = dead_sources
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message("A Completely Different Paper", "10.0/x")
+        )
+        config = FactCheckerConfig(check_doi_consistency=False)
+        checker = FactChecker(crossref, dblp, s2, config, logger)
+
+        result = checker._check_doi_consistency(_ibrnet_entry())
+
+        assert result is None
+        crossref.get_by_doi.assert_not_called()
+
+
+class TestCrossrefGetByDoi:
+    """The new CrossrefClient.get_by_doi REST helper."""
+
+    def test_returns_message_on_200(self, logger):
+        http = MagicMock()
+        http._request.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"message": {"DOI": "10.0/x", "title": ["Hello"]}},
+        )
+        client = CrossrefClient(http)
+
+        msg = client.get_by_doi("10.0/x")
+
+        assert msg == {"DOI": "10.0/x", "title": ["Hello"]}
+        # Hits the REST /works/{doi} endpoint, not doi.org.
+        called_url = http._request.call_args[0][1]
+        assert "api.crossref.org/works/" in called_url
+
+    def test_returns_none_on_non_200(self, logger):
+        http = MagicMock()
+        http._request.return_value = MagicMock(status_code=404, json=lambda: {})
+        client = CrossrefClient(http)
+
+        assert client.get_by_doi("10.0/x") is None
+
+    def test_returns_none_on_exception(self, logger):
+        http = MagicMock()
+        http._request.side_effect = RuntimeError("boom")
+        client = CrossrefClient(http)
+
+        assert client.get_by_doi("10.0/x") is None
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_doi_consistency")
+
+
+@pytest.fixture
+def empty_http():
+    """HTTP client whose every request looks like a 404/empty result."""
+    mock = MagicMock()
+    mock._request.return_value = MagicMock(status_code=404, json=lambda: {})
+    return mock
+
+
+@pytest.fixture
+def dead_sources(empty_http):
+    """Crossref/DBLP/S2 clients that return nothing by default."""
+    return (
+        CrossrefClient(empty_http),
+        DBLPClient(empty_http),
+        SemanticScholarClient(empty_http),
+    )

--- a/tests/test_doi_consistency.py
+++ b/tests/test_doi_consistency.py
@@ -175,9 +175,7 @@ class TestDoiConsistency:
     def test_consistency_check_disabled_by_config(self, dead_sources, logger):
         """With the guard disabled the wrong DOI is not flagged (opt-out works)."""
         crossref, dblp, s2 = dead_sources
-        crossref.get_by_doi = MagicMock(
-            return_value=_crossref_message("A Completely Different Paper", "10.0/x")
-        )
+        crossref.get_by_doi = MagicMock(return_value=_crossref_message("A Completely Different Paper", "10.0/x"))
         config = FactCheckerConfig(check_doi_consistency=False)
         checker = FactChecker(crossref, dblp, s2, config, logger)
 

--- a/tests/test_doi_consistency.py
+++ b/tests/test_doi_consistency.py
@@ -220,6 +220,106 @@ class TestCrossrefGetByDoi:
         assert client.get_by_doi("10.0/x") is None
 
 
+class TestIdAnchoredAuthorMismatch:
+    """When an entry's own DOI/arXiv-ID resolves to the cited paper (title
+    matches) but the entry lists swapped/placeholder authors, that is positive
+    evidence of author fabrication -> AUTHOR_MISMATCH, not a silent VERIFIED or
+    abstention. Catches the residual slip-through where a hallucinated citation
+    carries a correct identifier but wrong authors. FPR-safe: only a genuine
+    author MISMATCH flags; correct authors verify and legitimate "and others"
+    truncations stay un-flagged.
+    """
+
+    def test_doi_title_match_wrong_authors_flagged(self, dead_sources, logger):
+        crossref, dblp, s2 = dead_sources
+        entry = _ibrnet_entry()
+        # DOI resolves to the SAME paper (title matches) but with different authors.
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(
+                entry["title"],
+                entry["doi"],
+                authors=[{"given": "John", "family": "Doe"}, {"given": "Jane", "family": "Roe"}],
+            )
+        )
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(entry)
+
+        assert result.status == FactCheckStatus.AUTHOR_MISMATCH
+        assert result.best_match is not None and "IBRNet" in result.best_match.title
+        crossref.get_by_doi.assert_called_once_with(entry["doi"])
+
+    def test_doi_title_and_authors_match_verifies(self, dead_sources, logger):
+        crossref, dblp, s2 = dead_sources
+        entry = _ibrnet_entry()
+        authors = [
+            {"given": "Qianqian", "family": "Wang"},
+            {"given": "Zhicheng", "family": "Wang"},
+            {"given": "Kyle", "family": "Genova"},
+        ]
+        matching = _crossref_message(entry["title"], entry["doi"], authors=authors)
+        matching["issued"] = {"date-parts": [[2021]]}
+        crossref.get_by_doi = MagicMock(return_value=matching)
+        crossref.search = MagicMock(return_value=[matching])
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(entry)
+
+        assert result.status != FactCheckStatus.AUTHOR_MISMATCH
+        assert result.status == FactCheckStatus.VERIFIED
+
+    def test_doi_truncated_authors_with_sentinel_not_flagged(self, dead_sources, logger):
+        """A legitimate "...and others" citation against the full author list is
+        consistent-but-incomplete (never a MISMATCH) -> not flagged."""
+        crossref, dblp, s2 = dead_sources
+        entry = _ibrnet_entry()
+        entry["author"] = "Wang, Qianqian and others"
+        authors = [
+            {"given": "Qianqian", "family": "Wang"},
+            {"given": "Zhicheng", "family": "Wang"},
+            {"given": "Kyle", "family": "Genova"},
+        ]
+        matching = _crossref_message(entry["title"], entry["doi"], authors=authors)
+        matching["issued"] = {"date-parts": [[2021]]}
+        crossref.get_by_doi = MagicMock(return_value=matching)
+        crossref.search = MagicMock(return_value=[matching])
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(entry)
+
+        assert result.status != FactCheckStatus.AUTHOR_MISMATCH
+
+    def test_arxiv_id_title_match_wrong_authors_flagged(self, dead_sources, logger):
+        from bibtex_updater.utils import PublishedRecord
+
+        crossref, dblp, s2 = dead_sources
+        entry = {
+            "ID": "node2018",
+            "ENTRYTYPE": "article",
+            "title": "Neural Ordinary Differential Equations",
+            "author": "Doe, John and Roe, Jane",
+            "eprint": "1806.07366",
+            "year": "2018",
+        }
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger, arxiv=MagicMock())
+        # arXiv ID resolves to the real paper (title matches) but wrong authors.
+        checker._arxiv_record = MagicMock(
+            return_value=PublishedRecord(
+                doi=None,
+                title="Neural Ordinary Differential Equations",
+                authors=[
+                    {"given": "Ricky T. Q.", "family": "Chen"},
+                    {"given": "Yulia", "family": "Rubanova"},
+                ],
+                year=2018,
+            )
+        )
+
+        result = checker.check_entry(entry)
+
+        assert result.status == FactCheckStatus.AUTHOR_MISMATCH
+
+
 @pytest.fixture
 def logger():
     return logging.getLogger("test_doi_consistency")

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -245,6 +245,65 @@ class TestFactCheckerFieldComparison:
         comparisons = fact_checker._compare_all_fields(entry, record)
         assert comparisons["venue"].matches is True
 
+    def test_compare_author_subset_not_asymmetric_mismatch(self, fact_checker):
+        """FIX C: entry lists first 3 authors, API record has 8 -> author matches.
+
+        The legacy asymmetric comparison (entry-first-3 vs full-8) scored ~0.375,
+        below author_threshold 0.80, falsely flagging a correctly cited paper.
+        """
+        entry = {
+            "title": "An Image Is Worth 16x16 Words",
+            "author": "Dosovitskiy, Alexey and Beyer, Lucas and Kolesnikov, Alexander",
+        }
+        record = PublishedRecord(
+            doi="10.48550/arXiv.2010.11929",
+            title="An Image Is Worth 16x16 Words",
+            authors=[
+                {"given": "Alexey", "family": "Dosovitskiy"},
+                {"given": "Lucas", "family": "Beyer"},
+                {"given": "Alexander", "family": "Kolesnikov"},
+                {"given": "Dirk", "family": "Weissenborn"},
+                {"given": "Xiaohua", "family": "Zhai"},
+                {"given": "Thomas", "family": "Unterthiner"},
+                {"given": "Mostafa", "family": "Dehghani"},
+                {"given": "Matthias", "family": "Minderer"},
+            ],
+        )
+        comparisons = fact_checker._compare_all_fields(entry, record)
+        assert comparisons["author"].matches is True
+
+    def test_compare_author_and_others_matches(self, fact_checker):
+        """FIX C: 'and others' must not introduce a phantom mismatch author."""
+        entry = {
+            "title": "Test",
+            "author": "Smith, John and Doe, Jane and others",
+        }
+        record = PublishedRecord(
+            doi="",
+            title="Test",
+            authors=[
+                {"given": "John", "family": "Smith"},
+                {"given": "Jane", "family": "Doe"},
+                {"given": "Alan", "family": "Turing"},
+            ],
+        )
+        comparisons = fact_checker._compare_all_fields(entry, record)
+        assert comparisons["author"].matches is True
+
+    def test_compare_different_first_author_still_fails(self, fact_checker):
+        """FIX C: a genuinely wrong lead author must still be flagged."""
+        entry = {"title": "Test", "author": "Wrong, Person and Doe, Jane"}
+        record = PublishedRecord(
+            doi="",
+            title="Test",
+            authors=[
+                {"given": "John", "family": "Smith"},
+                {"given": "Jane", "family": "Doe"},
+            ],
+        )
+        comparisons = fact_checker._compare_all_fields(entry, record)
+        assert comparisons["author"].matches is False
+
 
 class TestFactCheckerStatusDetermination:
     """Tests for FactChecker status determination."""
@@ -867,6 +926,83 @@ class TestDOIValidation:
         assert result.status != FactCheckStatus.DOI_NOT_FOUND
 
 
+# ------------- FIX D: arXiv DOI version-suffix Tests -------------
+
+
+class TestArxivDoiVersionStripping:
+    """FIX D: versioned arXiv DOIs must be version-stripped before resolution."""
+
+    def test_versioned_arxiv_doi_stripped_and_resolves(self, fact_checker):
+        """The versioned arXiv DOI 404s, but the version-stripped one resolves (302).
+
+        We must NOT flag it as DOI_NOT_FOUND.
+        """
+        client = fact_checker.crossref.http.client
+
+        def fake_head(url, headers=None):
+            # The stripped (unversioned) DOI is what should be requested.
+            assert "v1" not in url
+            assert url == "https://doi.org/10.48550/arxiv.2010.11929"
+            return MagicMock(status_code=302)
+
+        client.head.side_effect = fake_head
+        result = fact_checker._validate_doi({"doi": "10.48550/arXiv.2010.11929v1"})
+        assert result is None
+
+    def test_non_arxiv_doi_version_like_suffix_not_stripped(self, fact_checker):
+        """A non-arXiv DOI ending in letter+digit must NOT be version-stripped."""
+        client = fact_checker.crossref.http.client
+        seen = {}
+
+        def fake_head(url, headers=None):
+            seen["url"] = url
+            return MagicMock(status_code=200)
+
+        client.head.side_effect = fake_head
+        fact_checker._validate_doi({"doi": "10.1234/journal.v2"})
+        # The trailing 'v2' must survive (non-arXiv prefix).
+        assert seen["url"] == "https://doi.org/10.1234/journal.v2"
+
+    def test_head_hostile_host_retries_with_get(self, fact_checker):
+        """A 404 to HEAD that resolves on GET must NOT be DOI_NOT_FOUND."""
+        client = fact_checker.crossref.http.client
+        client.head.return_value = MagicMock(status_code=404)
+        client.get.return_value = MagicMock(status_code=206)  # ranged GET success
+        result = fact_checker._validate_doi({"doi": "10.1234/headhostile"})
+        assert result is None
+        client.get.assert_called_once()
+
+    def test_genuinely_missing_doi_still_flagged(self, fact_checker):
+        """404 on both HEAD and GET -> genuinely missing DOI."""
+        client = fact_checker.crossref.http.client
+        client.head.return_value = MagicMock(status_code=404)
+        client.get.return_value = MagicMock(status_code=410)
+        result = fact_checker._validate_doi({"doi": "10.1234/gone"})
+        assert result == FactCheckStatus.DOI_NOT_FOUND
+
+    def test_publisher_block_not_flagged(self, fact_checker):
+        """418/403/429 are publisher blocks, not invalid DOIs."""
+        client = fact_checker.crossref.http.client
+        client.head.return_value = MagicMock(status_code=418)
+        result = fact_checker._validate_doi({"doi": "10.1109/ieee.block"})
+        assert result is None
+
+    def test_batch_validate_strips_arxiv_version(self, processor):
+        """_batch_validate_dois must also version-strip arXiv DOIs."""
+        client = processor.checker.crossref.http.client
+        requested = []
+
+        def fake_head(url, headers=None):
+            requested.append(url)
+            return MagicMock(status_code=302)
+
+        client.head.side_effect = fake_head
+        entries = [{"ID": "vit", "doi": "10.48550/arXiv.2010.11929v1"}]
+        results = processor._batch_validate_dois(entries)
+        assert results["vit"] is True
+        assert requested == ["https://doi.org/10.48550/arxiv.2010.11929"]
+
+
 # ------------- Venue Matching Tests -------------
 
 
@@ -947,6 +1083,82 @@ class TestVenueMatching:
         )
         comparisons = fact_checker._compare_all_fields(entry, record)
         assert comparisons["venue"].matches is False
+
+
+class TestVenueSymmetryAndPreprint:
+    """FIX E-venue: symmetric empty handling + preprint/series non-comparability."""
+
+    def test_empty_api_venue_is_neutral_not_mismatch(self):
+        """Empty API venue (arXiv-indexed record) must NOT hard-fail."""
+        from bibtex_updater.fact_checker import venues_match
+
+        matches, score = venues_match("NeurIPS", "")
+        assert matches is True
+        assert score == 1.0
+
+    def test_empty_entry_venue_is_neutral(self):
+        from bibtex_updater.fact_checker import venues_match
+
+        matches, _ = venues_match("", "NeurIPS")
+        assert matches is True
+
+    def test_arxiv_api_venue_is_non_comparable(self):
+        """A published-conference entry vs an arXiv API venue is not a mismatch."""
+        from bibtex_updater.fact_checker import venues_match
+
+        matches, score = venues_match("NeurIPS", "arXiv preprint arXiv:2010.11929")
+        assert matches is True
+        assert score == 1.0
+
+    def test_corr_api_venue_is_non_comparable(self):
+        from bibtex_updater.fact_checker import venues_match
+
+        matches, _ = venues_match("ICML", "CoRR")
+        assert matches is True
+
+    def test_pmlr_series_is_non_comparable(self):
+        """PMLR is an umbrella series, not a specific venue."""
+        from bibtex_updater.fact_checker import venues_match
+
+        matches, _ = venues_match("ICML", "Proceedings of Machine Learning Research")
+        assert matches is True
+
+    def test_genuinely_different_venues_still_mismatch(self):
+        """Two populated, distinct real venues must still be detectable."""
+        from bibtex_updater.fact_checker import venues_match
+
+        matches, _ = venues_match("NeurIPS", "ICML")
+        assert matches is False
+
+    def test_neurips_full_name_aliases(self):
+        from bibtex_updater.fact_checker import venues_match
+
+        for full in (
+            "Conference on Neural Information Processing Systems",
+            "Annual Conference on Neural Information Processing Systems",
+        ):
+            matches, _ = venues_match("NeurIPS", full)
+            assert matches is True, full
+
+    def test_empty_api_venue_in_field_comparison_no_mismatch(self, fact_checker):
+        """An arXiv-indexed record with blank venue should not produce venue_mismatch."""
+        entry = {
+            "ID": "test",
+            "ENTRYTYPE": "inproceedings",
+            "title": "Attention Is All You Need",
+            "author": "Vaswani, Ashish",
+            "booktitle": "NeurIPS",
+            "year": "2017",
+        }
+        record = PublishedRecord(
+            doi="10.48550/arXiv.1706.03762",
+            title="Attention Is All You Need",
+            authors=[{"given": "Ashish", "family": "Vaswani"}],
+            journal="",  # arXiv-indexed: blank venue
+            year=2017,
+        )
+        comparisons = fact_checker._compare_all_fields(entry, record)
+        assert comparisons["venue"].matches is True
 
 
 class TestNormalizeVenue:

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -315,10 +315,11 @@ class TestFactCheckerCheckEntry:
         assert "No title" in result.errors[0]
 
     def test_entry_not_found(self, fact_checker, sample_entry):
-        # All API clients return empty results by default
+        # All API clients return empty results by default. The cascade now
+        # queries four sources: crossref -> openalex -> dblp -> semanticscholar.
         result = fact_checker.check_entry(sample_entry)
         assert result.status == FactCheckStatus.NOT_FOUND
-        assert len(result.api_sources_queried) == 3
+        assert result.api_sources_queried == ["crossref", "openalex", "dblp", "semanticscholar"]
 
 
 # ------------- FactCheckProcessor Tests -------------

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -578,10 +578,18 @@ class TestFactCheckerCheckEntry:
 
     def test_entry_not_found(self, fact_checker, sample_entry):
         # All API clients return empty results by default. The cascade now
-        # queries four sources: crossref -> openalex -> dblp -> semanticscholar.
+        # queries five sources: crossref -> openalex -> dblp -> openreview ->
+        # semanticscholar (OpenAlex and OpenReview are lazily built from the
+        # shared crossref.http mock).
         result = fact_checker.check_entry(sample_entry)
         assert result.status == FactCheckStatus.NOT_FOUND
-        assert result.api_sources_queried == ["crossref", "openalex", "dblp", "semanticscholar"]
+        assert result.api_sources_queried == [
+            "crossref",
+            "openalex",
+            "dblp",
+            "openreview",
+            "semanticscholar",
+        ]
 
     def test_weak_unrelated_match_abstains(self, fact_checker, monkeypatch):
         # Fix B: the search returns an UNRELATED paper (low best_score). This is

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -318,10 +318,25 @@ class TestFactCheckerStatusDetermination:
         status = fact_checker._determine_status(0.95, comparisons, ["crossref"])
         assert status == FactCheckStatus.VERIFIED
 
-    def test_hallucinated_low_score(self, fact_checker):
+    def test_low_score_abstains_not_hallucinated(self, fact_checker):
+        # Fix B: a weak best match means the title search returned an unrelated
+        # paper -- the tool could not verify, which is NOT positive evidence of
+        # fabrication. It must ABSTAIN (NOT_FOUND), not assert HALLUCINATED.
         comparisons = {"title": FieldComparison("title", "A", "B", 0.3, False)}
         status = fact_checker._determine_status(0.35, comparisons, [])
-        assert status == FactCheckStatus.HALLUCINATED
+        assert status == FactCheckStatus.NOT_FOUND
+
+    def test_wrong_paper_signature_abstains(self, fact_checker):
+        # Above the abstention score threshold, but the title is essentially
+        # unrelated and neither title nor author corroborate -> still abstain.
+        comparisons = {
+            "title": FieldComparison("title", "A", "Z", 0.10, False),
+            "author": FieldComparison("author", "X", "Q", 0.0, False),
+            "year": FieldComparison("year", "2021", "2021", 1.0, True),
+            "venue": FieldComparison("venue", "J", "J", 1.0, True),
+        }
+        status = fact_checker._determine_status(0.55, comparisons, ["crossref"])
+        assert status == FactCheckStatus.NOT_FOUND
 
     def test_title_mismatch_only(self, fact_checker):
         comparisons = {
@@ -364,6 +379,98 @@ class TestFactCheckerStatusDetermination:
         assert status == FactCheckStatus.PARTIAL_MATCH
 
 
+class TestDetectionRatePreservation:
+    """Fix B guard: positive-evidence hallucination signals must STILL yield
+    HALLUCINATED. These signals fire *before* ``_determine_status`` (in
+    ``check_entry``), so the new abstention rule cannot suppress them.
+    """
+
+    def test_future_date_still_flagged(self, fact_checker):
+        # _validate_year runs before any title search / score gate.
+        entry = {
+            "ID": "future",
+            "ENTRYTYPE": "article",
+            "title": "Some Real Title",
+            "author": "Smith, John",
+            "year": "2099",
+        }
+        result = fact_checker.check_entry(entry)
+        assert result.status == FactCheckStatus.FUTURE_DATE
+        assert result.status != FactCheckStatus.NOT_FOUND
+
+    def test_invalid_year_still_flagged(self, fact_checker):
+        entry = {
+            "ID": "badyear",
+            "ENTRYTYPE": "article",
+            "title": "Some Real Title",
+            "author": "Smith, John",
+            "year": "1500",
+        }
+        result = fact_checker.check_entry(entry)
+        assert result.status == FactCheckStatus.INVALID_YEAR
+        assert result.status != FactCheckStatus.NOT_FOUND
+
+    def test_fabricated_doi_still_flagged(self, fact_checker):
+        # Pre-validated DOI map marks the DOI invalid (404/410). _validate_doi
+        # returns DOI_NOT_FOUND before the title search runs.
+        entry = {
+            "ID": "fakedoi",
+            "ENTRYTYPE": "article",
+            "title": "Some Real Title",
+            "author": "Smith, John",
+            "year": "2020",
+            "doi": "10.9999/totally.made.up",
+        }
+        result = fact_checker.check_entry(entry, pre_validated_dois={"fakedoi": False})
+        assert result.status == FactCheckStatus.DOI_NOT_FOUND
+        assert result.status != FactCheckStatus.NOT_FOUND
+
+    def test_chimeric_title_still_flagged(self, fact_checker, monkeypatch):
+        # Chimeric detection fires on positive cross-source evidence BEFORE the
+        # candidate sort and score gate. Force the cascade to return two records
+        # from two sources whose titles each contribute distinct token sets that
+        # the entry title borrows from.
+        entry = {
+            "ID": "chimera",
+            "ENTRYTYPE": "article",
+            # Borrows "attention transformers sequence modeling" from one paper
+            # and "graph convolutional molecular property prediction" from
+            # another (>= 4 shared tokens per source, so the chimeric detector
+            # fires -- which is the point of this DR-preservation guard).
+            "title": "Attention Transformers Sequence Modeling Graph Convolutional Molecular Property Prediction",
+            "author": "Smith, John",
+            "year": "2020",
+        }
+        rec_a = PublishedRecord(
+            doi="10.1/a",
+            title="Attention Transformers Sequence Modeling Translation",
+            authors=[{"given": "John", "family": "Smith"}],
+            journal="JMLR",
+            year=2020,
+        )
+        rec_b = PublishedRecord(
+            doi="10.1/b",
+            title="Graph Convolutional Molecular Property Prediction Networks",
+            authors=[{"given": "Jane", "family": "Doe"}],
+            journal="NeurIPS",
+            year=2020,
+        )
+
+        def fake_cascade(entry, query, sq, sh, errors):
+            sq.extend(["crossref", "dblp"])
+            sh.extend(["crossref", "dblp"])
+            return [
+                (fact_checker._score_candidate(query, ["smith"], rec_a), rec_a, "crossref"),
+                (fact_checker._score_candidate(query, ["smith"], rec_b), rec_b, "dblp"),
+            ]
+
+        monkeypatch.setattr(fact_checker, "_query_cascade", fake_cascade)
+        monkeypatch.setattr(fact_checker, "_query_arxiv_by_id", lambda *a, **k: [])
+        result = fact_checker.check_entry(entry)
+        assert result.status == FactCheckStatus.HALLUCINATED
+        assert result.status != FactCheckStatus.NOT_FOUND
+
+
 class TestFactCheckerCheckEntry:
     """Tests for FactChecker.check_entry method."""
 
@@ -379,6 +486,36 @@ class TestFactCheckerCheckEntry:
         result = fact_checker.check_entry(sample_entry)
         assert result.status == FactCheckStatus.NOT_FOUND
         assert result.api_sources_queried == ["crossref", "openalex", "dblp", "semanticscholar"]
+
+    def test_weak_unrelated_match_abstains(self, fact_checker, monkeypatch):
+        # Fix B: the search returns an UNRELATED paper (low best_score). This is
+        # a failed lookup, not positive evidence of fabrication -> NOT_FOUND,
+        # never HALLUCINATED.
+        entry = {
+            "ID": "weak",
+            "ENTRYTYPE": "article",
+            "title": "A Very Specific Real Paper Title That Was Not Indexed",
+            "author": "Smith, John",
+            "year": "2020",
+        }
+        unrelated = PublishedRecord(
+            doi="10.1/unrelated",
+            title="Completely Different Topic About Quantum Chromodynamics",
+            authors=[{"given": "Zed", "family": "Other"}],
+            journal="Physics Today",
+            year=2019,
+        )
+
+        def fake_cascade(entry, query, sq, sh, errors):
+            sq.append("crossref")
+            sh.append("crossref")
+            return [(fact_checker._score_candidate(query, ["smith"], unrelated), unrelated, "crossref")]
+
+        monkeypatch.setattr(fact_checker, "_query_cascade", fake_cascade)
+        monkeypatch.setattr(fact_checker, "_query_arxiv_by_id", lambda *a, **k: [])
+        result = fact_checker.check_entry(entry)
+        assert result.status == FactCheckStatus.NOT_FOUND
+        assert result.status != FactCheckStatus.HALLUCINATED
 
 
 # ------------- FactCheckProcessor Tests -------------
@@ -434,7 +571,12 @@ class TestFactCheckProcessor:
         assert summary["status_counts"]["verified"] == 1
         assert summary["status_counts"]["not_found"] == 1
         assert summary["status_counts"]["hallucinated"] == 1
-        assert summary["problematic_count"] == 2
+        # Fix B: not_found is now an ABSTENTION ("could not verify"), reported
+        # separately from PROBLEMATIC (positive evidence). Only the hallucinated
+        # entry is problematic; the not_found entry is abstained.
+        assert summary["problematic_count"] == 1
+        assert summary["abstained_count"] == 1
+        assert summary["verified_count"] == 1
 
     def test_generate_json_report(self, processor, sample_published_record):
         results = [

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -17,6 +17,7 @@ from bibtex_updater.fact_checker import (
     FactCheckStatus,
     FieldComparison,
     SemanticScholarClient,
+    build_verification_result,
 )
 from bibtex_updater.matching import MatchOutcome
 from bibtex_updater.utils import PublishedRecord
@@ -611,6 +612,177 @@ class TestFactCheckerCheckEntry:
         result = fact_checker.check_entry(entry)
         assert result.status == FactCheckStatus.NOT_FOUND
         assert result.status != FactCheckStatus.HALLUCINATED
+
+
+# ------------- Thread-safety of per-entry state -------------
+
+
+class TestCheckEntryThreadSafety:
+    """check_entry runs concurrently across a ThreadPoolExecutor (see
+    FactCheckProcessor.process_entries). Per-entry verification state (the
+    cross-source author intersection and the per-source records) must therefore
+    live on each FactCheckResult, NOT on the shared FactChecker instance, or
+    concurrent entries clobber each other and produce nondeterministic verdicts.
+    """
+
+    @staticmethod
+    def _matching_record(entry: dict) -> PublishedRecord:
+        """Build a record that matches an entry exactly (so it VERIFIES)."""
+        # surname -> {"given","family"} so the author intersection is non-trivial
+        # and entry-specific.
+        family = entry["author"].split(",")[0].strip()
+        return PublishedRecord(
+            doi=f"10.9999/{entry['ID']}",
+            title=entry["title"],
+            authors=[{"given": "A", "family": family}],
+            journal=entry["journal"],
+            year=int(entry["year"]),
+        )
+
+    def _install_per_entry_cascade(self, checker, monkeypatch, barrier=None):
+        """Stub the cascade so each entry resolves to its OWN matching record.
+
+        If ``barrier`` is given, every worker blocks on it inside the cascade so
+        all entries are guaranteed to be *interleaved* inside check_entry at the
+        same time -- the exact window where shared-instance state would race.
+        """
+
+        def fake_cascade(entry, query, sq, sh, errors):
+            sq.append("crossref")
+            sh.append("crossref")
+            rec = self._matching_record(entry)
+            if barrier is not None:
+                # Force all workers to sit inside check_entry simultaneously.
+                barrier.wait(timeout=10)
+            return [(0.99, rec, "crossref")]
+
+        monkeypatch.setattr(checker, "_query_cascade", fake_cascade)
+        monkeypatch.setattr(checker, "_query_arxiv_by_id", lambda *a, **k: [])
+
+    @staticmethod
+    def _entry(i: int) -> dict:
+        return {
+            "ID": f"entry{i}",
+            "ENTRYTYPE": "article",
+            "title": f"Unique Paper Title Number {i}",
+            "author": f"Surname{i}, Given",
+            "journal": f"Journal {i}",
+            "year": str(2000 + (i % 20)),
+        }
+
+    def test_no_per_entry_state_left_on_instance(self, fact_checker, monkeypatch):
+        """After check_entry, nothing entry-specific lives on the shared self."""
+        self._install_per_entry_cascade(fact_checker, monkeypatch)
+        result = fact_checker.check_entry(self._entry(1))
+        assert result.status == FactCheckStatus.VERIFIED
+        # The old racy attributes must be gone entirely.
+        assert not hasattr(fact_checker, "last_author_intersection")
+        assert not hasattr(fact_checker, "last_source_records")
+        # Per-entry state rides on the result instead.
+        assert result.source_records  # populated
+        assert "crossref" in result.source_records
+        assert result.author_intersection is not None
+
+    def test_result_carries_its_own_records(self, fact_checker, monkeypatch):
+        """Each result's source_records/intersection describe ITS entry."""
+        self._install_per_entry_cascade(fact_checker, monkeypatch)
+        r3 = fact_checker.check_entry(self._entry(3))
+        r7 = fact_checker.check_entry(self._entry(7))
+        # The per-source record for each result is the one matching its entry.
+        assert r3.source_records["crossref"].doi == "10.9999/entry3"
+        assert r7.source_records["crossref"].doi == "10.9999/entry7"
+        # A sequential second call must not have mutated the first result.
+        assert r3.source_records["crossref"].doi == "10.9999/entry3"
+
+    def test_concurrent_check_entry_no_cross_contamination(self, fact_checker, monkeypatch):
+        """Interleaved concurrent check_entry calls must not cross-contaminate
+        the per-entry records, the intersection, or the rich VerificationResult.
+        """
+        import concurrent.futures
+        import threading
+
+        n = 16
+        entries = [self._entry(i) for i in range(n)]
+        # Barrier forces all n workers to be *inside* check_entry simultaneously,
+        # maximizing the chance a shared-state bug would surface.
+        barrier = threading.Barrier(n)
+        self._install_per_entry_cascade(fact_checker, monkeypatch, barrier=barrier)
+
+        def run(entry):
+            res = fact_checker.check_entry(entry)
+            rich = build_verification_result(res)
+            return entry["ID"], res, rich
+
+        out: dict[str, tuple] = {}
+        with concurrent.futures.ThreadPoolExecutor(max_workers=n) as ex:
+            for key, res, rich in ex.map(run, entries):
+                out[key] = (res, rich)
+
+        assert len(out) == n
+        for i in range(n):
+            key = f"entry{i}"
+            res, rich = out[key]
+            assert res.status == FactCheckStatus.VERIFIED, key
+            # Each result's source record matches its OWN entry (the bug would
+            # leave a sibling entry's record here).
+            assert res.source_records["crossref"].doi == f"10.9999/{key}", key
+            # The rich result, built from res alone (no self.last_*), is entry-
+            # specific: it reflects this entry's own matched metadata.
+            assert rich.bibtex_key == key
+            assert rich.matched_metadata is not None
+            assert rich.matched_metadata["doi"] == f"10.9999/{key}", key
+
+        # And the shared instance still holds no per-entry leftovers.
+        assert not hasattr(fact_checker, "last_author_intersection")
+        assert not hasattr(fact_checker, "last_source_records")
+
+    def test_arxiv_record_cache_is_thread_safe(self, fact_checker, monkeypatch):
+        """The cross-entry arXiv memo is guarded: concurrent lookups of distinct
+        IDs all populate the cache without losing entries, the fetch runs outside
+        the lock, and a given ID is fetched at most once.
+        """
+        import concurrent.futures
+        import threading
+
+        # Real ArxivClient is None on the fixture; install a fake that records
+        # how many times each ID is fetched (a cache miss == one fetch).
+        fetch_counts: dict[str, int] = {}
+        counts_lock = threading.Lock()
+
+        class _FakeArxiv:
+            def fetch_atom(self, arxiv_id: str) -> str:
+                with counts_lock:
+                    fetch_counts[arxiv_id] = fetch_counts.get(arxiv_id, 0) + 1
+                # Return a minimal value; parsing is monkeypatched below.
+                return f"<atom>{arxiv_id}</atom>"
+
+        fact_checker.arxiv = _FakeArxiv()
+        # Parse step: map the xml back to a per-id record (no real XML needed).
+        monkeypatch.setattr(
+            "bibtex_updater.fact_checker.arxiv_atom_to_record",
+            lambda xml: PublishedRecord(doi=None, title=xml, authors=[]),
+        )
+
+        ids = [f"2401.{i:05d}" for i in range(8)]
+        # Hammer each ID from several threads at once -> exercises the double-
+        # checked insert: at most one fetch per ID despite the concurrency.
+        tasks = ids * 6
+
+        def run(arxiv_id):
+            return arxiv_id, fact_checker._arxiv_record(arxiv_id)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=12) as ex:
+            results = list(ex.map(run, tasks))
+
+        # Every lookup returned the correct per-id record.
+        for arxiv_id, rec in results:
+            assert rec is not None
+            assert rec.title == f"<atom>{arxiv_id}</atom>"
+        # The cache holds exactly the distinct IDs, none lost to races.
+        assert set(fact_checker._arxiv_record_cache.keys()) == set(ids)
+        # Each distinct ID was fetched at most once despite 6x concurrent hits.
+        for arxiv_id in ids:
+            assert fetch_counts[arxiv_id] == 1, (arxiv_id, fetch_counts[arxiv_id])
 
 
 # ------------- FactCheckProcessor Tests -------------

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -873,9 +873,7 @@ class TestFactCheckProcessor:
         # problematic = partial_match (now included so buckets fully partition)
         assert summary["problematic_count"] == 1
         # All four entries are accounted for across the three buckets.
-        assert (
-            summary["verified_count"] + summary["abstained_count"] + summary["problematic_count"] == summary["total"]
-        )
+        assert summary["verified_count"] + summary["abstained_count"] + summary["problematic_count"] == summary["total"]
 
     def test_generate_json_report(self, processor, sample_published_record):
         results = [

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -18,6 +18,7 @@ from bibtex_updater.fact_checker import (
     FieldComparison,
     SemanticScholarClient,
 )
+from bibtex_updater.matching import MatchOutcome
 from bibtex_updater.utils import PublishedRecord
 
 # ------------- Fixtures -------------
@@ -239,18 +240,49 @@ class TestFactCheckerFieldComparison:
         comparisons = fact_checker._compare_all_fields(entry, record)
         assert comparisons["year"].matches is False
 
-    def test_compare_missing_venue_allowed(self, fact_checker):
-        entry = {"title": "Test", "author": "Author"}  # No journal
+    def test_compare_no_venue_claim_is_vacuously_confirmed(self, fact_checker):
+        """Entry makes NO venue claim -> nothing to confirm -> vacuous MATCH.
+
+        A preprint @misc/@article with no journal/booktitle must not be blocked
+        from VERIFIED just because it omits a venue: there is no claim to verify.
+        """
+        from bibtex_updater.matching import MatchOutcome
+
+        entry = {"title": "Test", "author": "Author"}  # No journal/booktitle
         record = PublishedRecord(doi="", title="Test", journal="Some Journal")
         comparisons = fact_checker._compare_all_fields(entry, record)
-        assert comparisons["venue"].matches is True
+        venue = comparisons["venue"]
+        assert venue.outcome is MatchOutcome.MATCH
+        assert venue.matches is True
 
-    def test_compare_author_subset_not_asymmetric_mismatch(self, fact_checker):
-        """FIX C: entry lists first 3 authors, API record has 8 -> author matches.
+    def test_compare_claimed_venue_vs_preprint_record_is_non_comparable(self, fact_checker):
+        """Entry CLAIMS a published venue but the record is preprint-only ->
+        NON_COMPARABLE: not a mismatch, but not a positive confirmation either."""
+        from bibtex_updater.matching import MatchOutcome
 
-        The legacy asymmetric comparison (entry-first-3 vs full-8) scored ~0.375,
-        below author_threshold 0.80, falsely flagging a correctly cited paper.
+        entry = {"title": "Test", "author": "Smith, John", "booktitle": "NeurIPS"}
+        record = PublishedRecord(
+            doi="",
+            title="Test",
+            authors=[{"given": "John", "family": "Smith"}],
+            journal="arXiv preprint arXiv:2010.11929",
+        )
+        comparisons = fact_checker._compare_all_fields(entry, record)
+        venue = comparisons["venue"]
+        assert venue.outcome is MatchOutcome.NON_COMPARABLE
+        assert venue.is_mismatch is False
+        assert venue.matches is False  # cannot confirm the claimed published venue
+
+    def test_compare_author_subset_without_sentinel_is_partial(self, fact_checker):
+        """FIX C / positive-confirmation: entry lists first 3 of 8 authors with no
+        elision sentinel -> consistent but INCOMPLETE -> PARTIAL, not a full match.
+
+        The legacy asymmetric comparison scored ~0.375 (false mismatch); the prior
+        softening folded this into a full match. A silent leading subset is now a
+        PARTIAL confirmation: not a mismatch, but not a positive confirmation either.
         """
+        from bibtex_updater.matching import MatchOutcome
+
         entry = {
             "title": "An Image Is Worth 16x16 Words",
             "author": "Dosovitskiy, Alexey and Beyer, Lucas and Kolesnikov, Alexander",
@@ -270,7 +302,10 @@ class TestFactCheckerFieldComparison:
             ],
         )
         comparisons = fact_checker._compare_all_fields(entry, record)
-        assert comparisons["author"].matches is True
+        author = comparisons["author"]
+        assert author.outcome is MatchOutcome.PARTIAL
+        assert author.is_mismatch is False
+        assert author.matches is False  # incomplete is NOT a full confirmation
 
     def test_compare_author_and_others_matches(self, fact_checker):
         """FIX C: 'and others' must not introduce a phantom mismatch author."""
@@ -377,6 +412,66 @@ class TestFactCheckerStatusDetermination:
         }
         status = fact_checker._determine_status(0.70, comparisons, ["crossref"])
         assert status == FactCheckStatus.PARTIAL_MATCH
+
+
+class TestPositiveConfirmationGate:
+    """VERIFIED requires positive confirmation of EVERY claimed field.
+
+    A field that is neither a confirmed MATCH nor a real MISMATCH
+    (NON_COMPARABLE venue / PARTIAL author) must route to UNCONFIRMED -- a
+    could-not-verify abstention -- not VERIFIED and not a *_MISMATCH.
+    """
+
+    def _confirmed(self, name):
+        return FieldComparison(name, "x", "x", 1.0, True, outcome=MatchOutcome.MATCH)
+
+    def test_non_comparable_venue_routes_to_unconfirmed(self, fact_checker):
+        comparisons = {
+            "title": self._confirmed("title"),
+            "author": self._confirmed("author"),
+            "year": self._confirmed("year"),
+            "venue": FieldComparison("venue", "NeurIPS", "", 1.0, False, outcome=MatchOutcome.NON_COMPARABLE),
+        }
+        status = fact_checker._determine_status(0.95, comparisons, ["crossref"])
+        assert status == FactCheckStatus.UNCONFIRMED
+
+    def test_partial_author_routes_to_unconfirmed(self, fact_checker):
+        comparisons = {
+            "title": self._confirmed("title"),
+            "author": FieldComparison("author", "a,b", "a,b,c,d", 1.0, False, outcome=MatchOutcome.PARTIAL),
+            "year": self._confirmed("year"),
+            "venue": self._confirmed("venue"),
+        }
+        status = fact_checker._determine_status(0.95, comparisons, ["crossref"])
+        assert status == FactCheckStatus.UNCONFIRMED
+
+    def test_all_confirmed_is_verified(self, fact_checker):
+        comparisons = {
+            "title": self._confirmed("title"),
+            "author": self._confirmed("author"),
+            "year": self._confirmed("year"),
+            "venue": self._confirmed("venue"),
+        }
+        status = fact_checker._determine_status(0.95, comparisons, ["crossref"])
+        assert status == FactCheckStatus.VERIFIED
+
+    def test_real_venue_mismatch_beats_unconfirmed(self, fact_checker):
+        """A real MISMATCH is positive evidence -> PROBLEMATIC, taking priority
+        over a co-occurring non-confirming field."""
+        comparisons = {
+            "title": self._confirmed("title"),
+            "author": self._confirmed("author"),
+            "year": self._confirmed("year"),
+            "venue": FieldComparison("venue", "NeurIPS", "ICML", 0.0, False, outcome=MatchOutcome.MISMATCH),
+        }
+        status = fact_checker._determine_status(0.95, comparisons, ["crossref"])
+        assert status == FactCheckStatus.VENUE_MISMATCH
+
+    def test_unconfirmed_is_an_abstention_not_a_problem(self):
+        """UNCONFIRMED belongs in the could-not-verify (abstained) bucket."""
+        from bibtex_updater.fact_checker import _is_abstained_status
+
+        assert _is_abstained_status(FactCheckStatus.UNCONFIRMED) is True
 
 
 class TestDetectionRatePreservation:
@@ -577,6 +672,30 @@ class TestFactCheckProcessor:
         assert summary["problematic_count"] == 1
         assert summary["abstained_count"] == 1
         assert summary["verified_count"] == 1
+
+    def test_summary_buckets_partition_unconfirmed_and_partial(self, processor, sample_published_record):
+        """The three buckets must partition all entries: UNCONFIRMED -> could-not-
+        verify (abstained); PARTIAL_MATCH -> problematic; VERIFIED -> verified."""
+
+        def _r(key, status):
+            return FactCheckResult(key, "article", status, 0.7, {}, None, ["crossref"], ["crossref"], [])
+
+        results = [
+            _r("v", FactCheckStatus.VERIFIED),
+            _r("u", FactCheckStatus.UNCONFIRMED),
+            _r("p", FactCheckStatus.PARTIAL_MATCH),
+            _r("n", FactCheckStatus.NOT_FOUND),
+        ]
+        summary = processor.generate_summary(results)
+        assert summary["verified_count"] == 1
+        # could-not-verify = unconfirmed + not_found
+        assert summary["abstained_count"] == 2
+        # problematic = partial_match (now included so buckets fully partition)
+        assert summary["problematic_count"] == 1
+        # All four entries are accounted for across the three buckets.
+        assert (
+            summary["verified_count"] + summary["abstained_count"] + summary["problematic_count"] == summary["total"]
+        )
 
     def test_generate_json_report(self, processor, sample_published_record):
         results = [
@@ -1149,62 +1268,72 @@ class TestArxivDoiVersionStripping:
 
 
 class TestVenueMatching:
-    """Tests for venue matching with aliases."""
+    """Tests for venue matching with aliases (now three-valued)."""
 
     def test_exact_match(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("NeurIPS", "NeurIPS")
-        assert matches is True
+        result = venues_match("NeurIPS", "NeurIPS")
+        assert result.outcome is MatchOutcome.MATCH
+        assert result.is_confirmed is True
 
     def test_alias_match_neurips(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("NeurIPS", "Advances in Neural Information Processing Systems")
-        assert matches is True
-        assert score >= 0.90
+        result = venues_match("NeurIPS", "Advances in Neural Information Processing Systems")
+        assert result.outcome is MatchOutcome.MATCH
+        assert result.score >= 0.90
 
     def test_alias_match_nips_neurips(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("NIPS", "NeurIPS")
-        assert matches is True
+        assert venues_match("NIPS", "NeurIPS").outcome is MatchOutcome.MATCH
 
     def test_alias_match_icml(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("ICML", "International Conference on Machine Learning")
-        assert matches is True
+        assert venues_match("ICML", "International Conference on Machine Learning").outcome is MatchOutcome.MATCH
 
     def test_different_venues(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("NeurIPS", "ICML")
-        assert matches is False
+        result = venues_match("NeurIPS", "ICML")
+        assert result.outcome is MatchOutcome.MISMATCH
+        assert result.is_mismatch is True
 
     def test_empty_entry_venue(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("", "NeurIPS")
-        assert matches is True  # No claim = no mismatch
+        # No claim on one side -> non-comparable (NOT a positive confirmation).
+        result = venues_match("", "NeurIPS")
+        assert result.outcome is MatchOutcome.NON_COMPARABLE
+        assert result.is_confirmed is False
 
     def test_proceedings_prefix_stripped(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match(
+        result = venues_match(
             "Proceedings of NeurIPS 2023",
             "Advances in Neural Information Processing Systems",
         )
-        assert matches is True
+        assert result.outcome is MatchOutcome.MATCH
 
     def test_wrong_venue_detected(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match(
+        result = venues_match(
             "IEEE Conference on Computer Vision and Pattern Recognition",
             "IEEE International Conference on Computer Vision",
         )
-        assert matches is False
+        assert result.outcome is MatchOutcome.MISMATCH
 
     def test_venue_in_fact_checker(self, fact_checker):
         """Venue mismatch detected in field comparison."""
@@ -1228,62 +1357,76 @@ class TestVenueMatching:
 
 
 class TestVenueSymmetryAndPreprint:
-    """FIX E-venue: symmetric empty handling + preprint/series non-comparability."""
+    """FIX E-venue: symmetric empty handling + preprint/series non-comparability.
 
-    def test_empty_api_venue_is_neutral_not_mismatch(self):
-        """Empty API venue (arXiv-indexed record) must NOT hard-fail."""
+    Non-comparable cases are now distinguished from positive confirmation: a
+    blank or preprint-only record cannot CONFIRM the claimed published venue, so
+    it returns NON_COMPARABLE (not MATCH and not MISMATCH).
+    """
+
+    def test_empty_api_venue_is_non_comparable_not_mismatch(self):
+        """Empty API venue (arXiv-indexed record) must NOT hard-fail as mismatch."""
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("NeurIPS", "")
-        assert matches is True
-        assert score == 1.0
+        result = venues_match("NeurIPS", "")
+        assert result.outcome is MatchOutcome.NON_COMPARABLE
+        assert result.is_mismatch is False
+        assert result.is_confirmed is False
 
-    def test_empty_entry_venue_is_neutral(self):
+    def test_empty_entry_venue_is_non_comparable(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, _ = venues_match("", "NeurIPS")
-        assert matches is True
+        assert venues_match("", "NeurIPS").outcome is MatchOutcome.NON_COMPARABLE
 
     def test_arxiv_api_venue_is_non_comparable(self):
-        """A published-conference entry vs an arXiv API venue is not a mismatch."""
+        """A published-conference entry vs an arXiv API venue is non-comparable."""
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, score = venues_match("NeurIPS", "arXiv preprint arXiv:2010.11929")
-        assert matches is True
-        assert score == 1.0
+        result = venues_match("NeurIPS", "arXiv preprint arXiv:2010.11929")
+        assert result.outcome is MatchOutcome.NON_COMPARABLE
+        assert result.is_confirmed is False
 
     def test_corr_api_venue_is_non_comparable(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, _ = venues_match("ICML", "CoRR")
-        assert matches is True
+        assert venues_match("ICML", "CoRR").outcome is MatchOutcome.NON_COMPARABLE
 
     def test_pmlr_series_is_non_comparable(self):
         """PMLR is an umbrella series, not a specific venue."""
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, _ = venues_match("ICML", "Proceedings of Machine Learning Research")
-        assert matches is True
+        assert venues_match("ICML", "Proceedings of Machine Learning Research").outcome is MatchOutcome.NON_COMPARABLE
 
     def test_genuinely_different_venues_still_mismatch(self):
         """Two populated, distinct real venues must still be detectable."""
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
-        matches, _ = venues_match("NeurIPS", "ICML")
-        assert matches is False
+        assert venues_match("NeurIPS", "ICML").outcome is MatchOutcome.MISMATCH
 
     def test_neurips_full_name_aliases(self):
         from bibtex_updater.fact_checker import venues_match
+        from bibtex_updater.matching import MatchOutcome
 
         for full in (
             "Conference on Neural Information Processing Systems",
             "Annual Conference on Neural Information Processing Systems",
         ):
-            matches, _ = venues_match("NeurIPS", full)
-            assert matches is True, full
+            assert venues_match("NeurIPS", full).outcome is MatchOutcome.MATCH, full
 
-    def test_empty_api_venue_in_field_comparison_no_mismatch(self, fact_checker):
-        """An arXiv-indexed record with blank venue should not produce venue_mismatch."""
+    def test_empty_api_venue_in_field_comparison_not_mismatch(self, fact_checker):
+        """An arXiv-indexed record with blank venue must NOT produce venue_mismatch.
+
+        It is non-comparable: not a confirmed match (so ``matches`` is False), but
+        also not a mismatch -- the verdict routes to UNCONFIRMED, not VENUE_MISMATCH.
+        """
+        from bibtex_updater.matching import MatchOutcome
+
         entry = {
             "ID": "test",
             "ENTRYTYPE": "inproceedings",
@@ -1300,7 +1443,10 @@ class TestVenueSymmetryAndPreprint:
             year=2017,
         )
         comparisons = fact_checker._compare_all_fields(entry, record)
-        assert comparisons["venue"].matches is True
+        venue = comparisons["venue"]
+        assert venue.outcome is MatchOutcome.NON_COMPARABLE
+        assert venue.is_mismatch is False
+        assert venue.matches is False  # non-comparable is NOT a positive confirmation
 
 
 class TestNormalizeVenue:

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -411,3 +411,215 @@ class TestExpandedVenueAliases:
         db_venues = ["sigmod", "vldb", "icde"]
         for venue in db_venues:
             assert venue in EXPANDED_VENUE_ALIASES, f"{venue} should be in alias map"
+
+
+class TestVenueAliasExpansion:
+    """Same venue written differently must canonicalize identically.
+
+    Each entry maps a canonical key to a list of spellings (acronym, long form,
+    numbered/dated proceedings, publisher-decorated forms) that should ALL
+    resolve to that single canonical venue.
+    """
+
+    # canonical -> variant spellings that must all map to it
+    _SAME_VENUE = {
+        "neurips": [
+            "NeurIPS",
+            "NIPS",
+            "Advances in Neural Information Processing Systems",
+            "Conference on Neural Information Processing Systems",
+            "Advances in Neural Information Processing Systems 36 (NeurIPS 2023)",
+            "The 36th Conference on Neural Information Processing Systems",
+        ],
+        "icml": [
+            "ICML",
+            "International Conference on Machine Learning",
+            "Proceedings of the 40th International Conference on Machine Learning",
+            "Proceedings of the 40th International Conference on Machine Learning, PMLR",
+        ],
+        "iclr": [
+            "ICLR",
+            "International Conference on Learning Representations",
+            "Proceedings of the International Conference on Learning Representations",
+        ],
+        "cvpr": [
+            "CVPR",
+            "IEEE Conference on Computer Vision and Pattern Recognition",
+            "IEEE/CVF Conference on Computer Vision and Pattern Recognition",
+            "Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern Recognition",
+        ],
+        "iccv": [
+            "ICCV",
+            "IEEE International Conference on Computer Vision",
+            "IEEE/CVF International Conference on Computer Vision",
+            "Proceedings of the IEEE/CVF International Conference on Computer Vision",
+        ],
+        "eccv": [
+            "ECCV",
+            "European Conference on Computer Vision",
+        ],
+        "aaai": [
+            "AAAI",
+            "AAAI Conference on Artificial Intelligence",
+            "Proceedings of the AAAI Conference on Artificial Intelligence",
+        ],
+        "acl": [
+            "ACL",
+            "Annual Meeting of the Association for Computational Linguistics",
+            "Findings of ACL",
+            "Findings of the Association for Computational Linguistics: ACL 2023",
+        ],
+        "emnlp": [
+            "EMNLP",
+            "Conference on Empirical Methods in Natural Language Processing",
+            "Findings of EMNLP",
+            "Findings of the Association for Computational Linguistics: EMNLP 2023",
+        ],
+        "naacl": [
+            "NAACL",
+            "NAACL-HLT",
+            "North American Chapter of the Association for Computational Linguistics",
+            "Findings of NAACL",
+        ],
+        "eacl": [
+            "EACL",
+            "Conference of the European Chapter of the Association for Computational Linguistics",
+            "Findings of EACL",
+        ],
+        "coling": [
+            "COLING",
+            "International Conference on Computational Linguistics",
+        ],
+        "kdd": [
+            "KDD",
+            "SIGKDD",
+            "ACM SIGKDD",
+            "ACM SIGKDD Conference on Knowledge Discovery and Data Mining",
+        ],
+        "ijcai": [
+            "IJCAI",
+            "International Joint Conference on Artificial Intelligence",
+        ],
+        "uai": [
+            "UAI",
+            "Conference on Uncertainty in Artificial Intelligence",
+        ],
+        "aistats": [
+            "AISTATS",
+            "International Conference on Artificial Intelligence and Statistics",
+        ],
+        "colt": [
+            "COLT",
+            "Conference on Learning Theory",
+        ],
+        "interspeech": [
+            "INTERSPEECH",
+            "Conference of the International Speech Communication Association",
+        ],
+        "icassp": [
+            "ICASSP",
+            "IEEE International Conference on Acoustics, Speech and Signal Processing",
+        ],
+        "sigir": [
+            "SIGIR",
+            "International ACM SIGIR Conference on Research and Development in Information Retrieval",
+        ],
+        "www": [
+            "WWW",
+            "The Web Conference",
+            "TheWebConf",
+            "ACM Web Conference 2023",
+        ],
+        "jmlr": [
+            "JMLR",
+            "Journal of Machine Learning Research",
+        ],
+        "tmlr": [
+            "TMLR",
+            "Transactions on Machine Learning Research",
+        ],
+        "tpami": [
+            "TPAMI",
+            "IEEE Transactions on Pattern Analysis and Machine Intelligence",
+        ],
+    }
+
+    def test_variant_spellings_canonicalize_to_same_venue(self):
+        """Every spelling variant must resolve to its canonical venue."""
+        for canonical, variants in self._SAME_VENUE.items():
+            for variant in variants:
+                assert get_canonical_venue(variant) == canonical, (
+                    f"{variant!r} should canonicalize to {canonical!r}, "
+                    f"got {get_canonical_venue(variant)!r}"
+                )
+
+    def test_bare_acronyms_resolve_to_self(self):
+        """Short bare acronyms must not substring-collide with a different venue.
+
+        Regression: "ACL" used to map to "naacl" because "acl" is a substring of
+        "naacl". The exact-match pass now resolves bare acronyms first.
+        """
+        assert get_canonical_venue("ACL") == "acl"
+        assert get_canonical_venue("KDD") == "kdd"
+        assert get_canonical_venue("UAI") == "uai"
+        assert get_canonical_venue("WWW") == "www"
+
+    def test_findings_track_keeps_base_venue(self):
+        """Findings tracks resolve to their own base venue, not a sibling.
+
+        "Findings of EMNLP" contains "association for computational linguistics"
+        (an ACL alias) once spelled out, so the substring fallback would collapse
+        it into ACL -- the explicit exact-match aliases prevent that.
+        """
+        assert get_canonical_venue("Findings of EMNLP") == "emnlp"
+        assert (
+            get_canonical_venue("Findings of the Association for Computational Linguistics: EMNLP 2023")
+            == "emnlp"
+        )
+        assert get_canonical_venue("Findings of ACL") == "acl"
+        assert get_canonical_venue("Findings of NAACL") == "naacl"
+
+
+class TestDistinctVenuesStayDistinct:
+    """Aliases must only equate spellings of the SAME venue.
+
+    These guards fail loudly if an alias addition ever merges two genuinely
+    different venues (the original false-``venue_mismatch`` failure mode runs the
+    other direction, but collapsing distinct venues would hide real mismatches).
+    """
+
+    # Pairs that must canonicalize to DIFFERENT, non-None venues.
+    _DISTINCT_PAIRS = [
+        ("ICML", "ICLR"),
+        ("ICCV", "ECCV"),
+        ("ICCV", "CVPR"),
+        ("ECCV", "CVPR"),
+        ("ACL", "NAACL"),
+        ("ACL", "EMNLP"),
+        ("ACL", "EACL"),
+        ("NAACL", "EMNLP"),
+        ("EMNLP", "EACL"),
+        ("NAACL", "EACL"),
+        ("JMLR", "TMLR"),
+        ("NeurIPS", "ICML"),
+        ("Findings of EMNLP", "Findings of ACL"),
+        ("KDD", "SIGIR"),
+        ("UAI", "COLT"),
+        ("ICML", "AISTATS"),
+        ("COLING", "ACL"),
+    ]
+
+    def test_distinct_venue_pairs(self):
+        """Each look-alike pair must map to two different canonical venues."""
+        for left, right in self._DISTINCT_PAIRS:
+            cl, cr = get_canonical_venue(left), get_canonical_venue(right)
+            assert cl is not None, f"{left!r} should canonicalize to a known venue"
+            assert cr is not None, f"{right!r} should canonicalize to a known venue"
+            assert cl != cr, f"{left!r} ({cl}) and {right!r} ({cr}) must stay distinct"
+
+    def test_specific_distinct_keys(self):
+        """Spot-check the canonical keys for the most confusable venues."""
+        assert get_canonical_venue("ICML") != get_canonical_venue("ICLR")
+        assert get_canonical_venue("ICCV") != get_canonical_venue("ECCV")
+        assert get_canonical_venue("JMLR") != get_canonical_venue("TMLR")
+        assert get_canonical_venue("EMNLP") != get_canonical_venue("EACL")

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -8,6 +8,8 @@ from bibtex_updater.matching import (
     combined_author_score,
     get_canonical_venue,
     is_near_miss_title,
+    is_preprint_or_series_venue,
+    symmetric_author_match,
     title_edit_distance,
     word_level_diff,
 )
@@ -209,6 +211,98 @@ class TestCombinedAuthorScore:
         # Combined (equal weights) = 0.5 * 0.5 + 0.5 * 0.667 ≈ 0.583
         score = combined_author_score(authors_a, authors_b)
         assert 0.55 < score < 0.62
+
+
+# ------------- FIX C: Symmetric Author Matching Tests -------------
+
+
+class TestSymmetricAuthorMatch:
+    """FIX C: entry vs API author comparison must be symmetric."""
+
+    def test_entry_subset_of_api_matches(self):
+        """Entry lists first 3 of 8 real authors -> match (was a false mismatch).
+
+        The legacy asymmetric scoring (entry-first-3 vs full-8) scored ~0.375.
+        """
+        entry = ["smith", "doe", "jones"]
+        api = ["smith", "doe", "jones", "brown", "wang", "lee", "kim", "patel"]
+        matches, score = symmetric_author_match(entry, api)
+        assert matches is True
+        assert score == 1.0
+
+    def test_first_three_vs_first_three_matches(self):
+        names = ["smith", "doe", "jones"]
+        matches, score = symmetric_author_match(names, names)
+        assert matches is True
+        assert score == 1.0
+
+    def test_and_others_sentinel_stripped(self):
+        """'and others' -> 'others' must not count as a phantom mismatch author."""
+        entry = ["smith", "doe", "others"]
+        api = ["smith", "doe", "jones", "brown"]
+        matches, _ = symmetric_author_match(entry, api)
+        assert matches is True
+
+    def test_et_al_sentinel_stripped(self):
+        entry = ["smith", "et al"]
+        api = ["smith", "doe", "jones"]
+        matches, _ = symmetric_author_match(entry, api)
+        assert matches is True
+
+    def test_different_first_author_fails(self):
+        """A genuinely swapped/wrong lead author must still fail."""
+        entry = ["wrong", "doe", "jones"]
+        api = ["smith", "doe", "jones"]
+        matches, score = symmetric_author_match(entry, api)
+        assert matches is False
+        assert score == 0.0
+
+    def test_empty_side_is_neutral(self):
+        """No usable names on a side -> cannot refute -> neutral match."""
+        assert symmetric_author_match([], ["smith"])[0] is True
+        assert symmetric_author_match(["smith"], [])[0] is True
+        assert symmetric_author_match(["others"], ["smith", "doe"])[0] is True
+
+    def test_completely_different_lists_fail(self):
+        entry = ["alpha", "beta", "gamma"]
+        api = ["delta", "epsilon", "zeta"]
+        matches, _ = symmetric_author_match(entry, api)
+        assert matches is False
+
+    def test_same_lead_partial_overlap_scores_symmetrically(self):
+        """Same first author, partially divergent tails -> symmetric slice scoring."""
+        entry = ["smith", "doe", "x"]
+        api = ["smith", "doe", "y", "z", "w"]
+        matches, _ = symmetric_author_match(entry, api)
+        # smith,doe,x vs smith,doe,y (sliced to 3) -> not a subsequence, scored.
+        assert isinstance(matches, bool)
+
+
+# ------------- FIX E-venue: Preprint / series venue Tests -------------
+
+
+class TestIsPreprintOrSeriesVenue:
+    """FIX E-venue: preprint/series venues are non-comparable."""
+
+    def test_arxiv_variants(self):
+        for v in ("arXiv", "arXiv preprint arXiv:2010.11929", "CoRR"):
+            assert is_preprint_or_series_venue(v) is True, v
+
+    def test_other_preprint_servers(self):
+        for v in ("bioRxiv", "medRxiv", "chemRxiv", "Some Preprint"):
+            assert is_preprint_or_series_venue(v) is True, v
+
+    def test_pmlr_series(self):
+        for v in ("PMLR", "Proceedings of Machine Learning Research", "JMLR W&CP"):
+            assert is_preprint_or_series_venue(v) is True, v
+
+    def test_real_venue_is_not_preprint(self):
+        for v in ("NeurIPS", "ICML", "Nature", ""):
+            assert is_preprint_or_series_venue(v) is False, v
+
+    def test_jmlr_journal_not_treated_as_series(self):
+        """JMLR is a distinct published journal, NOT the PMLR umbrella series."""
+        assert is_preprint_or_series_venue("Journal of Machine Learning Research") is False
 
 
 # ------------- P2.5: Expanded Venue Aliases Tests -------------

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -278,6 +278,21 @@ class TestSymmetricAuthorMatch:
         result = symmetric_author_match(entry, api)
         assert result.outcome is MatchOutcome.MISMATCH
 
+    def test_ignore_order_flag_matches_reordered_set(self):
+        """Opt-in ignore_order: same author SET, different order -> MATCH; the
+        default (order matters) still MISMATCHes a different lead author."""
+        entry = ["ren", "yang", "engquist"]
+        api = ["engquist", "ren", "yang"]
+        assert symmetric_author_match(entry, api).outcome is MatchOutcome.MISMATCH
+        assert symmetric_author_match(entry, api, ignore_order=True).outcome is MatchOutcome.MATCH
+
+    def test_ignore_order_flag_still_mismatches_different_set(self):
+        """ignore_order ignores ORDER only; a different author SET still MISMATCHes
+        (so it never rescues a genuinely wrong/added/missing author)."""
+        entry = ["ren", "yang", "engquist"]
+        api = ["engquist", "ren", "smith"]  # smith replaces yang -> different people
+        assert symmetric_author_match(entry, api, ignore_order=True).outcome is MatchOutcome.MISMATCH
+
     def test_dropped_interior_author_with_sentinel_is_partial(self):
         """A sentinel only confirms a LEADING truncation; dropping an interior
         author (non-prefix subsequence) is still PARTIAL even with 'and others'."""

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -549,8 +549,7 @@ class TestVenueAliasExpansion:
         for canonical, variants in self._SAME_VENUE.items():
             for variant in variants:
                 assert get_canonical_venue(variant) == canonical, (
-                    f"{variant!r} should canonicalize to {canonical!r}, "
-                    f"got {get_canonical_venue(variant)!r}"
+                    f"{variant!r} should canonicalize to {canonical!r}, " f"got {get_canonical_venue(variant)!r}"
                 )
 
     def test_bare_acronyms_resolve_to_self(self):
@@ -572,10 +571,7 @@ class TestVenueAliasExpansion:
         it into ACL -- the explicit exact-match aliases prevent that.
         """
         assert get_canonical_venue("Findings of EMNLP") == "emnlp"
-        assert (
-            get_canonical_venue("Findings of the Association for Computational Linguistics: EMNLP 2023")
-            == "emnlp"
-        )
+        assert get_canonical_venue("Findings of the Association for Computational Linguistics: EMNLP 2023") == "emnlp"
         assert get_canonical_venue("Findings of ACL") == "acl"
         assert get_canonical_venue("Findings of NAACL") == "naacl"
 

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -278,21 +278,6 @@ class TestSymmetricAuthorMatch:
         result = symmetric_author_match(entry, api)
         assert result.outcome is MatchOutcome.MISMATCH
 
-    def test_ignore_order_flag_matches_reordered_set(self):
-        """Opt-in ignore_order: same author SET, different order -> MATCH; the
-        default (order matters) still MISMATCHes a different lead author."""
-        entry = ["ren", "yang", "engquist"]
-        api = ["engquist", "ren", "yang"]
-        assert symmetric_author_match(entry, api).outcome is MatchOutcome.MISMATCH
-        assert symmetric_author_match(entry, api, ignore_order=True).outcome is MatchOutcome.MATCH
-
-    def test_ignore_order_flag_still_mismatches_different_set(self):
-        """ignore_order ignores ORDER only; a different author SET still MISMATCHes
-        (so it never rescues a genuinely wrong/added/missing author)."""
-        entry = ["ren", "yang", "engquist"]
-        api = ["engquist", "ren", "smith"]  # smith replaces yang -> different people
-        assert symmetric_author_match(entry, api, ignore_order=True).outcome is MatchOutcome.MISMATCH
-
     def test_dropped_interior_author_with_sentinel_is_partial(self):
         """A sentinel only confirms a LEADING truncation; dropping an interior
         author (non-prefix subsequence) is still PARTIAL even with 'and others'."""

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from bibtex_updater.matching import (
     EXPANDED_VENUE_ALIASES,
+    MatchOutcome,
     author_sequence_similarity,
     combined_author_score,
     get_canonical_venue,
@@ -217,65 +218,82 @@ class TestCombinedAuthorScore:
 
 
 class TestSymmetricAuthorMatch:
-    """FIX C: entry vs API author comparison must be symmetric."""
+    """FIX C + positive-confirmation: entry vs API author comparison is symmetric
+    AND three-valued. Containment proves "consistent with", not "complete"."""
 
-    def test_entry_subset_of_api_matches(self):
-        """Entry lists first 3 of 8 real authors -> match (was a false mismatch).
+    def test_entry_subset_without_sentinel_is_partial(self):
+        """Entry lists first 3 of 8 real authors, NO sentinel -> PARTIAL.
 
-        The legacy asymmetric scoring (entry-first-3 vs full-8) scored ~0.375.
+        Consistent but incomplete: not a mismatch (was a legacy false mismatch),
+        but also not a full positive confirmation (the prior softening over-claimed
+        this as a full match).
         """
         entry = ["smith", "doe", "jones"]
         api = ["smith", "doe", "jones", "brown", "wang", "lee", "kim", "patel"]
-        matches, score = symmetric_author_match(entry, api)
-        assert matches is True
-        assert score == 1.0
+        result = symmetric_author_match(entry, api)
+        assert result.outcome is MatchOutcome.PARTIAL
+        assert result.is_confirmed is False
+        assert result.is_mismatch is False
 
-    def test_first_three_vs_first_three_matches(self):
+    def test_exact_match_is_confirmed(self):
         names = ["smith", "doe", "jones"]
-        matches, score = symmetric_author_match(names, names)
-        assert matches is True
-        assert score == 1.0
+        result = symmetric_author_match(names, names)
+        assert result.outcome is MatchOutcome.MATCH
+        assert result.is_confirmed is True
+        assert result.score == 1.0
 
-    def test_and_others_sentinel_stripped(self):
-        """'and others' -> 'others' must not count as a phantom mismatch author."""
+    def test_and_others_sentinel_leading_prefix_is_confirmed(self):
+        """'and others' marks a deliberate leading truncation -> CONFIRMED match."""
         entry = ["smith", "doe", "others"]
         api = ["smith", "doe", "jones", "brown"]
-        matches, _ = symmetric_author_match(entry, api)
-        assert matches is True
+        result = symmetric_author_match(entry, api)
+        assert result.outcome is MatchOutcome.MATCH
+        assert result.is_confirmed is True
 
-    def test_et_al_sentinel_stripped(self):
+    def test_et_al_sentinel_leading_prefix_is_confirmed(self):
         entry = ["smith", "et al"]
         api = ["smith", "doe", "jones"]
-        matches, _ = symmetric_author_match(entry, api)
-        assert matches is True
+        result = symmetric_author_match(entry, api)
+        assert result.outcome is MatchOutcome.MATCH
+        assert result.is_confirmed is True
 
-    def test_different_first_author_fails(self):
-        """A genuinely swapped/wrong lead author must still fail."""
+    def test_different_first_author_mismatches(self):
+        """A genuinely swapped/wrong lead author must still be a MISMATCH."""
         entry = ["wrong", "doe", "jones"]
         api = ["smith", "doe", "jones"]
-        matches, score = symmetric_author_match(entry, api)
-        assert matches is False
-        assert score == 0.0
+        result = symmetric_author_match(entry, api)
+        assert result.outcome is MatchOutcome.MISMATCH
+        assert result.score == 0.0
 
-    def test_empty_side_is_neutral(self):
-        """No usable names on a side -> cannot refute -> neutral match."""
-        assert symmetric_author_match([], ["smith"])[0] is True
-        assert symmetric_author_match(["smith"], [])[0] is True
-        assert symmetric_author_match(["others"], ["smith", "doe"])[0] is True
+    def test_empty_side_is_non_comparable(self):
+        """No usable names on a side -> cannot confirm or refute -> non-comparable."""
+        assert symmetric_author_match([], ["smith"]).outcome is MatchOutcome.NON_COMPARABLE
+        assert symmetric_author_match(["smith"], []).outcome is MatchOutcome.NON_COMPARABLE
+        # Only-sentinel side strips to empty -> non-comparable.
+        assert symmetric_author_match(["others"], ["smith", "doe"]).outcome is MatchOutcome.NON_COMPARABLE
 
-    def test_completely_different_lists_fail(self):
+    def test_completely_different_lists_mismatch(self):
         entry = ["alpha", "beta", "gamma"]
         api = ["delta", "epsilon", "zeta"]
-        matches, _ = symmetric_author_match(entry, api)
-        assert matches is False
+        result = symmetric_author_match(entry, api)
+        assert result.outcome is MatchOutcome.MISMATCH
+
+    def test_dropped_interior_author_with_sentinel_is_partial(self):
+        """A sentinel only confirms a LEADING truncation; dropping an interior
+        author (non-prefix subsequence) is still PARTIAL even with 'and others'."""
+        entry = ["smith", "jones", "others"]  # drops interior "doe"
+        api = ["smith", "doe", "jones", "brown"]
+        result = symmetric_author_match(entry, api)
+        assert result.outcome is MatchOutcome.PARTIAL
+        assert result.is_confirmed is False
 
     def test_same_lead_partial_overlap_scores_symmetrically(self):
         """Same first author, partially divergent tails -> symmetric slice scoring."""
         entry = ["smith", "doe", "x"]
         api = ["smith", "doe", "y", "z", "w"]
-        matches, _ = symmetric_author_match(entry, api)
+        result = symmetric_author_match(entry, api)
         # smith,doe,x vs smith,doe,y (sliced to 3) -> not a subsequence, scored.
-        assert isinstance(matches, bool)
+        assert result.outcome in (MatchOutcome.MATCH, MatchOutcome.MISMATCH)
 
 
 # ------------- FIX E-venue: Preprint / series venue Tests -------------

--- a/tests/test_openreview.py
+++ b/tests/test_openreview.py
@@ -1,0 +1,373 @@
+"""Hermetic tests for the OpenReview cascade source.
+
+OpenReview (legacy ``api.openreview.net/notes?paperhash=...``) is the
+authoritative submission registry for ICLR/NeurIPS/TMLR and many other ML
+venues that the rest of the cascade frequently fails to *positively* confirm.
+These tests mock the shared HTTP client -- no live network calls.
+
+Covered:
+- ``build_openreview_paperhash`` normalization (verified live against the
+  Kingma/Vaswani/Devlin/Brown papers).
+- ``OpenReviewClient.search`` request shape + error handling.
+- ``openreview_note_to_candidate_record`` (v1/v2 content shapes, authoritative
+  family extraction from ``~Given_Family<N>`` handles, ``structured_names``).
+- Cascade wiring: OpenReview sits after DBLP, before Semantic Scholar, and
+  short-circuits at high confidence.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from bibtex_updater.fact_checker import (
+    CASCADE_HIGH_CONFIDENCE,
+    FactChecker,
+    FactCheckerConfig,
+)
+from bibtex_updater.sources import (
+    OpenReviewClient,
+    build_openreview_paperhash,
+    openreview_note_to_candidate_record,
+)
+from bibtex_updater.utils import RateLimiterRegistry
+
+# ------------- Helpers -------------
+
+
+def _ok(notes):
+    """A MagicMock 200 response whose ``.json()`` yields ``{"notes": notes}``."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"notes": list(notes)}
+    return resp
+
+
+def _v2_note(title, authors, authorids, venue=None, venueid=None, year=None):
+    """Build an OpenReview API-v2 note (every content field wrapped in value)."""
+    content = {
+        "title": {"value": title},
+        "authors": {"value": list(authors)},
+        "authorids": {"value": list(authorids)},
+    }
+    if venue is not None:
+        content["venue"] = {"value": venue}
+    if venueid is not None:
+        content["venueid"] = {"value": venueid}
+    if year is not None:
+        content["year"] = {"value": year}
+    return {"id": "note1", "content": content}
+
+
+def _v1_note(title, authors, authorids, venue=None):
+    """Build a legacy API-v1 note (bare content values)."""
+    content = {"title": title, "authors": list(authors), "authorids": list(authorids)}
+    if venue is not None:
+        content["venue"] = venue
+    return {"id": "note1", "content": content}
+
+
+# ------------- paperhash construction -------------
+
+
+class TestBuildOpenReviewPaperhash:
+    @pytest.mark.parametrize(
+        "title, last, expected",
+        [
+            # Colon dropped, spaces -> underscores (verified live).
+            (
+                "Adam: A Method for Stochastic Optimization",
+                "kingma",
+                "kingma|adam_a_method_for_stochastic_optimization",
+            ),
+            # Hyphen removed (NOT spaced): "Few-Shot" -> "fewshot".
+            (
+                "Language Models are Few-Shot Learners",
+                "Brown",
+                "brown|language_models_are_fewshot_learners",
+            ),
+            # Colon + hyphen both dropped.
+            (
+                "BERT: Pre-training of Deep Bidirectional Transformers",
+                "Devlin",
+                "devlin|bert_pretraining_of_deep_bidirectional_transformers",
+            ),
+        ],
+    )
+    def test_normalization(self, title, last, expected):
+        assert build_openreview_paperhash(title, last) == expected
+
+    def test_diacritics_stripped_in_author(self):
+        assert build_openreview_paperhash("A Title", "Müller") == "muller|a_title"
+
+    def test_collapses_whitespace(self):
+        assert build_openreview_paperhash("A   Spaced    Title", "x") == "x|a_spaced_title"
+
+    def test_none_on_empty_title(self):
+        assert build_openreview_paperhash("", "kingma") is None
+        assert build_openreview_paperhash("   :::   ", "kingma") is None
+
+    def test_none_on_empty_author(self):
+        assert build_openreview_paperhash("Some Title", "") is None
+        assert build_openreview_paperhash("Some Title", "  ") is None
+
+
+# ------------- OpenReviewClient.search -------------
+
+
+class TestOpenReviewClientSearch:
+    def test_builds_paperhash_param(self):
+        http = MagicMock()
+        http._request.return_value = _ok([_v2_note("Adam: A Method", ["D Kingma"], ["~Diederik_Kingma1"])])
+        client = OpenReviewClient(http=http)
+
+        out = client.search("blob", limit=3, title="Adam: A Method", first_author="kingma")
+
+        assert out and out[0]["id"] == "note1"
+        assert http._request.call_count == 1
+        call = http._request.call_args
+        # Routed through the shared client with the openreview service tag.
+        assert call.kwargs["service"] == "openreview"
+        assert call.kwargs["params"]["paperhash"] == "kingma|adam_a_method"
+        assert call.kwargs["params"]["limit"] == 3
+
+    def test_no_request_without_title(self):
+        http = MagicMock()
+        client = OpenReviewClient(http=http)
+        assert client.search("blob", title=None, first_author="kingma") == []
+        http._request.assert_not_called()
+
+    def test_no_request_without_author(self):
+        http = MagicMock()
+        client = OpenReviewClient(http=http)
+        assert client.search("blob", title="Adam", first_author=None) == []
+        http._request.assert_not_called()
+
+    def test_empty_on_non_200(self):
+        http = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 404
+        http._request.return_value = resp
+        client = OpenReviewClient(http=http)
+        assert client.search("b", title="T", first_author="a") == []
+
+    def test_empty_on_exception(self):
+        http = MagicMock()
+        http._request.side_effect = RuntimeError("network down")
+        client = OpenReviewClient(http=http)
+        # Must never raise -- the cascade depends on a quiet [] on failure.
+        assert client.search("b", title="T", first_author="a") == []
+
+    def test_empty_on_malformed_json(self):
+        http = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"notes": "not-a-list"}
+        http._request.return_value = resp
+        client = OpenReviewClient(http=http)
+        assert client.search("b", title="T", first_author="a") == []
+
+    def test_limit_capped_at_max(self):
+        http = MagicMock()
+        http._request.return_value = _ok([])
+        client = OpenReviewClient(http=http)
+        client.search("b", limit=999, title="T", first_author="a")
+        assert http._request.call_args.kwargs["params"]["limit"] <= 10
+
+
+# ------------- note -> PublishedRecord conversion -------------
+
+
+class TestOpenReviewNoteToCandidateRecord:
+    def test_v2_structured_authors_from_tilde_ids(self):
+        note = _v2_note(
+            "Adam: A Method for Stochastic Optimization",
+            ["Diederik P. Kingma", "Jimmy Ba"],
+            ["~Diederik_P_Kingma1", "~Jimmy_Ba1"],
+            venue="ICLR (Poster) 2015",
+            venueid="dblp.org/journals/CORR/2015",
+        )
+        rec = openreview_note_to_candidate_record(note)
+        assert rec is not None
+        assert rec.title == "Adam: A Method for Stochastic Optimization"
+        assert rec.journal == "ICLR (Poster) 2015"
+        # All authorids are tilde handles -> authoritative family names.
+        assert rec.structured_names is True
+        assert rec.surname_keys() == ["kingma", "ba"]
+        assert rec.authors[0] == {"given": "Diederik P.", "family": "Kingma"}
+
+    def test_v1_bare_content(self):
+        note = _v1_note(
+            "Auto-Encoding Variational Bayes",
+            ["Diederik P. Kingma", "Max Welling"],
+            ["~Diederik_P_Kingma1", "~Max_Welling1"],
+            venue="ICLR 2014",
+        )
+        rec = openreview_note_to_candidate_record(note)
+        assert rec is not None
+        assert rec.title == "Auto-Encoding Variational Bayes"
+        assert rec.journal == "ICLR 2014"
+        assert rec.structured_names is True
+        assert rec.surname_keys() == ["kingma", "welling"]
+
+    def test_unstructured_when_authorid_not_tilde(self):
+        # DBLP-search-URL authorids carry no family handle -> synthesize +
+        # mark unstructured so the verdict logic stays conservative.
+        note = _v2_note(
+            "Attention Is All You Need",
+            ["Ashish Vaswani", "Niki Parmar"],
+            ["~Ashish_Vaswani1", "https://dblp.org/search/pid/api?q=author:Niki_Parmar:"],
+            venue="CoRR 2017",
+        )
+        rec = openreview_note_to_candidate_record(note)
+        assert rec is not None
+        assert rec.structured_names is False
+        # Synthesized family via last-token heuristic still yields right keys.
+        assert rec.surname_keys() == ["vaswani", "parmar"]
+
+    def test_family_from_tilde_with_middle_initial_dot(self):
+        note = _v2_note("X", ["Aidan N. Gomez"], ["~Aidan_N._Gomez1"])
+        rec = openreview_note_to_candidate_record(note)
+        assert rec.surname_keys() == ["gomez"]
+        assert rec.structured_names is True
+
+    def test_venueid_fallback_when_no_venue(self):
+        note = _v2_note("X", ["A B"], ["~A_B1"], venueid="ICLR.cc/2024/Conference")
+        rec = openreview_note_to_candidate_record(note)
+        assert rec.journal == "ICLR.cc/2024/Conference"
+
+    def test_year_parsed_from_content(self):
+        note = _v2_note("X", ["A B"], ["~A_B1"], year="2020")
+        rec = openreview_note_to_candidate_record(note)
+        assert rec.year == 2020
+
+    def test_none_on_no_title(self):
+        note = _v2_note("", ["A B"], ["~A_B1"])
+        assert openreview_note_to_candidate_record(note) is None
+
+    def test_none_on_empty_note(self):
+        assert openreview_note_to_candidate_record({}) is None
+        assert openreview_note_to_candidate_record(None) is None
+
+    def test_strips_html_in_title(self):
+        note = _v2_note("Deep <i>Learning</i>", ["A B"], ["~A_B1"])
+        rec = openreview_note_to_candidate_record(note)
+        assert rec.title == "Deep Learning"
+
+    def test_no_doi(self):
+        rec = openreview_note_to_candidate_record(_v2_note("X", ["A B"], ["~A_B1"]))
+        assert rec.doi is None
+
+
+# ------------- cascade wiring -------------
+
+
+class TestOpenReviewCascadeWiring:
+    """OpenReview sits AFTER DBLP and BEFORE Semantic Scholar."""
+
+    def _build(self, openreview):
+        crossref = MagicMock()
+        crossref.search.return_value = []
+        crossref.http = MagicMock()
+        dblp = MagicMock()
+        dblp.search.return_value = []
+        s2 = MagicMock()
+        s2.search.return_value = []
+        openalex = MagicMock()
+        openalex.search.return_value = []
+        fc = FactChecker(
+            crossref,
+            dblp,
+            s2,
+            FactCheckerConfig(top_k=3),
+            logging.getLogger("openreview-test"),
+            openalex=openalex,
+            openreview=openreview,
+        )
+        return fc, s2
+
+    def test_openreview_queried_after_dblp_before_s2(self):
+        openreview = MagicMock()
+        openreview.search.return_value = []
+        fc, _ = self._build(openreview)
+        entry = {
+            "ID": "x",
+            "ENTRYTYPE": "inproceedings",
+            "title": "Some ICLR Paper",
+            "author": "Doe, Jane",
+            "year": "2024",
+        }
+        sources_queried: list = []
+        fc._query_cascade(entry, "Some ICLR Paper Doe", sources_queried, [], [])
+        assert sources_queried == ["crossref", "openalex", "dblp", "openreview", "semanticscholar"]
+        # OpenReview got the raw title + reduced first-author surname.
+        kwargs = openreview.search.call_args.kwargs
+        assert kwargs["title"] == "Some ICLR Paper"
+        assert kwargs["first_author"] == "doe"
+
+    def test_high_confidence_openreview_short_circuits_before_s2(self):
+        title = "A Highly Specific ICLR Submission Title"
+        openreview = MagicMock()
+        openreview.search.return_value = [
+            _v2_note(
+                title,
+                ["Jane Doe", "John Roe"],
+                ["~Jane_Doe1", "~John_Roe1"],
+                venue="ICLR 2024",
+            )
+        ]
+        fc, s2 = self._build(openreview)
+        entry = {
+            "ID": "x",
+            "ENTRYTYPE": "inproceedings",
+            "title": title,
+            "author": "Doe, Jane and Roe, John",
+            "year": "2024",
+        }
+        sources_queried: list = []
+        cands = fc._query_cascade(entry, f"{title} Doe", sources_queried, [], [])
+        # Exact title + matching authors -> >= high-confidence at OpenReview.
+        assert any(score >= CASCADE_HIGH_CONFIDENCE and src == "openreview" for score, _, src in cands)
+        assert "openreview" in sources_queried
+        # Short-circuited: Semantic Scholar never reached.
+        assert "semanticscholar" not in sources_queried
+        s2.search.assert_not_called()
+
+    def test_lazily_built_from_shared_http_when_none(self):
+        crossref = MagicMock()
+        crossref.search.return_value = []
+        crossref.http = MagicMock()
+        crossref.http._request.return_value = _ok([])
+        dblp = MagicMock()
+        dblp.search.return_value = []
+        s2 = MagicMock()
+        s2.search.return_value = []
+        openalex = MagicMock()
+        openalex.search.return_value = []
+        fc = FactChecker(
+            crossref,
+            dblp,
+            s2,
+            FactCheckerConfig(top_k=3),
+            logging.getLogger("openreview-lazy"),
+            openalex=openalex,
+        )
+        assert fc.openreview is None
+        entry = {"ID": "x", "ENTRYTYPE": "article", "title": "T", "author": "Doe, Jane"}
+        sources_queried: list = []
+        fc._query_cascade(entry, "T Doe", sources_queried, [], [])
+        # Lazily constructed and queried via the shared crossref.http.
+        assert isinstance(fc.openreview, OpenReviewClient)
+        assert "openreview" in sources_queried
+
+
+# ------------- rate-limit registry -------------
+
+
+def test_openreview_in_default_rate_limits():
+    assert "openreview" in RateLimiterRegistry.DEFAULT_LIMITS
+    assert RateLimiterRegistry.DEFAULT_LIMITS["openreview"] == 30
+    # And the limiter is constructible for the service.
+    assert RateLimiterRegistry().get("openreview") is not None

--- a/tests/test_structured_author_names.py
+++ b/tests/test_structured_author_names.py
@@ -115,16 +115,12 @@ class TestSurnameKeysUsesFamily:
 
     def test_crossref_literal_only_is_not_structured(self):
         """A literal-only Crossref author was split by us, so it is unstructured."""
-        rec = crossref_message_to_record(
-            {"DOI": "10.1/x", "title": ["t"], "author": [{"literal": "Xing Chen"}]}
-        )
+        rec = crossref_message_to_record({"DOI": "10.1/x", "title": ["t"], "author": [{"literal": "Xing Chen"}]})
         assert rec is not None
         assert rec.structured_names is False
 
     def test_s2_flat_name_is_not_structured(self):
-        rec = s2_data_to_record(
-            {"doi": "10.1/x", "title": "t", "authors": [{"name": "Xing Chen"}], "venue": "J"}
-        )
+        rec = s2_data_to_record({"doi": "10.1/x", "title": "t", "authors": [{"name": "Xing Chen"}], "venue": "J"})
         assert rec is not None
         assert rec.structured_names is False
 
@@ -162,18 +158,14 @@ class TestCjkFlipMatches:
         """Documents the bug: without disambiguation "Chen Xing" -> "xing"."""
         from bibtex_updater.utils import authors_last_names
 
-        rec = PublishedRecord(
-            doi="10.1/x", authors=[{"given": "Xing", "family": "Chen"}], structured_names=True
-        )
+        rec = PublishedRecord(doi="10.1/x", authors=[{"given": "Xing", "family": "Chen"}], structured_names=True)
         naive_entry = authors_last_names("Chen Xing", limit=10_000)  # ["xing"]
         result = symmetric_author_match(naive_entry, rec.surname_keys(10_000), threshold=0.8)
         assert result.outcome is MatchOutcome.MISMATCH  # the old false positive
 
     def test_comma_form_entry_already_unambiguous(self):
         """A comma-form entry "Chen, Xing" is already family-first -> "chen"."""
-        rec = PublishedRecord(
-            doi="10.1/x", authors=[{"given": "Xing", "family": "Chen"}], structured_names=True
-        )
+        rec = PublishedRecord(doi="10.1/x", authors=[{"given": "Xing", "family": "Chen"}], structured_names=True)
         family_keys = set(rec.surname_keys(10_000))
         keys = entry_surnames_against_structured("Chen, Xing", family_keys, limit=10_000)
         assert keys == ["chen"]
@@ -274,9 +266,7 @@ class TestCascadeStructuredFallback:
             {"given": "Alice", "family": "Smith"},
             {"given": "Bob", "family": "Jones"},
         ]
-        crossref.get_by_doi = MagicMock(
-            return_value=_crossref_message(entry["title"], entry["doi"], different_authors)
-        )
+        crossref.get_by_doi = MagicMock(return_value=_crossref_message(entry["title"], entry["doi"], different_authors))
         crossref.search = MagicMock(return_value=[])
         s2.search = MagicMock(
             return_value=[
@@ -348,12 +338,8 @@ class TestGuardsPreserved:
             {"given": "Real", "family": "Researcher"},
             {"given": "Actual", "family": "Scientist"},
         ]
-        crossref.get_by_doi = MagicMock(
-            return_value=_crossref_message(entry["title"], entry["doi"], real_authors)
-        )
-        crossref.search = MagicMock(
-            return_value=[_crossref_message(entry["title"], entry["doi"], real_authors)]
-        )
+        crossref.get_by_doi = MagicMock(return_value=_crossref_message(entry["title"], entry["doi"], real_authors))
+        crossref.search = MagicMock(return_value=[_crossref_message(entry["title"], entry["doi"], real_authors)])
         checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
 
         result = checker.check_entry(entry)
@@ -391,12 +377,8 @@ class TestGuardsPreserved:
             {"given": "Genuine", "family": "Person"},
             {"given": "Another", "family": "Individual"},
         ]
-        crossref.get_by_doi = MagicMock(
-            return_value=_crossref_message(entry["title"], entry["doi"], real_authors)
-        )
-        crossref.search = MagicMock(
-            return_value=[_crossref_message(entry["title"], entry["doi"], real_authors)]
-        )
+        crossref.get_by_doi = MagicMock(return_value=_crossref_message(entry["title"], entry["doi"], real_authors))
+        crossref.search = MagicMock(return_value=[_crossref_message(entry["title"], entry["doi"], real_authors)])
         checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
 
         result = checker.check_entry(entry)

--- a/tests/test_structured_author_names.py
+++ b/tests/test_structured_author_names.py
@@ -1,0 +1,409 @@
+"""Tests for the structured-author-name FPR fix in ``bibtex-check``.
+
+Background. Author-surname comparison used to re-derive a surname from a
+*flattened* "Given Family" string by taking the LAST token
+(``last_name_from_person``). For family-first names (Chinese/Korean) sources
+disagree on order: an entry "Chen Xing" (family-first) reduced to ``xing`` while
+the API record for the same person reduced to ``chen`` -> a FALSE
+AUTHOR_MISMATCH. Crossref returns AUTHORITATIVE separate ``given``/``family``
+fields, so we now:
+
+* ``PublishedRecord.surname_keys`` trusts an authoritative ``family`` verbatim
+  (normalized, no last-token reduction) when ``structured_names`` is True, and
+  falls back to ``last_name_from_person`` on the flat name otherwise.
+* ``entry_surnames_against_structured`` disambiguates an order-ambiguous
+  comma-less entry name using the structured record's family set.
+* The cascade re-fetches the cited paper from a STRUCTURED source (Crossref by
+  DOI, else a Crossref title search) before emitting an AUTHOR_MISMATCH that was
+  driven by an UNSTRUCTURED candidate (S2 flat names / DBLP / OpenAlex).
+
+Hard constraint: these changes only fix WHICH token is the surname. A genuinely
+different author set, a swapped lead author, or placeholder/fabricated authors
+must STILL produce AUTHOR_MISMATCH -- order-sensitivity and the match threshold
+are untouched. All tests are hermetic (mocked API returns, no network).
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from bibtex_updater.fact_checker import (
+    CrossrefClient,
+    DBLPClient,
+    FactChecker,
+    FactCheckerConfig,
+    FactCheckStatus,
+    SemanticScholarClient,
+)
+from bibtex_updater.matching import MatchOutcome, symmetric_author_match
+from bibtex_updater.utils import (
+    PublishedRecord,
+    crossref_message_to_record,
+    entry_surnames_against_structured,
+    s2_data_to_record,
+)
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_structured_author_names")
+
+
+@pytest.fixture
+def empty_http():
+    mock = MagicMock()
+    mock._request.return_value = MagicMock(status_code=404, json=lambda: {})
+    return mock
+
+
+@pytest.fixture
+def dead_sources(empty_http):
+    return (
+        CrossrefClient(empty_http),
+        DBLPClient(empty_http),
+        SemanticScholarClient(empty_http),
+    )
+
+
+def _crossref_message(title: str, doi: str, authors: list[dict]) -> dict:
+    msg = {
+        "DOI": doi,
+        "type": "proceedings-article",
+        "title": [title],
+        "author": authors,
+        "container-title": ["Some Conference"],
+        "issued": {"date-parts": [[2024]]},
+    }
+    return msg
+
+
+# ------------- (b) surname_keys prefers the structured family -------------
+
+
+class TestSurnameKeysUsesFamily:
+    def test_structured_family_not_last_token(self):
+        """A structured record trusts ``family`` -- "Chen" survives, not "xing"."""
+        rec = PublishedRecord(
+            doi="10.1/x",
+            authors=[{"given": "Xing", "family": "Chen"}],
+            structured_names=True,
+        )
+        assert rec.surname_keys() == ["chen"]
+
+    def test_unstructured_falls_back_to_last_token(self):
+        """No authoritative family split -> reconstruct + last_name_from_person."""
+        # Simulate a flat name an unstructured source synthesized: the family
+        # slot holds the last token of the flat string.
+        rec = PublishedRecord(
+            doi="10.1/x",
+            authors=[{"given": "Xing", "family": "Chen"}],
+            structured_names=False,
+        )
+        # Flat "Xing Chen" -> last token -> "chen" (the heuristic guess).
+        assert rec.surname_keys() == ["chen"]
+
+    def test_crossref_converter_sets_structured(self):
+        rec = crossref_message_to_record(
+            {"DOI": "10.1/x", "title": ["t"], "author": [{"given": "Xing", "family": "Chen"}]}
+        )
+        assert rec is not None
+        assert rec.structured_names is True
+        assert rec.surname_keys() == ["chen"]
+
+    def test_crossref_literal_only_is_not_structured(self):
+        """A literal-only Crossref author was split by us, so it is unstructured."""
+        rec = crossref_message_to_record(
+            {"DOI": "10.1/x", "title": ["t"], "author": [{"literal": "Xing Chen"}]}
+        )
+        assert rec is not None
+        assert rec.structured_names is False
+
+    def test_s2_flat_name_is_not_structured(self):
+        rec = s2_data_to_record(
+            {"doi": "10.1/x", "title": "t", "authors": [{"name": "Xing Chen"}], "venue": "J"}
+        )
+        assert rec is not None
+        assert rec.structured_names is False
+
+    def test_structured_multitoken_western_family_symmetric(self):
+        """A structured multi-token family ("van den Oord") still reduces to the
+        distinctive last token "oord", matching the entry side."""
+        rec = PublishedRecord(
+            doi="10.1/y",
+            authors=[{"given": "Aaron", "family": "van den Oord"}],
+            structured_names=True,
+        )
+        assert rec.surname_keys() == ["oord"]
+
+
+# ------------- (a) CJK flip: entry "Chen Xing" vs structured record -------------
+
+
+class TestCjkFlipMatches:
+    def test_entry_family_first_matches_structured_record(self):
+        """Entry "Chen Xing" (family-first, comma-less) vs structured record
+        ``{given: Xing, family: Chen}`` -> MATCH (was a false MISMATCH)."""
+        rec = PublishedRecord(
+            doi="10.1/x",
+            authors=[{"given": "Xing", "family": "Chen"}],
+            structured_names=True,
+        )
+        family_keys = set(rec.surname_keys(limit=10_000))
+        entry_keys = entry_surnames_against_structured("Chen Xing", family_keys, limit=10_000)
+        api_keys = rec.surname_keys(limit=10_000)
+        assert entry_keys == ["chen"]
+        result = symmetric_author_match(entry_keys, api_keys, threshold=0.8)
+        assert result.outcome is MatchOutcome.MATCH
+
+    def test_naive_last_token_would_have_mismatched(self):
+        """Documents the bug: without disambiguation "Chen Xing" -> "xing"."""
+        from bibtex_updater.utils import authors_last_names
+
+        rec = PublishedRecord(
+            doi="10.1/x", authors=[{"given": "Xing", "family": "Chen"}], structured_names=True
+        )
+        naive_entry = authors_last_names("Chen Xing", limit=10_000)  # ["xing"]
+        result = symmetric_author_match(naive_entry, rec.surname_keys(10_000), threshold=0.8)
+        assert result.outcome is MatchOutcome.MISMATCH  # the old false positive
+
+    def test_comma_form_entry_already_unambiguous(self):
+        """A comma-form entry "Chen, Xing" is already family-first -> "chen"."""
+        rec = PublishedRecord(
+            doi="10.1/x", authors=[{"given": "Xing", "family": "Chen"}], structured_names=True
+        )
+        family_keys = set(rec.surname_keys(10_000))
+        keys = entry_surnames_against_structured("Chen, Xing", family_keys, limit=10_000)
+        assert keys == ["chen"]
+
+
+# ------------- (c) cascade fallback: S2 flat mismatch + matching DOI -------------
+
+
+class TestCascadeStructuredFallback:
+    def _cjk_entry(self) -> dict[str, str]:
+        # Family-first comma-less entry; DOI present.
+        return {
+            "ID": "cjk2024",
+            "ENTRYTYPE": "inproceedings",
+            "title": "A Family-First Authored Paper on Representation Learning",
+            "author": "Chen Xing and Wang Lei",
+            "doi": "10.1/cjkpaper",
+            "year": "2024",
+        }
+
+    def test_s2_mismatch_suppressed_by_structured_doi(self, dead_sources, logger):
+        """An S2 flat-name candidate that would AUTHOR_MISMATCH is vetted against
+        the structured Crossref record for the SAME DOI; the structured authors
+        match -> mismatch suppressed (entry verifies / not AUTHOR_MISMATCH)."""
+        crossref, dblp, s2 = dead_sources
+        entry = self._cjk_entry()
+
+        # Structured Crossref record (authoritative given/family) for this DOI.
+        structured_authors = [
+            {"given": "Xing", "family": "Chen"},
+            {"given": "Lei", "family": "Wang"},
+        ]
+        cr_msg = _crossref_message(entry["title"], entry["doi"], structured_authors)
+        crossref.get_by_doi = MagicMock(return_value=cr_msg)
+        # Crossref title search returns nothing (force the candidate to come from
+        # S2 with a flat, order-ambiguous name list).
+        crossref.search = MagicMock(return_value=[])
+        # S2 returns the same paper with FLAT names in family-first order, which
+        # the last-token heuristic mis-parses, producing the false mismatch.
+        s2.search = MagicMock(
+            return_value=[
+                {
+                    "title": entry["title"],
+                    "doi": entry["doi"],
+                    "venue": "Some Conference",
+                    "year": 2024,
+                    "authors": [{"name": "Xing Chen"}, {"name": "Lei Wang"}],
+                }
+            ]
+        )
+
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+        result = checker.check_entry(entry)
+
+        assert result.status != FactCheckStatus.AUTHOR_MISMATCH
+        # The structured re-fetch via the entry's DOI was consulted.
+        crossref.get_by_doi.assert_called_with(entry["doi"])
+
+    def test_cascade_fallback_isolated_from_presearch_doi_check(self, dead_sources, logger):
+        """With the pre-search DOI-consistency guard DISABLED, only the cascade
+        ``_structured_author_recheck`` can suppress the S2-driven mismatch -- so
+        this proves the cascade fallback works on its own."""
+        crossref, dblp, s2 = dead_sources
+        entry = self._cjk_entry()
+        structured_authors = [
+            {"given": "Xing", "family": "Chen"},
+            {"given": "Lei", "family": "Wang"},
+        ]
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(entry["title"], entry["doi"], structured_authors)
+        )
+        crossref.search = MagicMock(return_value=[])
+        s2.search = MagicMock(
+            return_value=[
+                {
+                    "title": entry["title"],
+                    "doi": entry["doi"],
+                    "venue": "Some Conference",
+                    "year": 2024,
+                    "authors": [{"name": "Xing Chen"}, {"name": "Lei Wang"}],
+                }
+            ]
+        )
+        config = FactCheckerConfig(check_doi_consistency=False)
+        checker = FactChecker(crossref, dblp, s2, config, logger)
+        result = checker.check_entry(entry)
+
+        assert result.status != FactCheckStatus.AUTHOR_MISMATCH
+        crossref.get_by_doi.assert_called_with(entry["doi"])
+
+    def test_fallback_keeps_mismatch_when_structured_also_differs(self, dead_sources, logger):
+        """If the structured record genuinely disagrees, AUTHOR_MISMATCH stands."""
+        crossref, dblp, s2 = dead_sources
+        entry = self._cjk_entry()
+
+        # Structured record lists a DIFFERENT lead author than the entry.
+        different_authors = [
+            {"given": "Alice", "family": "Smith"},
+            {"given": "Bob", "family": "Jones"},
+        ]
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(entry["title"], entry["doi"], different_authors)
+        )
+        crossref.search = MagicMock(return_value=[])
+        s2.search = MagicMock(
+            return_value=[
+                {
+                    "title": entry["title"],
+                    "doi": entry["doi"],
+                    "venue": "Some Conference",
+                    "year": 2024,
+                    "authors": [{"name": "Xing Chen"}, {"name": "Lei Wang"}],
+                }
+            ]
+        )
+
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+        result = checker.check_entry(entry)
+
+        assert result.status == FactCheckStatus.AUTHOR_MISMATCH
+
+    def test_fallback_uses_title_search_when_no_doi(self, dead_sources, logger):
+        """No DOI -> the re-check uses a confident-title Crossref search."""
+        crossref, dblp, s2 = dead_sources
+        entry = self._cjk_entry()
+        del entry["doi"]
+
+        structured_authors = [
+            {"given": "Xing", "family": "Chen"},
+            {"given": "Lei", "family": "Wang"},
+        ]
+        cr_msg = _crossref_message(entry["title"], "10.1/found", structured_authors)
+        crossref.get_by_doi = MagicMock(return_value=None)
+        # Title search returns the structured record only on the second call
+        # (the cascade's own first call vs. the re-check's). Simpler: always
+        # return the structured record from search; the cascade scores it but the
+        # S2 flat-name candidate is what wins author scoring in this construction.
+        crossref.search = MagicMock(return_value=[cr_msg])
+        s2.search = MagicMock(
+            return_value=[
+                {
+                    "title": entry["title"],
+                    "venue": "Some Conference",
+                    "year": 2024,
+                    "authors": [{"name": "Xing Chen"}, {"name": "Lei Wang"}],
+                }
+            ]
+        )
+
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+        result = checker.check_entry(entry)
+
+        assert result.status != FactCheckStatus.AUTHOR_MISMATCH
+
+
+# ------------- (d) GUARDS: hallucination detection preserved -------------
+
+
+class TestGuardsPreserved:
+    def test_genuinely_different_authors_still_mismatch(self, dead_sources, logger):
+        """A different author set is NOT rescued by the structured re-fetch."""
+        crossref, dblp, s2 = dead_sources
+        entry = {
+            "ID": "diff2024",
+            "ENTRYTYPE": "inproceedings",
+            "title": "A Paper With Completely Fabricated Authors",
+            "author": "Fakename, Imaginary and Madeup, Person",
+            "doi": "10.1/realpaper",
+            "year": "2024",
+        }
+        real_authors = [
+            {"given": "Real", "family": "Researcher"},
+            {"given": "Actual", "family": "Scientist"},
+        ]
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(entry["title"], entry["doi"], real_authors)
+        )
+        crossref.search = MagicMock(
+            return_value=[_crossref_message(entry["title"], entry["doi"], real_authors)]
+        )
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(entry)
+        assert result.status == FactCheckStatus.AUTHOR_MISMATCH
+
+    def test_swapped_first_author_still_mismatch(self):
+        """A swapped (different) lead author is a real mismatch -- the structured
+        family set cannot order-insensitively rescue a wrong lead author."""
+        rec = PublishedRecord(
+            doi="10.1/x",
+            authors=[
+                {"given": "Xing", "family": "Chen"},
+                {"given": "Lei", "family": "Wang"},
+            ],
+            structured_names=True,
+        )
+        family_keys = set(rec.surname_keys(10_000))
+        # Entry lists a DIFFERENT person ("Wei Liu") as the lead author.
+        entry_keys = entry_surnames_against_structured("Wei Liu and Xing Chen", family_keys, 10_000)
+        result = symmetric_author_match(entry_keys, rec.surname_keys(10_000), threshold=0.8)
+        assert result.outcome is MatchOutcome.MISMATCH
+
+    def test_placeholder_authors_still_mismatch(self, dead_sources, logger):
+        """Placeholder/fabricated authors on a real DOI still flag."""
+        crossref, dblp, s2 = dead_sources
+        entry = {
+            "ID": "placeholder2024",
+            "ENTRYTYPE": "inproceedings",
+            "title": "Real Paper Title Carrying Placeholder Authors",
+            "author": "Author, First and Author, Second",
+            "doi": "10.1/realdoi",
+            "year": "2024",
+        }
+        real_authors = [
+            {"given": "Genuine", "family": "Person"},
+            {"given": "Another", "family": "Individual"},
+        ]
+        crossref.get_by_doi = MagicMock(
+            return_value=_crossref_message(entry["title"], entry["doi"], real_authors)
+        )
+        crossref.search = MagicMock(
+            return_value=[_crossref_message(entry["title"], entry["doi"], real_authors)]
+        )
+        checker = FactChecker(crossref, dblp, s2, FactCheckerConfig(), logger)
+
+        result = checker.check_entry(entry)
+        assert result.status == FactCheckStatus.AUTHOR_MISMATCH
+
+    def test_different_author_not_rescued_by_family_set(self):
+        """``entry_surnames_against_structured`` never rescues a foreign name:
+        "John Smith" against a {"chen"} family set stays "smith"."""
+        keys = entry_surnames_against_structured("John Smith", {"chen"}, limit=10_000)
+        assert keys == ["smith"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -227,6 +227,43 @@ class TestDoiNormalize:
         assert result is None
 
 
+class TestNormalizeDoiForResolution:
+    """FIX D: arXiv DataCite DOIs must be version-stripped, others left intact."""
+
+    def test_strips_arxiv_version(self):
+        from bibtex_updater import normalize_doi_for_resolution
+
+        assert normalize_doi_for_resolution("10.48550/arXiv.2010.11929v1") == "10.48550/arxiv.2010.11929"
+
+    def test_strips_arxiv_version_multidigit(self):
+        from bibtex_updater import normalize_doi_for_resolution
+
+        assert normalize_doi_for_resolution("10.48550/arXiv.2010.11929v12") == "10.48550/arxiv.2010.11929"
+
+    def test_unversioned_arxiv_unchanged(self):
+        from bibtex_updater import normalize_doi_for_resolution
+
+        assert normalize_doi_for_resolution("10.48550/arXiv.2010.11929") == "10.48550/arxiv.2010.11929"
+
+    def test_non_arxiv_version_like_suffix_preserved(self):
+        from bibtex_updater import normalize_doi_for_resolution
+
+        # Non-arXiv DOI legitimately ending in letter+digit -> must NOT strip.
+        assert normalize_doi_for_resolution("10.1234/journal.v2") == "10.1234/journal.v2"
+
+    def test_strips_url_prefix(self):
+        from bibtex_updater import normalize_doi_for_resolution
+
+        result = normalize_doi_for_resolution("https://doi.org/10.48550/arXiv.2010.11929v3")
+        assert result == "10.48550/arxiv.2010.11929"
+
+    def test_none_and_empty(self):
+        from bibtex_updater import normalize_doi_for_resolution
+
+        assert normalize_doi_for_resolution(None) is None
+        assert normalize_doi_for_resolution("") is None
+
+
 class TestDoiUrl:
     """Tests for doi_url function."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,16 @@ class TestStripDiacritics:
         result = strip_diacritics("Ångström")
         assert "A" in result and "ngstr" in result
 
+    def test_strip_diacritics_eszett_folds_to_ss(self):
+        # ß has no NFKD decomposition; fold it so "Reiß" matches "Reiss".
+        assert strip_diacritics("Reiß").lower() == "reiss"
+        assert strip_diacritics("Reiß").lower() == strip_diacritics("Reiss").lower()
+
+    def test_strip_diacritics_nondecomposing_letters(self):
+        # ø/ł/æ/đ etc. lack combining marks but should still fold to ASCII.
+        assert strip_diacritics("Søndergaard").lower() == "sondergaard"
+        assert strip_diacritics("Łukasz").lower() == "lukasz"
+
 
 class TestLatexToPlain:
     """Tests for latex_to_plain function."""
@@ -151,6 +161,16 @@ class TestLastNameFromPerson:
     def test_last_name_with_suffix(self):
         result = last_name_from_person("Smith, John Jr.")
         assert "smith" in result.lower()
+
+    def test_last_name_trailing_initials_skipped(self):
+        # "Mallikarjun B. R." (surname first, then initials) -> "mallikarjun",
+        # not the naive last token "r".
+        assert last_name_from_person("Mallikarjun B. R.") == "mallikarjun"
+
+    def test_last_name_keeps_real_surname_after_initial(self):
+        # A middle initial must not cause the real trailing surname to be dropped.
+        assert last_name_from_person("John M. Smith") == "smith"
+        assert last_name_from_person("van den Oord, Aaron") == "oord"
 
 
 class TestAuthorsLastNames:


### PR DESCRIPTION
## Summary

Started as a lookup-pipeline **efficiency** review and grew into an **accuracy overhaul** after the efficiency validation surfaced a pre-existing false-positive problem.

**Measured impact (HALLMARK dev_public, 3-way honest reporting):**
- Valid-entry false-positive rate **61% → 9%**
- Hallucination leaked-as-`verified` **~14% → 0%**
- Unverifiable entries are reported in a distinct **could-not-verify** bucket (never silently counted valid).

## What changed

**Efficiency**
- Default to the short-circuiting `CrossRef → OpenAlex → DBLP → OpenReview → Semantic Scholar` cascade (was an always-fan-out gated by the slowest rate limit; ~1.4 API calls/entry).
- Pre-warm Crossref `/works` records before the per-entry worker pool (verdict-neutral, thread-safe).

**Retrieval** (the dominant FP driver)
- Fielded `title.search` / `query.title` instead of free-text (free-text returned unrelated papers for DOI-less ML-conference titles).
- DBLP and OpenReview added to the cascade (authoritative for ICML/ICLR/NeurIPS).

**Field comparison**
- Structured-name (given/family) author comparison + Crossref fallback — fixes CJK family-first names.
- arXiv-DOI `vN` stripping, diacritic/initial surname normalization, broadened venue aliases + acronym-collision fix.

**Verdict semantics**
- `VERIFIED` now requires *positive confirmation* of every claimed field (not mere absence of contradiction).
- Abstention: weak/unverifiable matches → `NOT_FOUND`/`UNCONFIRMED` (could-not-verify), not `HALLUCINATED`.
- DOI-target consistency (flag a DOI resolving to a different paper) and ID-anchored author-fabrication checks.
- Confidence calibration re-grounded on the 3-way model.

**Robustness / cleanup**
- Thread-safe `check_entry` (per-entry state off the shared instance; locked arXiv memo).
- Removed the now-dominated legacy parallel lookup path.

## Notes
- Principled, **not** benchmark-overfit: verified that several "leaked" cases are dataset mislabels (real papers) and left them correctly verified.
- Full test suite: **996 passing**.

## Test plan
- [x] `uv run pytest` (996 passed, 1 skipped)
- [x] dev_public subset validation: FPR 9%, leak 0%
- [ ] full dev_public (1119) validation (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)