### PR TITLE
docs: state explicitly what not_found does and does not assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ python scripts/eval_hallmark.py --split /path/to/hallmark/data/v1.0/test_public.
 - **Multi-source validation**: Crossref, OpenAlex, DBLP, OpenReview, Semantic Scholar
 - **Detailed mismatch detection**: Title, author, year, venue comparisons
 - **Integrity checks**: DOI- and arXiv-ID-target consistency, ID-anchored author fabrication, chimeric-title detection
-- **Hallucination detection**: Reserves `hallucinated` for positive evidence (fabricated DOI, future/invalid year, ID misattribution); abstains (`not_found`) on weak matches
+- **Hallucination detection**: Reserves `hallucinated` for positive evidence (fabricated DOI, future/invalid year, ID misattribution); abstains (`not_found`) on weak matches. `not_found` means "the sources queried do not know this reference", not "this reference is fabricated" — but it carries negative polarity (`p_valid` 0.35) and integrations commonly map it to a hallucination label, so decide that policy deliberately ([what `not_found` does and does not assert](docs/REFERENCE_FACT_CHECKER.md#what-not_found-does-and-does-not-assert))
 - **Structured reports**: JSON and JSONL output formats
 - **CI/CD integration**: Strict mode with exit codes for automation
 

--- a/docs/REFERENCE_FACT_CHECKER.md
+++ b/docs/REFERENCE_FACT_CHECKER.md
@@ -83,6 +83,35 @@ Author handling: sources return authors in as-published order, so author-order d
 
 `hallucinated` is reserved for positive-evidence signals; a merely weak title-search match **abstains** as `not_found` rather than asserting fabrication.
 
+### What `not_found` does and does not assert
+
+`not_found` and `unconfirmed` share the could-not-verify bucket, but they are **not interchangeable**, and integrations must not treat them as such.
+
+| | `unconfirmed` | `not_found` |
+|---|---|---|
+| meaning | a record was found; some claimed field could not be confirmed | no matching record was found |
+| `p_valid` | 0.50 — neutral | **0.35 — negative polarity** |
+| how integrations read it | abstention | **commonly mapped to "hallucinated"** |
+
+`not_found` says *this tool searched its sources and found nothing*. It does **not** say the reference is fabricated. But because it carries negative polarity, downstream consumers routinely collapse it into a hallucination label — the HALLMARK harness, for instance, maps `not_found` → `HALLUCINATED` unless `coverage_incomplete` is set. Anything scoring or gating on this output inherits that reading, so state your own policy deliberately rather than letting the default decide it for you.
+
+The distinction bites hardest on **document classes the databases structurally never index**: dissertations, journal front matter (editorials, guest columns), and national-language work. A miss there carries no information about whether the work exists. Two concrete cases:
+
+- Enumerating every DOI under one journal's ISSN returns 300 records, all `type: journal-article` — its editorials are published but never deposited, so no lookup can ever confirm them.
+- Crossref/OpenAlex/DBLP/S2 do not index PhD theses; dissertations live in institutional and national repositories.
+
+For that reason `@phdthesis`/`@mastersthesis` abstain as `unconfirmed` (neutral) rather than `not_found` when the title does not confirm. Positive evidence still flags: DOI, year and arXiv-ID validation all run before this point.
+
+**Opting into the stricter policy.** If you *want* a clean exhaustive miss to count against an entry, use the existing strict flags rather than reinterpreting the status yourself:
+
+```bash
+bibtex-check refs.bib --strict --strict-warn-cnv    # exit 4 on could-not-verify too
+```
+
+`--strict-warn-cnv` promotes both `not_found` and `unconfirmed` to the visible fourth category `strict_warn_cnv`, so CI fails on entries the tool could not anchor. Default mode leaves the three-way verdict unchanged.
+
+Always check `coverage_incomplete` first: a `not_found` carrying that flag was reached while a source errored or was throttled, so it is not an exhaustive miss at all — re-run after a cooldown before drawing any conclusion.
+
 ## Status Codes
 
 | Status | Bucket | Description |

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -214,6 +214,19 @@ class FactCheckStatus(Enum):
 
     # Academic verification statuses
     VERIFIED = "verified"
+    # No matching record was found. This asserts "the sources queried do not
+    # know this reference", NOT "this reference is fabricated" -- HALLUCINATED
+    # is reserved for positive evidence.
+    #
+    # It is an abstention, but NOT a neutral one: p_valid is 0.35 (below 0.5),
+    # and downstream integrations routinely collapse it into a hallucination
+    # label (the HALLMARK harness maps not_found -> HALLUCINATED unless
+    # coverage_incomplete is set). Anything gating on this output inherits that
+    # reading, so prefer UNCONFIRMED (p_valid 0.5) whenever a miss carries no
+    # information -- notably for document classes the databases structurally do
+    # not index: theses, journal front matter, national-language work. Users who
+    # WANT a clean miss to count opt in with --strict --strict-warn-cnv, which
+    # promotes it to STRICT_WARN_CNV; see docs/REFERENCE_FACT_CHECKER.md.
     NOT_FOUND = "not_found"
     # A matching record was found and nothing contradicts the entry, but at
     # least one claimed field could not be POSITIVELY CONFIRMED (e.g. only a


### PR DESCRIPTION
`not_found` and `unconfirmed` share the could-not-verify bucket, and the docs described both as abstentions. True, but not the whole contract — and the missing half is load-bearing for anyone scoring or gating on this output.

## The gap

| | `unconfirmed` | `not_found` |
|---|---|---|
| meaning | record found; a claimed field unconfirmable | no matching record found |
| `p_valid` | 0.50 — neutral | **0.35 — negative polarity** |
| how integrations read it | abstention | **commonly mapped to "hallucinated"** |

`not_found` says *the sources queried do not know this reference*. It does not say the reference is fabricated. But the negative polarity means downstream consumers routinely collapse it into a hallucination label — the HALLMARK harness maps `not_found` → `HALLUCINATED` unless `coverage_incomplete` is set.

## Why it matters

Hardest on **document classes the databases structurally never index**:

- Enumerating every DOI under one journal's ISSN returns 300 records, all `type: journal-article` — its editorials are published but never deposited, so no lookup can ever confirm them.
- Crossref/OpenAlex/DBLP/S2 do not index PhD theses; dissertations live in institutional and national repositories.

A miss there carries no information about whether the work exists. This is already why `@phdthesis`/`@mastersthesis` abstain as `unconfirmed` rather than `not_found` (v1.6.0).

## No behaviour change

The opt-in already exists; it is now documented as the supported way to take the stricter line instead of callers reinterpreting the status themselves:

```bash
bibtex-check refs.bib --strict --strict-warn-cnv    # exit 4 on could-not-verify too
```

Every figure quoted is asserted against the code (`p_valid` 0.35 / 0.50, and 0.50 again when `coverage_incomplete` is set), and the documented CLI flag is verified present in `--help`.

Docs + one enum comment only. 1691 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114duwwbzwpsvyBFEPoTb32