### PR TITLE
fix(utils): close the adaptive-limiter lock race

### DIFF
--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -1207,13 +1207,14 @@ class AdaptiveRateLimiterRegistry(RateLimiterRegistry):
             try:
                 remaining_int = int(remaining)
                 if remaining_int < 10:
-                    # Getting close to limit, slow down
-                    current_limit = self._limits.get(service, 30)
-                    new_limit = max(current_limit // 2, self._min_limits.get(service, 5))
-                    if new_limit != current_limit:
-                        self._limits[service] = new_limit
-                        # Recreate limiter with new limit
-                        with self._lock:
+                    # Getting close to limit, slow down. The read-modify-write
+                    # on ``_limits`` must share the lock with the paired
+                    # ``_limiters`` swap, or a concurrent adapt can tear them.
+                    with self._lock:
+                        current_limit = self._limits.get(service, 30)
+                        new_limit = max(current_limit // 2, self._min_limits.get(service, 5))
+                        if new_limit != current_limit:
+                            self._limits[service] = new_limit
                             self._limiters[service] = RateLimiter(new_limit)
             except (ValueError, TypeError):
                 pass
@@ -1233,11 +1234,11 @@ class AdaptiveRateLimiterRegistry(RateLimiterRegistry):
             with self._lock:
                 self._backoff_until[service] = time.time() + backoff_seconds
 
-            # Also reduce the rate limit
-            current_limit = self._limits.get(service, 30)
-            new_limit = max(current_limit // 2, self._min_limits.get(service, 5))
-            self._limits[service] = new_limit
+            # Also reduce the rate limit (same locking rationale as above).
             with self._lock:
+                current_limit = self._limits.get(service, 30)
+                new_limit = max(current_limit // 2, self._min_limits.get(service, 5))
+                self._limits[service] = new_limit
                 self._limiters[service] = RateLimiter(new_limit)
 
     def wait(self, service: str) -> None:
@@ -1263,8 +1264,8 @@ class AdaptiveRateLimiterRegistry(RateLimiterRegistry):
             service: Name of the API service
         """
         default = self.DEFAULT_LIMITS.get(service, 30)
-        self._limits[service] = default
         with self._lock:
+            self._limits[service] = default
             if service in self._limiters:
                 self._limiters[service] = RateLimiter(default)
 


### PR DESCRIPTION
`AdaptiveRateLimiterRegistry` wrote `_limits[service]` outside the lock that guards the paired `_limiters` swap in three places (X-RateLimit-Remaining slowdown, 429 backoff, `reset_limit`), so concurrent `adapt` calls could tear the limit/limiter pair. This hoists the lock over each read-modify-write block. No behavior change under single-threaded use; 1,564 tests pass locally.

Salvages the one still-relevant fix from #43 — the rest of that PR (uniform rate scaling, static retry delay) has been superseded on main by the hand-tuned per-service limits, circuit breaker, and jittered `retry_after_seconds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)