### PR TITLE
perf(fact-checker): cut bibtex-check timeout/rate-limit stalls (verdict-neutral)

### DIFF
--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -74,6 +74,7 @@ from bibtex_updater.utils import (
     CROSSREF_API,
     DBLP_API_SEARCH,
     S2_API,
+    AdaptiveRateLimiterRegistry,
     GivenNameVariety,
     # Text normalization
     HttpClient,
@@ -4013,14 +4014,24 @@ class FactCheckProcessor:
                 "DOI pre-validation complete: %d checked, %d failed", len(pre_validated_dois), failed_count
             )
 
-        # Latency: warm the Crossref /works response cache for all entry DOIs in
-        # parallel up front, so the per-entry DOI checks (consistency + structured
-        # author recheck) hit the cache instead of each making a serial,
-        # rate-limited round-trip. Verdict-neutral; failures fall back to the
-        # existing per-entry fetch. (Mirrors _batch_validate_dois.)
-        warmed = self._batch_warm_crossref_records(entries)
-        if warmed:
-            self.logger.info("Pre-fetched Crossref records for %d DOIs", warmed)
+        # Latency: warm the Crossref /works response cache for all entry DOIs so
+        # the per-entry DOI checks (consistency + structured author recheck) hit
+        # the cache instead of each making a serial, rate-limited round-trip.
+        # Run it in the BACKGROUND so the per-entry worker pool starts
+        # immediately rather than waiting out the serial pre-warm prefix (gated
+        # by the crossref 50/min limiter -- tens of seconds on large
+        # bibliographies). Verdict-neutral: warming only seeds the shared,
+        # thread-safe SqliteCache with the same records the per-entry path would
+        # fetch; a DOI not yet warmed when a worker reaches it falls back to an
+        # on-demand fetch of the identical record. The thread is joined in the
+        # finally block so it is never leaked. (Mirrors _batch_validate_dois.)
+        warm_thread = threading.Thread(
+            target=self._batch_warm_crossref_records,
+            args=(entries,),
+            name="crossref-prewarm",
+            daemon=True,
+        )
+        warm_thread.start()
 
         results: list[FactCheckResult | None] = [None] * len(entries)  # Pre-allocate to preserve order
 
@@ -4098,6 +4109,11 @@ class FactCheckProcessor:
         finally:
             if jsonl_file:
                 jsonl_file.close()
+            # Drain the background pre-warm before returning so the thread is
+            # never leaked (its per-DOI failures are already swallowed inside
+            # _batch_warm_crossref_records, so this join cannot raise). By now the
+            # worker pool has usually outlived it, making the join near-instant.
+            warm_thread.join()
 
         # Filter out None values (from failed entries)
         return [r for r in results if r is not None]
@@ -4446,6 +4462,36 @@ Examples:
     return p
 
 
+def build_rate_limits(rate_limit: float, s2_api_key: str | None) -> dict[str, int]:
+    """Per-service request/min limits scaled by the ``--rate-limit`` knob.
+
+    Every service in :data:`RateLimiterRegistry.DEFAULT_LIMITS` is scaled by
+    ``rate_limit / 45`` (45 is the default), so lowering ``--rate-limit`` to
+    escape 429s now throttles *every* source. Previously the inline dict scaled
+    only six services, leaving OpenAlex, arXiv, ACL Anthology, Europe PMC and
+    Scholar pinned at their hard-coded defaults — so a user who dialled the rate
+    down to dodge 429s kept hammering those services at full speed. This changes
+    pacing only: it never alters which records are fetched or how a verdict is
+    computed, and at the default ``--rate-limit=45`` (``rate_scale == 1``) every
+    value equals its default.
+
+    Semantic Scholar keeps its key-aware override (the authenticated pool is far
+    higher; the keyless pool must stay low to dodge bot-detection). The book
+    verifiers (``openlibrary`` / ``google_books``) are not in DEFAULT_LIMITS, so
+    they are added explicitly.
+    """
+    rate_scale = rate_limit / 45.0  # 45 is the default --rate-limit
+    limits = {
+        service: max(10, int(default * rate_scale)) for service, default in RateLimiterRegistry.DEFAULT_LIMITS.items()
+    }
+    # Book-verifier services (not in DEFAULT_LIMITS).
+    limits["openlibrary"] = max(10, int(30 * rate_scale))
+    limits["google_books"] = max(10, int(30 * rate_scale))
+    # Semantic Scholar: authenticated pool is much higher; keyless stays low.
+    limits["semanticscholar"] = 60 if s2_api_key else max(5, int(10 * rate_scale))
+    return limits
+
+
 def main() -> int:
     """Main entry point."""
     args = build_parser().parse_args()
@@ -4519,18 +4565,11 @@ def main() -> int:
         logger.info("Using Semantic Scholar API key (authenticated rate limits)")
 
     cache = SqliteCache(args.cache_file) if not args.no_cache else None
-    # Scale per-service limits proportionally to --rate-limit
-    rate_scale = args.rate_limit / 45.0  # 45 is the default
-    limiter = RateLimiterRegistry(
-        {
-            "crossref": max(10, int(50 * rate_scale)),
-            "semanticscholar": 60 if s2_api_key else max(5, int(10 * rate_scale)),
-            "dblp": max(10, int(30 * rate_scale)),
-            "openreview": max(10, int(30 * rate_scale)),
-            "openlibrary": max(10, int(30 * rate_scale)),
-            "google_books": max(10, int(30 * rate_scale)),
-        }
-    )
+    # Per-service limits scaled by --rate-limit (see build_rate_limits). The
+    # adaptive registry additionally halves a service's rate on a 429 and honors
+    # Retry-After, so a rate-limited batch backs off correctly instead of
+    # re-hammering the same limit through the retry loop.
+    limiter = AdaptiveRateLimiterRegistry(build_rate_limits(args.rate_limit, s2_api_key))
     http = HttpClient(
         timeout=20.0,
         user_agent="BibtexFactChecker/1.0 (mailto:factchecker@example.com)",

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -1018,9 +1018,10 @@ class AdaptiveRateLimiterRegistry(RateLimiterRegistry):
                     current_limit = self._limits.get(service, 30)
                     new_limit = max(current_limit // 2, self._min_limits.get(service, 5))
                     if new_limit != current_limit:
-                        self._limits[service] = new_limit
-                        # Recreate limiter with new limit
+                        # Recreate limiter under the lock that guards both
+                        # _limits and _limiters against concurrent get() readers.
                         with self._lock:
+                            self._limits[service] = new_limit
                             self._limiters[service] = RateLimiter(new_limit)
             except (ValueError, TypeError):
                 pass
@@ -1039,11 +1040,12 @@ class AdaptiveRateLimiterRegistry(RateLimiterRegistry):
                 # Default 60 second backoff
                 self._backoff_until[service] = time.time() + 60.0
 
-            # Also reduce the rate limit
+            # Also reduce the rate limit (under the registry lock; concurrent
+            # workers read _limits/_limiters in get()).
             current_limit = self._limits.get(service, 30)
             new_limit = max(current_limit // 2, self._min_limits.get(service, 5))
-            self._limits[service] = new_limit
             with self._lock:
+                self._limits[service] = new_limit
                 self._limiters[service] = RateLimiter(new_limit)
 
     def wait(self, service: str) -> None:
@@ -1501,6 +1503,43 @@ class HttpClient:
         else:
             return self._rate_limiter  # type: ignore[return-value]
 
+    def _adapt_rate_limit(self, service: str | None, response: httpx.Response) -> None:
+        """Let an adaptive registry react to a response (429 / rate headers).
+
+        No-op unless the rate limiter is an ``AdaptiveRateLimiterRegistry`` and a
+        concrete ``service`` is known (skipped for ``service is None`` so the
+        ``crossref`` default used for pacing is never polluted). Adapting only
+        reconfigures *future* pacing for the service; it never touches the
+        current response or the retry budget, so it cannot change which records
+        are fetched or any verdict.
+        """
+        if service and hasattr(self._rate_limiter, "adapt"):
+            try:
+                self._rate_limiter.adapt(service, response)  # type: ignore[union-attr]
+            except Exception:
+                pass
+
+    @staticmethod
+    def _retry_delay(exc: httpx.HTTPError, backoff: float) -> float:
+        """Backoff before the next retry: honor a 429 ``Retry-After`` if present.
+
+        A server that tells us exactly when to retry is both faster (when it
+        wants a short wait) and more polite (when it wants a long one) than the
+        blind exponential schedule. Retry-After (integer seconds) is capped at
+        60s so a hostile or mis-set header cannot stall a single entry for hours;
+        everything else (5xx, connection errors, read timeouts) keeps the
+        exponential ``backoff``.
+        """
+        response = getattr(exc, "response", None)
+        if response is not None and getattr(response, "status_code", None) == 429:
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                try:
+                    return min(float(int(retry_after)), 60.0)
+                except (ValueError, TypeError):
+                    pass
+        return backoff
+
     def _request(
         self,
         method: str,
@@ -1533,9 +1572,11 @@ class HttpClient:
                 )
         backoff = 1.0
         attempts = 6
-        limiter = self._get_limiter_for_service(service)
         for attempt in range(attempts):
-            limiter.wait()
+            # Re-fetch the per-service limiter each attempt so an adaptive rate
+            # reduction (triggered by a prior 429 via _adapt_rate_limit) is
+            # picked up immediately, by this thread and by sibling workers.
+            self._get_limiter_for_service(service).wait()
             try:
                 headers = {"Accept": accept} if accept else {}
                 if json_body is not None:
@@ -1544,6 +1585,11 @@ class HttpClient:
                 if service == "semanticscholar" and self.s2_api_key:
                     headers["x-api-key"] = self.s2_api_key
                 resp = self.client.request(method, url, params=params, headers=headers, json=json_body)
+                # Feed the response to an adaptive registry so a 429 (or a low
+                # X-RateLimit-Remaining) throttles this service for the rest of
+                # the run, instead of every worker re-hammering the same limit.
+                # Pacing only -- never changes the response content or a verdict.
+                self._adapt_rate_limit(service, resp)
                 if resp.status_code in self.RETRYABLE_STATUS:
                     raise httpx.HTTPStatusError("Retryable status", request=resp.request, response=resp)
                 if self.cache and cache_key and resp.headers.get("Content-Type", "").startswith("application/json"):
@@ -1552,12 +1598,12 @@ class HttpClient:
                     except Exception:
                         pass
                 return resp
-            except httpx.HTTPError:
+            except httpx.HTTPError as exc:
                 # Don't sleep after the final attempt -- we're about to give up, so
                 # the backoff would just be a wasted stall (up to 16s) on a dead or
                 # rate-limited source.
                 if attempt < attempts - 1:
-                    time.sleep(backoff)
+                    time.sleep(self._retry_delay(exc, backoff))
                     backoff = min(backoff * 2, 16.0)
         raise RuntimeError(f"Network failure after retries for {url}")
 

--- a/tests/test_crossref_prefetch.py
+++ b/tests/test_crossref_prefetch.py
@@ -420,3 +420,60 @@ class TestPrefetchFailureFallback:
         # IBRNet warmed normally -> mismatch verdict from per-entry path.
         checker.crossref.get_by_doi.side_effect = lambda doi: real_get(doi)
         assert checker.check_entry(_ibrnet_entry()).status == FactCheckStatus.DOI_MISMATCH
+
+
+class TestBackgroundPrewarm:
+    """The Crossref pre-warm runs in a background thread so the per-entry worker
+    pool starts immediately, instead of waiting out the serial, rate-limited
+    pre-warm prefix. Verdict-neutrality is covered by ``TestVerdictNeutral`` /
+    ``TestPrefetchWarmsCache`` (the warmed method itself is unchanged); these
+    tests pin the new orchestration contract: overlap + no leaked thread.
+    """
+
+    def test_prewarm_runs_concurrently_with_worker_pool(self, logger, tmp_path):
+        http, _ = _make_http({}, tmp_path)
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+        # Isolate the orchestration from the (separate) DOI pre-validation pool.
+        processor._batch_validate_dois = lambda entries: {}  # type: ignore[method-assign]
+
+        events: list[str] = []
+        lock = threading.Lock()
+        release = threading.Event()
+
+        def fake_warm(entries):
+            with lock:
+                events.append("warm_start")
+            # Block until a worker signals it is running, then finish.
+            release.wait(timeout=5)
+            with lock:
+                events.append("warm_end")
+            return 0
+
+        def fake_check_entry(entry, **kwargs):
+            with lock:
+                events.append("worker")
+            release.set()  # let the background warm complete
+            return object()  # jsonl_path=None -> result attributes never read
+
+        processor._batch_warm_crossref_records = fake_warm  # type: ignore[method-assign]
+        checker.check_entry = fake_check_entry  # type: ignore[method-assign]
+
+        results = processor.process_entries([_ibrnet_entry()], max_workers=2)
+
+        assert len(results) == 1
+        # A worker ran BEFORE the background warm finished -> they overlapped.
+        # Synchronous warming would record "warm_end" before "worker".
+        assert events.index("worker") < events.index("warm_end")
+
+    def test_prewarm_thread_is_joined_not_leaked(self, logger, tmp_path):
+        http, _ = _make_http({}, tmp_path)
+        checker = _checker(http, logger)
+        processor = FactCheckProcessor(checker, logger)
+        processor._batch_validate_dois = lambda entries: {}  # type: ignore[method-assign]
+        checker.check_entry = lambda entry, **kwargs: object()  # type: ignore[method-assign]
+
+        processor.process_entries([_ibrnet_entry()], max_workers=2)
+
+        # The background pre-warm must be joined before process_entries returns.
+        assert not any(t.name == "crossref-prewarm" and t.is_alive() for t in threading.enumerate())

--- a/tests/test_rate_limit_backoff.py
+++ b/tests/test_rate_limit_backoff.py
@@ -1,0 +1,169 @@
+"""Tests for rate-limit pacing fixes in ``bibtex-check``.
+
+Two behaviours are covered, both targeting the user-reported timeout / rate-limit
+symptoms while staying strictly verdict-neutral (pacing only — never which record
+is fetched or how a verdict is computed):
+
+P2 — ``build_rate_limits`` scales EVERY known service by ``--rate-limit`` (the old
+inline dict scaled only 6 of ~9 services, so OpenAlex/arXiv ignored the knob).
+
+P1 — the synchronous ``HttpClient._request`` retry loop now (a) honours a server
+``Retry-After`` header on a 429 instead of blindly using its own exponential
+backoff, and (b) feeds each response to ``AdaptiveRateLimiterRegistry.adapt`` so a
+429 halves the per-service rate for subsequent requests (reducing 429 storms).
+
+All tests are hermetic: the httpx transport is a canned stub; no network access.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from bibtex_updater.fact_checker import build_rate_limits
+from bibtex_updater.utils import (
+    AdaptiveRateLimiterRegistry,
+    HttpClient,
+    RateLimiterRegistry,
+)
+
+
+class _ScriptedTransport:
+    """httpx.Client stand-in that returns a scripted sequence of responses.
+
+    Each ``request`` pops the next ``(status, headers)`` from the script; once
+    exhausted it repeats the final entry. Bodies are an empty JSON object so the
+    JSON cache path is exercised exactly like a real API response.
+    """
+
+    def __init__(self, script: list[tuple[int, dict[str, str]]]):
+        self._script = script
+        self.calls = 0
+
+    def request(self, method, url, **kwargs):
+        idx = min(self.calls, len(self._script) - 1)
+        self.calls += 1
+        status, extra_headers = self._script[idx]
+        headers = {"Content-Type": "application/json", **extra_headers}
+        return httpx.Response(
+            status,
+            content=b"{}",
+            headers=headers,
+            request=httpx.Request(method, str(url)),
+        )
+
+
+def _http(registry, transport) -> HttpClient:
+    # No cache so retried statuses are never short-circuited by a cache hit;
+    # high base limits so the rate limiter itself never sleeps in these tests.
+    http = HttpClient(timeout=5.0, user_agent="test", rate_limiter=registry, cache=None)
+    http.client = transport  # type: ignore[assignment]
+    return http
+
+
+# --------------------------------------------------------------------------- #
+# P2: --rate-limit must scale ALL services, not just 6.
+# --------------------------------------------------------------------------- #
+
+
+def test_build_rate_limits_at_default_is_byte_identical_to_defaults():
+    """At --rate-limit=45 (rate_scale=1.0) every service equals its default."""
+    limits = build_rate_limits(rate_limit=45.0, s2_api_key=None)
+    for service, default in RateLimiterRegistry.DEFAULT_LIMITS.items():
+        if service == "semanticscholar":
+            continue  # key-aware overlay handled separately
+        assert limits[service] == default, service
+
+
+def test_build_rate_limits_scales_openalex_and_arxiv():
+    """The previously-unscaled polite-pool services now respond to --rate-limit.
+
+    At half the default rate (22.5/45 = 0.5) OpenAlex (100) and arXiv (30) must
+    halve; under the old inline dict they stayed pinned at their defaults.
+    """
+    limits = build_rate_limits(rate_limit=22.5, s2_api_key=None)
+    assert limits["openalex"] == 50
+    assert limits["arxiv"] == 15
+
+
+def test_build_rate_limits_preserves_s2_key_aware_overlay():
+    """Keyless S2 stays low (bot-detection mitigation); a key lifts it to 60."""
+    keyless = build_rate_limits(rate_limit=45.0, s2_api_key=None)
+    keyed = build_rate_limits(rate_limit=45.0, s2_api_key="secret")
+    assert keyless["semanticscholar"] == 10
+    assert keyed["semanticscholar"] == 60
+
+
+def test_build_rate_limits_includes_book_verifier_services():
+    """openlibrary / google_books are not in DEFAULT_LIMITS but must be present."""
+    limits = build_rate_limits(rate_limit=45.0, s2_api_key=None)
+    assert "openlibrary" in limits
+    assert "google_books" in limits
+
+
+# --------------------------------------------------------------------------- #
+# P1: honour Retry-After + adaptive rate-halving in the sync retry loop.
+# --------------------------------------------------------------------------- #
+
+
+def test_request_honors_retry_after_header(monkeypatch):
+    """A 429 carrying ``Retry-After: 3`` makes the retry sleep ~3s, not the
+    exponential 1s the loop would otherwise use on the first retry."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+
+    registry = RateLimiterRegistry(dict.fromkeys(RateLimiterRegistry.DEFAULT_LIMITS, 100_000))
+    transport = _ScriptedTransport([(429, {"Retry-After": "3"}), (200, {})])
+    http = _http(registry, transport)
+
+    resp = http._request("GET", "https://api.crossref.org/works", service="crossref")
+
+    assert resp.status_code == 200
+    assert sleeps, "expected a backoff sleep between the 429 and the retry"
+    # First (and only) backoff must honour the server's Retry-After of 3s,
+    # not the loop's exponential first step of 1.0s.
+    assert sleeps[0] == pytest.approx(3.0)
+
+
+def test_request_caps_absurd_retry_after(monkeypatch):
+    """A hostile/huge Retry-After is capped so one entry cannot stall for hours."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("time.sleep", lambda s: sleeps.append(s))
+
+    registry = RateLimiterRegistry(dict.fromkeys(RateLimiterRegistry.DEFAULT_LIMITS, 100_000))
+    transport = _ScriptedTransport([(429, {"Retry-After": "99999"}), (200, {})])
+    http = _http(registry, transport)
+
+    http._request("GET", "https://api.crossref.org/works", service="crossref")
+
+    assert sleeps[0] <= 60.0
+
+
+def test_adaptive_registry_halves_rate_on_429(monkeypatch):
+    """A 429 must halve the per-service rate for subsequent requests via adapt().
+
+    This proves adapt() is actually wired into the synchronous request path
+    (previously it was dead code: only the async client reached it).
+    """
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    registry = AdaptiveRateLimiterRegistry({"crossref": 50})
+    transport = _ScriptedTransport([(429, {}), (200, {})])
+    http = _http(registry, transport)
+
+    http._request("GET", "https://api.crossref.org/works", service="crossref")
+
+    assert registry._limits["crossref"] == 25
+
+
+def test_healthy_responses_do_not_change_rate(monkeypatch):
+    """No 429 / no low-remaining header => the rate is untouched (perf-neutral)."""
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    registry = AdaptiveRateLimiterRegistry({"crossref": 50})
+    transport = _ScriptedTransport([(200, {})])
+    http = _http(registry, transport)
+
+    http._request("GET", "https://api.crossref.org/works", service="crossref")
+
+    assert registry._limits["crossref"] == 50


### PR DESCRIPTION
## Why

A user hit **timeouts and rate-limit (429) issues** running `bibtex-check`. Investigation (deep dive + adversarial soundness review) found the symptoms are driven by the cascade's per-entry network cost and a rate-limit layer that ignored server guidance — and that upgrading v0.9.2/v1.0.0 → v1.2.0 *mostly worsens* them (the cascade grew 3→5 sources + a relaxed-author fallback). These three changes cut wall-clock under rate-limit pressure **without changing any verification outcome**.

Rate-limiting in this tool fails *conservatively* (a lost source → abstention, never a fabricated flag), so pacing changes are structurally verdict-neutral; the ~2% FPR is unaffected.

## Changes

**P1 — honor `Retry-After` + adaptive rate-halving** (`utils.py`, `fact_checker.py`)
- `HttpClient._request` now honors a 429 `Retry-After` header (integer seconds, capped 60s) instead of blindly using its exponential schedule.
- Each response is fed to `AdaptiveRateLimiterRegistry.adapt()`, so a 429 halves that service's rate for the rest of the run rather than all workers re-hammering the same limit. **The adaptive backoff was previously async-only — the synchronous checker bypassed it entirely** (it called the per-service `RateLimiter.wait()` directly, never the registry's backoff-aware path).
- Moved `adapt()`'s `_limits` writes under the registry lock (removes a benign data race with concurrent `get()` readers).

**P2 — `--rate-limit` scales *all* services** (`fact_checker.py`)
- New `build_rate_limits()` scales every service in `DEFAULT_LIMITS`. Previously only 6 of ~9 scaled; **OpenAlex (100/min), arXiv, ACL, Europe PMC, Scholar ignored the knob**, so a user who dialed `--rate-limit` down to escape 429s kept hammering those at full speed.
- Byte-identical at the default `--rate-limit=45` (`rate_scale == 1`); S2 key-aware overlay preserved.

**P7 — background Crossref pre-warm** (`fact_checker.py`)
- The `/works` pre-warm now runs in a background thread (joined in `finally`, never leaked) so the per-entry worker pool starts immediately instead of waiting out the serial, rate-limited pre-warm prefix — the "hang at startup" on large bibliographies.

## Soundness

Every change is pacing/scheduling only — it never alters which records are fetched, candidate selection, the `_has_full_confirmation` short-circuit, abstention thresholds, the source roster, or cache correctness. An adversarial review pass explicitly rejected the *non*-neutral speed ideas (fail-fast-on-timeout, lower backoff ceiling, main-pool wall-clock guard, cascade parallelization) because they can flip verdicts; those are deliberately **not** in this PR.

## Tests

TDD: 10 new tests (`tests/test_rate_limit_backoff.py` for P1/P2; `TestBackgroundPrewarm` in `tests/test_crossref_prefetch.py` for P7). Full suite **1142 passing, 1 skipped**; pre-commit (black + ruff) clean.

## Follow-ups (not in this PR)
- **Zero-code biggest real-world win:** set `S2_API_KEY` — keyless Semantic Scholar (cascade stage 5) is pinned to 10/min and 429-prone; a key lifts it to 60/min.
- Optional opt-in `--fast` flag (revert short-circuit + skip fallback) — biggest per-entry speedup but trades away hallucination/venue detection, so default-off only; deferred pending a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)