### PR TITLE
fix(chain): discharge --report and the strict exit code in chain drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ htmlcov/
 
 # Cache files
 .cache.replace_preprints.json
+.cache.resolution.json
 *.cache
 .cache.*.db
 .smoke-cache.json

--- a/src/bibtex_updater/chain.py
+++ b/src/bibtex_updater/chain.py
@@ -15,6 +15,7 @@ could not resolve, failures -- still go to the checker, where verification matte
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -220,6 +221,9 @@ class ChainResult:
     cleaned_entries: list[dict[str, Any]] = field(default_factory=list)
     check_results: list[Any] = field(default_factory=list)
     report: dict[str, Any] = field(default_factory=dict)
+    # The checker processor that produced ``check_results``. The drivers need it to
+    # emit the same JSON report and strict verdict as the plain checker CLI.
+    processor: Any = None
 
 
 def run_chain(
@@ -322,6 +326,7 @@ def run_chain(
         cleaned_entries=cleaned_entries,
         check_results=check_results,
         report=report,
+        processor=processor,
     )
 
 
@@ -434,6 +439,83 @@ def _print_report(report: dict[str, Any], logger: logging.Logger) -> None:
             logger.warning("  %s: %s", e.get("key"), e.get("check"))
 
 
+def _write_check_report(check_args: Any, result: ChainResult, logger: logging.Logger) -> None:
+    """Persist the checker's JSON report, matching the plain ``bibtex-check`` schema.
+
+    Both chain drivers return before ``fact_checker.main``'s report-writing tail, so
+    a chain run has to discharge ``--report`` itself or the flag is silently dropped.
+    """
+    report_path = getattr(check_args, "report", None)
+    if not report_path:
+        return
+
+    processor = result.processor
+    doc: dict[str, Any] = (
+        processor.generate_json_report(result.check_results)
+        if processor is not None
+        else {"summary": {}, "entries": []}
+    )
+    # Trusted upgrades never reach the checker, so ``entries`` covers only the
+    # verified subset. The chain view is attached alongside it so the report still
+    # accounts for every input entry and says which ones were skipped as upgrades.
+    doc["chain"] = result.report
+    try:
+        with open(report_path, "w", encoding="utf-8") as fh:
+            json.dump(doc, fh, indent=2, ensure_ascii=False)
+    except OSError as e:
+        logger.error("Failed to write JSON report %s: %s", report_path, e)
+        return
+    logger.info("JSON report written to %s", report_path)
+
+
+def _strict_exit_code(check_args: Any, result: ChainResult, logger: logging.Logger) -> int:
+    """Mirror the plain checker's strict gate: only positive-evidence problems fail.
+
+    Abstentions (could-not-verify) never fail on their own; ``--strict-warn-cnv``
+    opts into failing on them too.
+    """
+    if not getattr(check_args, "strict", False):
+        return 0
+    processor = result.processor
+    if processor is None:
+        return 0
+
+    from .fact_checker import FactCheckStatus
+
+    summary = processor.generate_summary(result.check_results)
+    problem_count = summary.get("problematic_count", 0)
+    if problem_count > 0:
+        logger.warning("Strict mode: %d PROBLEMATIC entries (positive evidence of a problem)", problem_count)
+        return 4
+    cnv_warn_count = summary.get("status_counts", {}).get(FactCheckStatus.STRICT_WARN_CNV.value, 0)
+    if getattr(check_args, "strict_warn_cnv", False) and cnv_warn_count > 0:
+        logger.warning(
+            "Strict mode (warn-cnv): %d STRICT_WARN_CNV entries (could-not-verify, opt-in fail)",
+            cnv_warn_count,
+        )
+        return 4
+    return 0
+
+
+def _write_update_report(update_args: Any, result: ChainResult, logger: logging.Logger) -> None:
+    """Persist the resolver's JSONL original->updated report (``bibtex-update --report``)."""
+    report_path = getattr(update_args, "report", None)
+    if not report_path:
+        return
+
+    from .updater import write_report_line
+
+    try:
+        with open(report_path, "w", encoding="utf-8") as fh:
+            for res in result.results:
+                if res is not None:
+                    write_report_line(fh, res)
+    except OSError as e:
+        logger.error("Failed to write JSONL report %s: %s", report_path, e)
+        return
+    logger.info("JSONL report written to %s", report_path)
+
+
 def run_update_then_check(update_args: Any, logger: logging.Logger) -> int:
     """Driver for ``bibtex-update --then-check``: upgrade, write clean bib, verify the rest."""
     entries = _load_entries(list(getattr(update_args, "inputs", []) or []), logger)
@@ -453,6 +535,7 @@ def run_update_then_check(update_args: Any, logger: logging.Logger) -> int:
         logger.warning("No -o/--output or --in-place given; cleaned bib not written")
 
     _print_report(result.report, logger)
+    _write_update_report(update_args, result, logger)
     return 0
 
 
@@ -472,4 +555,7 @@ def run_check_resolve_first(check_args: Any, logger: logging.Logger) -> int:
     _write_bib(result.cleaned_entries, out_path, logger)
 
     _print_report(result.report, logger)
-    return 0
+    _write_check_report(check_args, result, logger)
+    if getattr(check_args, "jsonl", None):
+        logger.info("JSONL report streamed to %s (%d entries)", check_args.jsonl, len(result.check_results))
+    return _strict_exit_code(check_args, result, logger)

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -6047,6 +6047,10 @@ def main() -> int:
     if getattr(args, "resolve_first", False):
         from .chain import run_check_resolve_first
 
+        # The chain reads strictness off ``check_args``, so fold the env-var form in
+        # here -- otherwise BIBTEX_CHECK_STRICT=1 would be honored by the plain path
+        # but silently ignored when chaining.
+        args.strict = strict_mode
         return run_check_resolve_first(args, logger)
 
     # Load entries from all BibTeX files

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -7,10 +7,12 @@ from a bibliographic database, so re-verifying it is redundant ("clean bib, fast
 
 from __future__ import annotations
 
+import json
 import logging
 from types import SimpleNamespace
 
-from bibtex_updater.chain import build_chain_report, select_entries_to_check
+import bibtex_updater.chain as chain_mod
+from bibtex_updater.chain import ChainResult, build_chain_report, select_entries_to_check
 from bibtex_updater.updater import ProcessResult
 
 
@@ -264,3 +266,153 @@ class TestArgBridging:
         assert resolve_args.rate_limit == 25
         assert resolve_args.max_workers == 5
         assert _default_resolved_out(["refs.bib"]) == "refs.resolved.bib"
+
+
+class _FakeProcessor:
+    """Stands in for FactCheckProcessor: only the two report hooks are exercised."""
+
+    def __init__(self, problematic: int = 0, warn_cnv: int = 0):
+        self._problematic = problematic
+        self._warn_cnv = warn_cnv
+
+    def generate_summary(self, results):
+        return {
+            "total": len(results),
+            "problematic_count": self._problematic,
+            "status_counts": {"strict_warn_cnv": self._warn_cnv},
+        }
+
+    def generate_json_report(self, results):
+        return {
+            "summary": self.generate_summary(results),
+            "entries": [{"key": r.entry_key, "status": r.status} for r in results],
+        }
+
+
+def _bib(tmp_path, key: str = "a"):
+    path = tmp_path / "refs.bib"
+    path.write_text(f"@article{{{key}, title={{Some title}}, author={{Doe, Jane}}, year={{2020}}}}\n")
+    return path
+
+
+def _stub_chain(monkeypatch, *, processor, check_results=(), results=None):
+    """Replace run_chain so the drivers are tested without network or resolver work."""
+    results = results or [_result("a", "no_change")]
+
+    def fake_run_chain(entries, resolve_args, logger, *, check_args):
+        return ChainResult(
+            results=results,
+            cleaned_entries=[r.updated for r in results],
+            check_results=list(check_results),
+            report=build_chain_report(results, list(check_results)),
+            processor=processor,
+        )
+
+    monkeypatch.setattr(chain_mod, "run_chain", fake_run_chain)
+
+
+class TestChainReportPersistence:
+    """A chain run must honor the same --report/--jsonl contract as the plain CLI.
+
+    The drivers return before their CLI's report-writing tail, so every persistence
+    obligation has to be discharged inside the driver itself.
+    """
+
+    def test_resolve_first_writes_the_json_report(self, tmp_path, monkeypatch):
+        from bibtex_updater.chain import run_check_resolve_first
+        from bibtex_updater.fact_checker import build_parser
+
+        bib, report = _bib(tmp_path), tmp_path / "check.json"
+        checks = [SimpleNamespace(entry_key="a", status="verified")]
+        _stub_chain(monkeypatch, processor=_FakeProcessor(), check_results=checks)
+
+        args = build_parser().parse_args([str(bib), "--resolve-first", "--report", str(report), "--no-cache"])
+        assert run_check_resolve_first(args, logging.getLogger("t")) == 0
+
+        assert report.exists(), "--report was silently dropped in resolve-first mode"
+        doc = json.loads(report.read_text())
+        assert doc["entries"][0]["key"] == "a"
+        assert doc["summary"]["total"] == 1
+        # The chain view records what the checker never saw (trusted upgrades).
+        assert doc["chain"]["summary"]["total"] == 1
+
+    def test_resolve_first_without_report_writes_nothing(self, tmp_path, monkeypatch):
+        from bibtex_updater.chain import run_check_resolve_first
+        from bibtex_updater.fact_checker import build_parser
+
+        bib = _bib(tmp_path)
+        _stub_chain(monkeypatch, processor=_FakeProcessor())
+
+        args = build_parser().parse_args([str(bib), "--resolve-first", "--no-cache"])
+        assert run_check_resolve_first(args, logging.getLogger("t")) == 0
+        assert not list(tmp_path.glob("*.json"))
+
+    def test_resolve_first_strict_exits_4_on_problematic(self, tmp_path, monkeypatch):
+        from bibtex_updater.chain import run_check_resolve_first
+        from bibtex_updater.fact_checker import build_parser
+
+        bib = _bib(tmp_path)
+        checks = [SimpleNamespace(entry_key="a", status="hallucinated")]
+        _stub_chain(monkeypatch, processor=_FakeProcessor(problematic=1), check_results=checks)
+
+        args = build_parser().parse_args([str(bib), "--resolve-first", "--strict", "--no-cache"])
+        assert run_check_resolve_first(args, logging.getLogger("t")) == 4
+
+    def test_resolve_first_strict_exits_0_when_clean(self, tmp_path, monkeypatch):
+        from bibtex_updater.chain import run_check_resolve_first
+        from bibtex_updater.fact_checker import build_parser
+
+        bib = _bib(tmp_path)
+        _stub_chain(monkeypatch, processor=_FakeProcessor(problematic=0))
+
+        args = build_parser().parse_args([str(bib), "--resolve-first", "--strict", "--no-cache"])
+        assert run_check_resolve_first(args, logging.getLogger("t")) == 0
+
+    def test_resolve_first_strict_warn_cnv_exits_4(self, tmp_path, monkeypatch):
+        from bibtex_updater.chain import run_check_resolve_first
+        from bibtex_updater.fact_checker import build_parser
+
+        bib = _bib(tmp_path)
+        _stub_chain(monkeypatch, processor=_FakeProcessor(warn_cnv=2))
+
+        args = build_parser().parse_args([str(bib), "--resolve-first", "--strict", "--strict-warn-cnv", "--no-cache"])
+        assert run_check_resolve_first(args, logging.getLogger("t")) == 4
+
+    def test_then_check_writes_the_resolver_jsonl_report(self, tmp_path, monkeypatch):
+        from bibtex_updater.chain import run_update_then_check
+        from bibtex_updater.updater import build_arg_parser
+
+        bib, report = _bib(tmp_path), tmp_path / "resolve.jsonl"
+        out = tmp_path / "out.bib"
+        _stub_chain(monkeypatch, processor=_FakeProcessor(), results=[_result("a", "upgraded")])
+
+        args = build_arg_parser().parse_args(
+            [str(bib), "--then-check", "-o", str(out), "--report", str(report), "--no-cache"]
+        )
+        assert run_update_then_check(args, logging.getLogger("t")) == 0
+
+        assert report.exists(), "--report was silently dropped in then-check mode"
+        lines = [json.loads(ln) for ln in report.read_text().splitlines() if ln.strip()]
+        assert [ln["key_old"] for ln in lines] == ["a"]
+        assert lines[0]["action"] == "upgraded"
+
+
+class TestStrictEnvPropagation:
+    """BIBTEX_CHECK_STRICT must reach the chain path, not just the plain one."""
+
+    def test_env_strict_is_folded_into_args_before_chaining(self, tmp_path, monkeypatch):
+        import bibtex_updater.fact_checker as fc
+
+        bib = _bib(tmp_path)
+        seen = {}
+
+        def fake_driver(check_args, logger):
+            seen["strict"] = check_args.strict
+            return 0
+
+        monkeypatch.setattr(chain_mod, "run_check_resolve_first", fake_driver)
+        monkeypatch.setenv("BIBTEX_CHECK_STRICT", "1")
+        monkeypatch.setattr("sys.argv", ["bibtex-check", str(bib), "--resolve-first", "--no-cache"])
+        fc.main()
+
+        assert seen["strict"] is True


### PR DESCRIPTION
## The bug

`bibtex-check --resolve-first --report X.json` wrote the resolved `.bib` and printed a console summary, but never wrote `X.json`.

`fact_checker.main()` branches into the chain driver at `fact_checker.py:6047` and returns from there — the report-writing block lives at `:6158`, after the branch. So every persistence obligation the parent CLI had already parsed was silently dropped. The identical hole existed on the updater side (`bibtex-update --then-check --report`, `updater.py:4713`).

A flag that is accepted and then ignored is worse than a rejected one: the run looks clean and the audit trail just isn't there.

Two more casualties of the same early return:

- **`--strict` always exited 0** in resolve-first mode, so a CI gate on it passed regardless of how many problematic entries were found.
- **`BIBTEX_CHECK_STRICT=1` never reached the chain**, which reads strictness off `check_args`.

## The fix

`ChainResult` now carries the checker processor, and each driver discharges its own CLI's contract:

- `_write_check_report` emits the same `{summary, entries}` schema as the plain path, so downstream parsers keep working, with the chain view attached under `chain`. Trusted upgrades never reach the checker, so `entries` alone under-reports the input set — the `chain` block is what accounts for every entry and records which were skipped as upgrades.
- `_strict_exit_code` mirrors main's gate: only positive-evidence problems fail; `--strict-warn-cnv` opts into failing on abstentions.
- `_write_update_report` closes the `--then-check` hole.
- `args.strict` is folded in `main()` before branching so the env-var form reaches the chain.

Also gitignores `.cache.resolution.json` — the resolver's default `--resolution-cache` path, which lands in every working tree after a run.

## Verification

Six new tests in `tests/test_chain.py` cover report persistence, the no-report case, all three strict outcomes, the updater JSONL path, and env-var propagation. Full suite: **1571 passed, 1 skipped**; pre-commit clean.

End-to-end on a real 192-entry bibliography: 191 entries in the report, `coverage_incomplete: 0`, chain summary accounting for all 192 (1 trusted upgrade skipped), and `--strict` exiting 4 on positive evidence instead of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBzT1WZRRqjRq8bisAFgzU