### PR TITLE
fix(checker): match a bare-acronym venue against the entry's own parenthetical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A venue stored as a bare acronym read as a different venue.** Indexes sometimes return only a conference's acronym (`CNSM`, `NOMS`, `DATE`) while the entry spells the name out and appends the acronym itself — `2023 19th International Conference on Network and Service Management (CNSM)`. The acronym is one token, below the subsumption length floor, so neither canonicalization nor name-containment reached it and the entry mismatched its own venue. A bare acronym on one side that the other side declares in its own parentheses is now the same venue: reading the entry's declared shorthand, not guessing an acronym from initials. Restricted to acronyms of three or more characters (`IM`, `ML` collide across unrelated venues), and applied after the satellite-event guard, so a workshop that names its parent's acronym is still a distinct venue.
+
 ## [1.6.0] - 2026-07-22
 
 Bibliographies outside the anglophone-ML mainstream no longer mismatch themselves.

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -62,6 +62,7 @@ from bibtex_updater.matching import (
     normalize_volume_title,
     symmetric_author_match,
     title_edit_distance,
+    venue_acronym_matches,
     venue_name_subsumes,
     volume_title_subsumed,
 )
@@ -1840,8 +1841,12 @@ def venues_match(venue_a: str, venue_b: str, threshold: float = 0.70) -> VenueMa
             return VenueMatchResult(MatchOutcome.MATCH, score)
         return VenueMatchResult(MatchOutcome.MISMATCH, score)
     # One name containing the other is a shortened index entry, not a different
-    # venue -- the fuzzy score is low only because the lengths differ.
-    if venue_name_subsumes(match_a, match_b):
+    # venue -- the fuzzy score is low only because the lengths differ. Likewise a
+    # bare acronym the entry itself declares parenthetically ("CNSM" vs
+    # "... Service Management (CNSM)") is the same venue stored short; the RAW
+    # strings are used because normalization strips the case and parentheses the
+    # declaration depends on.
+    if venue_name_subsumes(match_a, match_b) or venue_acronym_matches(venue_a, venue_b):
         return VenueMatchResult(MatchOutcome.MATCH, max(score, threshold))
     return VenueMatchResult(MatchOutcome.MISMATCH, score)
 

--- a/src/bibtex_updater/matching.py
+++ b/src/bibtex_updater/matching.py
@@ -1097,6 +1097,62 @@ def venue_name_subsumes(venue_a: str, venue_b: str) -> bool:
     return not adds_satellite_marker(" ".join(longer), " ".join(shorter))
 
 
+#: A parenthetical acronym a venue declares for itself: an uppercase run of
+#: >= 3 chars, optionally trailed by the repeated year -- ``(CNSM)``,
+#: ``(NOMS 2024)``, ``(ICT4S)``. Two-letter parentheticals are excluded on
+#: purpose: acronyms that short (IM, ML, IP) collide across unrelated venues and
+#: cannot establish identity on their own.
+_PARENTHETICAL_ACRONYM_RE = re.compile(r"\(\s*([A-Z][A-Z0-9]{2,})\b[^)]*\)")
+
+#: A venue string that is a single acronym-like token (>= 3 chars). The API
+#: casing is unreliable, so lowercase is accepted here -- the all-caps
+#: parenthetical on the OTHER side is what anchors the match.
+_BARE_ACRONYM_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]{2,}$")
+
+
+def _declared_acronyms(venue: str) -> set[str]:
+    """The uppercase acronyms a venue declares in its own parentheses."""
+    return {m.group(1).lower() for m in _PARENTHETICAL_ACRONYM_RE.finditer(venue)}
+
+
+def _bare_acronym(venue: str) -> str | None:
+    """The venue reduced to a single acronym token, lowercased, or None.
+
+    A record whose whole venue string is one >= 3-char token once the year is
+    stripped ("CNSM", "2024 NOMS") is a bare acronym; a multi-word name is not.
+    """
+    stripped = re.sub(r"\b(?:19|20)\d{2}\b", " ", venue)
+    tokens = stripped.split()
+    if len(tokens) != 1:
+        return None
+    token = tokens[0]
+    return token.lower() if _BARE_ACRONYM_RE.match(token) else None
+
+
+def venue_acronym_matches(venue_a: str, venue_b: str) -> bool:
+    """True when one venue is a bare acronym the OTHER declares parenthetically.
+
+    Indexes sometimes store only a conference's acronym ("CNSM") while the entry
+    spells the name out and appends the acronym itself ("... Network and Service
+    Management (CNSM)"). The parenthetical is the venue's OWN declaration of its
+    shorthand, so matching the two reads that declaration -- it does not guess an
+    acronym from initials. A bare acronym is one token, below
+    :data:`_MIN_SUBSUMPTION_TOKENS`, so :func:`venue_name_subsumes` cannot reach
+    it; this closes that gap without weakening the length guard. Restricted to
+    >= 3-char acronyms, since shorter ones collide across unrelated venues.
+
+    Purely additive: it only turns a would-be MISMATCH into a MATCH, never the
+    reverse, and it runs after the satellite-marker guard, so a workshop that
+    declares its parent's acronym is still rejected.
+    """
+    bare_a, bare_b = _bare_acronym(venue_a), _bare_acronym(venue_b)
+    if bare_a and bare_a in _declared_acronyms(venue_b):
+        return True
+    if bare_b and bare_b in _declared_acronyms(venue_a):
+        return True
+    return False
+
+
 #: Hosting-*platform* markers. A record whose venue is only the platform name
 #: (OpenReview hosts ICLR, NeurIPS, TMLR, and many workshops) says nothing about
 #: the published venue, exactly like a preprint server -- so a venue comparison

--- a/tests/test_venue_series_subsumption.py
+++ b/tests/test_venue_series_subsumption.py
@@ -129,6 +129,68 @@ class TestVenueSubsumption:
         assert result.outcome is MatchOutcome.MATCH
 
 
+class TestBareAcronymVenueMatch:
+    """An index storing only a conference acronym matches the entry's own
+    parenthetical declaration of that acronym.
+
+    Six of the seven residual ``venue_mismatch`` flags on the Varga run were the
+    same shape: the record's venue is the bare acronym (``CNSM``) while the entry
+    spells the name out and appends the acronym itself
+    (``... Network and Service Management (CNSM)``). The parenthetical is the
+    venue's OWN declaration of its shorthand, so matching the two reads that
+    declaration rather than guessing an acronym from initials. The subsumption
+    rule cannot reach these: a bare acronym is a single token, below
+    ``_MIN_SUBSUMPTION_TOKENS``.
+    """
+
+    def test_bare_acronym_matches_entry_parenthetical(self):
+        result = venues_match(
+            "2023 19th International Conference on Network and Service Management (CNSM)",
+            "CNSM",
+        )
+        assert result.outcome is MatchOutcome.MATCH
+
+    def test_bare_acronym_match_is_symmetric(self):
+        result = venues_match(
+            "CNSM",
+            "2023 19th International Conference on Network and Service Management (CNSM)",
+        )
+        assert result.outcome is MatchOutcome.MATCH
+
+    def test_acronym_with_trailing_year_in_parenthetical(self):
+        result = venues_match(
+            "2024 IEEE/IFIP Network Operations and Management Symposium (NOMS 2024)",
+            "NOMS",
+        )
+        assert result.outcome is MatchOutcome.MATCH
+
+    def test_wrong_bare_acronym_still_mismatches(self):
+        # A bare acronym the entry does NOT declare is a genuine mismatch.
+        result = venues_match(
+            "2023 19th International Conference on Network and Service Management (CNSM)",
+            "NOMS",
+        )
+        assert result.outcome is MatchOutcome.MISMATCH
+
+    def test_two_letter_acronym_too_ambiguous_to_match_bare(self):
+        # Two-letter acronyms (IM, ML, IP...) collide across unrelated venues, so
+        # a BARE two-letter token must not match on the parenthetical alone. The
+        # spelled-out form is still covered by subsumption (see TestVenueSubsumption).
+        result = venues_match(
+            "International Symposium on Foobar Management (IM)",
+            "IM",
+        )
+        assert result.outcome is not MatchOutcome.MATCH
+
+    def test_acronym_rule_does_not_override_satellite_guard(self):
+        # A workshop declaring the parent's acronym is still a different venue.
+        result = venues_match(
+            "International Conference on Machine Learning Workshop (ICML)",
+            "ICML",
+        )
+        assert result.outcome is not MatchOutcome.MATCH
+
+
 class TestSubsumptionGuards:
     """Subsumption must not merge genuinely different venues."""
 


### PR DESCRIPTION
## Summary

Indexes sometimes store only a conference's acronym (`CNSM`, `NOMS`, `DATE`) while the entry spells the name out and appends the acronym itself — `2023 19th International Conference on Network and Service Management (CNSM)`. A bare acronym is a single token, below the subsumption length floor, and it does not canonicalize, so neither the alias map nor name-containment reached it: the entry mismatched **its own venue**.

The fix reads the acronym the entry declares in its own parentheses and treats a bare acronym on the other side that equals it as the same venue — reading a declaration, not guessing an acronym from initials. This is the residual `venue_mismatch` cluster from the off-domain (Hungarian telecom) Varga bibliography.

## Changes

- **`matching.py`**: new `venue_acronym_matches(a, b)` — a bare ≥3-char acronym on one side that the other side declares parenthetically is the same venue. Confined to the fuzzy fallback, runs **after** the satellite-event guard (a workshop naming its parent's acronym stays distinct), and capped at ≥3 chars (`IM`/`ML`/`IP` collide across venues).
- **`fact_checker.py`**: `venues_match` consults the new helper in the below-threshold branch, on the **raw** venue strings (normalization strips the case and parentheses the declaration depends on).
- **6 new tests** in `tests/test_venue_series_subsumption.py` (CNSM/NOMS matches, symmetry, trailing-year parenthetical, wrong-acronym mismatch, two-letter guard, satellite guard).
- **CHANGELOG**: `Unreleased → Fixed` entry.

## Why there is no downside

- **Purely additive** — it can only turn a would-be `MISMATCH` into a `MATCH`, never the reverse. Verified on the Varga bib with the acronym branch monkeypatched off: every venue verdict it changes is `MISMATCH → MATCH`, isolated footprint = 1 entry (the one whose index actually returned bare `CNSM`).
- **HALLMARK-inert (2572 entries, static analysis)**: 1942 of 2113 bare-acronym venues canonicalize and exit early; almost all the rest are arXiv/bioRxiv caught by the preprint gate; only 2 entries declare a parenthetical acronym and both canonicalize. Where the rule *could* fire it needs the record to independently declare the same acronym — a genuine venue agreement — and a venue match cannot verify an entry with a fabricated title/author, so no detection-rate regression.

## Checklist

- [x] Full suite green (1697 passed, 1 skipped)
- [x] pre-commit (black + ruff) clean
- [x] CHANGELOG updated
- [x] Additivity + HALLMARK inertness verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114duwwbzwpsvyBFEPoTb32