### PR TITLE
fix(matching): strip generational suffixes (Jr./III) from surname keys

### DIFF
--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -242,6 +242,34 @@ def split_authors_bibtex(author_field: str) -> list[str]:
     return parts
 
 
+#: Generational/lineage suffixes that trail a surname ("John Smith Jr.",
+#: "Forsyth III"). Like single-letter initials and 4-digit DBLP homonym
+#: suffixes, they are NOT the distinctive family token and must be dropped
+#: before taking the last token -- otherwise "John Smith Jr." reduces to "jr"
+#: and spuriously MISMATCHES the suffix-less "John Smith" of the same author.
+#: Multi-character only: a bare "V"/"I" generational numeral is already removed
+#: by the single-letter rule, and listing it here could eat a real initial.
+_GENERATIONAL_SUFFIXES: frozenset[str] = frozenset({"jr", "sr", "ii", "iii", "iv"})
+
+
+def _reduce_trailing_to_surname(tokens: list[str]) -> list[str]:
+    """Drop trailing non-surname tokens so the last token is the family name.
+
+    Strips, from the end: 4-digit DBLP homonym suffixes ("Sun 0020"), trailing
+    single-letter initials ("Mallikarjun B. R." -> the naive last token would be
+    "r"), and generational suffixes ("John Smith Jr." -> "jr"). Guarded by
+    ``len > 1`` so a name that is *only* an initial/number/suffix is never
+    emptied. Shared by :func:`last_name_from_person` and
+    :func:`_normalize_surname_key` so the entry side and the authoritative
+    record side reduce IDENTICALLY (the symmetry the whole comparison relies on).
+    """
+    while len(tokens) > 1 and (
+        re.fullmatch(r"\d{4}", tokens[-1]) or len(tokens[-1]) == 1 or tokens[-1] in _GENERATIONAL_SUFFIXES
+    ):
+        tokens.pop()
+    return tokens
+
+
 def last_name_from_person(name: str) -> str:
     """Extract a comparable surname key from a person name.
 
@@ -260,14 +288,7 @@ def last_name_from_person(name: str) -> str:
     last = strip_diacritics(last).lower()
     last = re.sub(r"[^a-z0-9\s-]", "", last).strip()
 
-    tokens = last.split()
-    # Drop trailing junk tokens so the key is the real surname:
-    #   - 4-digit DBLP homonym suffixes ("Sun 0020", "Li 0001")
-    #   - trailing single-letter initials ("Mallikarjun B. R." -> "mallikarjun",
-    #     where naive last-token would give "r")
-    # Guarded by len > 1 so a name that is only an initial/number is never emptied.
-    while len(tokens) > 1 and (re.fullmatch(r"\d{4}", tokens[-1]) or len(tokens[-1]) == 1):
-        tokens.pop()
+    tokens = _reduce_trailing_to_surname(last.split())
     if tokens:
         last = tokens[-1]
     return last
@@ -297,13 +318,12 @@ def _normalize_surname_key(family: str) -> str:
         family = family.split(",", 1)[0].strip()
     key = strip_diacritics(family).lower()
     key = re.sub(r"[^a-z0-9\s-]", "", key).strip()
-    tokens = key.split()
-    # Drop trailing junk (4-digit DBLP suffix / single-letter initial) then take
-    # the distinctive last family token -- identical reduction to
-    # ``last_name_from_person``, but applied to a family-only string so the lead
-    # given name of a CJK name can never masquerade as the surname.
-    while len(tokens) > 1 and (re.fullmatch(r"\d{4}", tokens[-1]) or len(tokens[-1]) == 1):
-        tokens.pop()
+    # Drop trailing junk (4-digit DBLP suffix / single-letter initial /
+    # generational suffix) then take the distinctive last family token --
+    # identical reduction to ``last_name_from_person`` (same shared helper),
+    # but applied to a family-only string so the lead given name of a CJK name
+    # can never masquerade as the surname.
+    tokens = _reduce_trailing_to_surname(key.split())
     if tokens:
         return tokens[-1]
     return ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -162,6 +162,23 @@ class TestLastNameFromPerson:
         result = last_name_from_person("Smith, John Jr.")
         assert "smith" in result.lower()
 
+    def test_last_name_generational_suffix_after_surname(self):
+        # A generational suffix trailing the SURNAME must be dropped, or
+        # "John Smith Jr." reduces to "jr" and spuriously mismatches the
+        # suffix-less "John Smith" of the same author (and the comma form).
+        assert last_name_from_person("John Smith Jr.") == "smith"
+        assert last_name_from_person("Smith Jr., John") == "smith"
+        assert last_name_from_person("Forsyth III") == "forsyth"
+        assert last_name_from_person("Robert Downey IV") == "downey"
+
+    def test_normalize_surname_key_symmetric_with_suffix(self):
+        # The authoritative record side must reduce a suffixed family
+        # identically to the entry side, or the two never compare equal.
+        from bibtex_updater.utils import _normalize_surname_key
+
+        assert _normalize_surname_key("Smith Jr.") == last_name_from_person("John Smith Jr.")
+        assert _normalize_surname_key("Forsyth III") == "forsyth"
+
     def test_last_name_trailing_initials_skipped(self):
         # "Mallikarjun B. R." (surname first, then initials) -> "mallikarjun",
         # not the naive last token "r".


### PR DESCRIPTION
## What

`last_name_from_person` / `_normalize_surname_key` reduced a person name to its surname key by dropping trailing 4-digit DBLP homonym suffixes and single-letter initials — but **not generational suffixes**. So `"John Smith Jr."` reduced to the key `"jr"` (and `"Smith Jr., John"` likewise), which then **spuriously MISMATCHed** the suffix-less `"John Smith"` of the same author — a false hallucination signal in the author check.

## Fix

Extract a shared `_reduce_trailing_to_surname()` helper (now also dropping `jr/sr/ii/iii/iv`) and route **both** the entry side and the authoritative-record side through it, so the two reduce identically — the symmetry the whole author comparison relies on. Multi-character suffixes only; a bare generational `"V"`/`"I"` is already removed by the single-letter rule, so listing it would risk eating a real initial.

```
last_name_from_person("John Smith Jr.")   # "jr"  -> "smith"
last_name_from_person("Smith Jr., John")  # "jr"  -> "smith"
_normalize_surname_key("Forsyth III")     # "iii" -> "forsyth"
```

## Tests

Adds `test_last_name_generational_suffix_after_surname` and `test_normalize_surname_key_symmetric_with_suffix` to `tests/test_utils.py::TestLastNameFromPerson`. Full suite green (1531 passed; the only 2 failures are pre-existing bare-`python`-subprocess obsidian-CLI tests, environmental — they fail on `main` too).

## Context

Surfaced while investigating author **name-variant** handling. The middle-initial case that prompted it — `"Roland S. Zimmermann"` vs `"Roland Zimmermann"` — was already correct (surname-only matching + a benign `MIDDLE_NAME` given-name tier); this fixes the adjacent generational-suffix case it exposed.

Behaviour change is confined to names whose surname token is exactly `jr/sr/ii/iii/iv` (no real surname is), so HALLMARK impact is ~nil — verified zero verdict change on the 3 `test_crossdomain` entries carrying such a token (all have the suffix mid-string, not surname-trailing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)