### PR TITLE
fix(matching): treat glued PubMed initials as initials, not a substitution

### DIFF
--- a/benchmarks/HALLMARK.md
+++ b/benchmarks/HALLMARK.md
@@ -173,9 +173,19 @@ abstention `p_valid ≈ 0.5` rather than a meaningful calibration signal).
   "maria", found beyond edit distance, and escalated to a substitution. Across the 22
   entries all 58 escalating positions are glued-initials runs whose letters are in fact
   the record's leading initials — every flag is benign. It does not appear at scale on
-  the ML splits (`test_public` FPR 4.2%); the scoped follow-up is to recognize a glued
-  all-caps initial run and route it through the existing `INITIAL_COMPATIBLE` /
-  `INITIAL_CONFLICT` path (never a substitution).
+  the ML splits (`test_public` FPR 4.2%).
+
+  *Fixed* (PR [#48](https://github.com/rpatrik96/bibtexupdater/pull/48)): a glued all-caps
+  initial run is now expanded to spaced initials before grading, routing it through the
+  existing `INITIAL_COMPATIBLE` / `INITIAL_CONFLICT` path so it can never escalate to a
+  substitution. On `test_crossdomain` this removes 22 of these FPs (**FPR 0.320 → 0.210,
+  MCC 0.658 → 0.736, F1 0.873 → 0.899**); dev/test detection is unchanged (their
+  given-name flags are real full-name differences, not glued initials, so the deglue
+  never fires). The fix unmasks three crossdomain entries whose true perturbation is in
+  the title/venue, not the authors — the author flag had been catching them incidentally:
+  two now abstain (`unconfirmed`) and one is a documented `near_miss_title` leak
+  (`KNOWN_LEAKS.md`, caught only by `--strict`), so DR moves 0.940 → 0.930. These are
+  pre-existing title/venue gaps exposed, not regressions introduced by the fix.
 
 This block was produced by `scripts/eval_hallmark.py` + `scripts/_compare_hallmark_runs.py`
 over `eval_runs/{dev_public,test_public,stress_test,test_crossdomain}/` — all four splits

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -529,14 +529,40 @@ def _nickname_equiv(a: str, b: str) -> bool:
     return any(a in grp and b in grp for grp in _NICKNAME_GROUPS)
 
 
+def _deglue_initials(given: str) -> str:
+    """Expand a glued, separator-less all-caps initial run into spaced initials.
+
+    PubMed/biomedical sources write given names as concatenated initials with no
+    dots or spaces -- "ME" for *Maria Elisabetta*, "RMF" for *Robin Maria
+    Francisca*. Without this, ``_given_tokens("ME")`` yields the single 2-char
+    token ``["me"]``, which is not all-length-1 so it escapes the initials branch
+    of :func:`classify_given_pair` and is graded as a *full* given token -- "me"
+    vs "maria" then escalates to a spurious SUBSTITUTION (a false author flag).
+
+    Case is the disambiguator: only an all-uppercase 2-5 letter run with no
+    separator is treated as glued initials, so a real short given ("Bo", "Wei",
+    mixed-case) is left untouched. The conservative failure mode if a genuinely
+    all-caps short name ever slips through is INITIAL_CONFLICT (-> soften/abstain),
+    never a false flag. Returns ``given`` unchanged when it is not such a run.
+    """
+    s = strip_diacritics(latex_to_plain(given or "")).strip()
+    if re.fullmatch(r"[A-Z]{2,5}", s):
+        return " ".join(s)
+    return given
+
+
 def classify_given_pair(given_entry: str, given_record: str) -> str:
     """Classify a single (entry, record) given-name pair into a GivenNameVariety.
 
     First-hit-wins cascade. Only SUBSTITUTION (two FULL, non-initial first given
     tokens that are neither a nickname pair nor within a small edit distance)
     escalates; everything else is a benign convention or a low-confidence variant.
+
+    Glued separator-less initial runs ("ME", "RMF") are expanded to spaced
+    initials first (see :func:`_deglue_initials`) so the initials branch handles
+    them instead of mis-grading them as full given tokens.
     """
-    te, tr = _given_tokens(given_entry), _given_tokens(given_record)
+    te, tr = _given_tokens(_deglue_initials(given_entry)), _given_tokens(_deglue_initials(given_record))
     if not te or not tr:
         return GivenNameVariety.NON_COMPARABLE
     if te == tr:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -575,6 +575,23 @@ class TestClassifyGivenPair:
         assert self._class("Sergey", "Serguei") == "soften"  # close romanization
         assert self._class("Y.", "Jiaming") == "soften"  # initial conflict
 
+    def test_glued_pubmed_initials_are_confirmed_not_substitution(self):
+        # PubMed writes given names as glued separator-less initial runs ("ME"
+        # for Maria Elisabetta). Without deglueing these were read as a full
+        # token and mis-escalated to a substitution ("me" vs "maria").
+        assert self._class("ME", "Maria Elisabetta") == "confirmed"
+        assert self._class("MK", "Michael K.") == "confirmed"
+        assert self._class("RMF", "Robin Maria Francisca") == "confirmed"
+        assert self._class("AA", "Alexey A.") == "confirmed"
+        # A glued run whose letters do NOT lead the record name is a low-confidence
+        # initial conflict (soften/abstain), never a hard substitution flag.
+        assert self._class("XY", "Maria Elisabetta") == "soften"
+        # Real short given names are mixed-case, not glued initials -> untouched.
+        assert self._class("Bo", "Bo") == "confirmed"
+        assert self._class("Wei", "Wei Zhang") == "confirmed"
+        # Deglueing must NOT rescue a genuine full-name substitution.
+        assert self._class("Yujing", "Yue") == "escalate"
+
     def test_missing_given_is_non_comparable(self):
         assert self._class("", "Yue") == "skip"
         assert self._class("Yue", "") == "skip"


### PR DESCRIPTION
## Bug

PubMed/biomedical citations write given names as **glued, separator-less initial runs** — `"ME"` for *Maria Elisabetta*, `"MK"` for *Michael K.*, `"RMF"` for *Robin Maria Francisca*. `_given_tokens("ME")` yields the single 2-char token `["me"]`, which is not all-length-1, so it escaped `classify_given_pair`'s initials branch, was graded as a **full** given token, compared `"me"` vs `"maria"`, found beyond edit distance, and escalated to a spurious `SUBSTITUTION` — a false author flag on a valid citation.

## Fix

`_deglue_initials`: an all-uppercase 2–5 letter run with no separator is expanded to spaced initials (`"ME"` → `"M E"`) before tokenizing, so the **existing** `INITIAL_COMPATIBLE` / `INITIAL_CONFLICT` logic handles it — it can never escalate to a substitution. Case is the disambiguator (`"Bo"`/`"Wei"` are mixed-case real names, untouched); the worst case for a stray all-caps token is `INITIAL_CONFLICT` → soften/abstain, never a false flag. Genuine substitutions (`Yujing`/`Yue`) aren't glued initials and still escalate.

## HALLMARK verification (end-to-end, all 35 entries the change can affect)

Re-ran every entry currently statused `given_name_substitution` across the four splits with the patched code:

- **Removes 23 false positives** (22 `test_crossdomain` + 1 `dev_public`).
- **`test_crossdomain`: FPR 0.320 → 0.210, MCC 0.658 → 0.736, F1 0.873 → 0.899, Precision +5.4pp.**
- **DR preserved on dev/test** — all 7 HALLUCINATED entries there stay caught (their given-name flags are real full-name differences, not glued initials, so the deglue never fires).
- It **unmasks 3 `test_crossdomain` entries** whose real perturbation is in the title/venue, not the authors (the author flag had incidentally covered them): 2 now abstain (`unconfirmed`), 1 is a documented `near_miss_title` leak (`KNOWN_LEAKS.md`, caught only by `--strict`). DR 0.940 → 0.930. These are pre-existing title/venue gaps exposed, not regressions introduced here. Shipped intentionally (the removed catches were author-flag noise; net is strongly positive).

## Tests

`tests/test_utils.py::TestClassifyGivenPair::test_glued_pubmed_initials_are_confirmed_not_substitution`. Full suite green (only the 2 pre-existing bare-`python`-subprocess obsidian-CLI failures remain, environmental).

🤖 Generated with [Claude Code](https://claude.com/claude-code)