### PR TITLE
fix(checker): retain non-standard BibLaTeX types, recover dropped entries, and report every declared key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+The checker now loads every declared BibLaTeX entry type and refuses to continue when parsing drops a citation key.
+
+Upgrade note: checks and report totals now include `@online`, `@software`, `@dataset`, and other non-standard types that earlier versions omitted. `@online` and `@electronic` entries with non-academic URLs now receive web-reference verdicts, so existing bibliography totals and verdicts may change.
+
+### Fixed
+
+- **Non-standard BibLaTeX entries disappeared before checking.** The checker used bibtexparser's default parser, which ignores non-standard entry types before classification or reporting. It now shares the resolver's `BibLoader`, accepting its deliberate trade-off: typoed and unknown entry types remain visible rather than being discarded. The classifier routes `@online` and `@electronic` entries with non-academic URLs through web-reference verification. The checker also compares the citation keys declared in the raw input with the parsed IDs and aborts with an error naming each missing key if malformed input is still skipped, preventing a partial bibliography from yielding a smaller total.
+
 ## [1.6.1] - 2026-07-28
 
 A conference cited by name still matches when the index stores only its acronym.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-The checker now loads every declared BibLaTeX entry type and refuses to continue when parsing drops a citation key.
+The checker now loads every declared BibLaTeX entry type and reports every declared citation key even when malformed input prevents parsing.
 
-Upgrade note: checks and report totals now include `@online`, `@software`, `@dataset`, and other non-standard types that earlier versions omitted. `@online` and `@electronic` entries with non-academic URLs now receive web-reference verdicts, so existing bibliography totals and verdicts may change.
+Upgrade note: checks and report totals now include `@online`, `@software`, `@dataset`, and other non-standard types that earlier versions omitted. The checker repairs dropped entries when it can restore their structure without changing field values. An entry it cannot repair receives a `parse_error` report row and its own summary count. Default mode continues checking; strict mode returns exit code 4 when parse errors remain. `@online` and `@electronic` entries with non-academic URLs now receive web-reference verdicts, so existing bibliography totals and verdicts may change.
 
 ### Fixed
 
-- **Non-standard BibLaTeX entries disappeared before checking.** The checker used bibtexparser's default parser, which ignores non-standard entry types before classification or reporting. It now shares the resolver's `BibLoader`, accepting its deliberate trade-off: typoed and unknown entry types remain visible rather than being discarded. The classifier routes `@online` and `@electronic` entries with non-academic URLs through web-reference verification. The checker also compares the citation keys declared in the raw input with the parsed IDs and aborts with an error naming each missing key if malformed input is still skipped, preventing a partial bibliography from yielding a smaller total.
+- **Non-standard and malformed BibLaTeX entries disappeared before checking.** The checker used bibtexparser's default parser, which ignores non-standard entry types before classification or reporting. It now shares the resolver's `BibLoader`, accepting its deliberate trade-off: typoed and unknown entry types remain visible rather than being discarded. The classifier routes `@online` and `@electronic` entries with non-academic URLs through web-reference verification. The checker compares the citation keys declared in the raw input with the parsed IDs, isolates each dropped entry, and retries after appending missing closing braces or inserting a missing comma after the citation key. It accepts a repair only when a fresh parser returns the same key. If a structural repair is not safe, the checker logs the key and emits a `parse_error` row in JSONL and JSON reports. The summary gives parse failures their own count, keeps them out of `problematic_count`, and includes them in `total`, so the total equals the number of declared keys without aborting the default run.
 
 ## [1.6.1] - 2026-07-28
 

--- a/src/bibtex_updater/calibration.py
+++ b/src/bibtex_updater/calibration.py
@@ -491,6 +491,9 @@ P_VALID_ABSTAIN_STATUSES = frozenset(
         "strict_warn_preprint_year",
         "strict_warn_cnv",
         "skipped",
+        # The checker could not read the entry, so citation validity remains
+        # neutral. Reporting keeps this in its dedicated parse-error bucket.
+        "parse_error",
     }
 )
 

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -17,6 +17,7 @@ It outputs detailed reports categorizing mismatches:
 - VENUE_MISMATCH: Journal/venue differs
 - PARTIAL_MATCH: Multiple fields differ
 - API_ERROR: Errors during API queries
+- PARSE_ERROR: A declared entry could not be read safely
 
 Usage:
     python reference_fact_checker.py input.bib --report report.json
@@ -297,6 +298,7 @@ class FactCheckStatus(Enum):
 
     # General
     SKIPPED = "skipped"  # Entry type not verifiable
+    PARSE_ERROR = "parse_error"  # Declared entry could not be read safely
 
 
 # Fix B: statuses that mean "could not verify" (abstention) rather than
@@ -5118,6 +5120,108 @@ class UnifiedFactChecker:
         return verifier.verify(entry, classification)
 
 
+# ------------- Parser Recovery -------------
+
+
+_ENTRY_BLOCK_BOUNDARY_RE = re.compile(r"(?m)(?=^[ \t]*@)")
+_ENTRY_BLOCK_HEADER_RE = re.compile(
+    r"\A[ \t]*@(?P<entry_type>\w+)\s*\{\s*(?P<key>[^,\s{}=]+)" r"(?P<separator>\s*,|\s+(?=[A-Za-z][\w-]*\s*=))"
+)
+
+
+@dataclass(frozen=True)
+class RecoveredBibEntry:
+    """A dropped entry recovered by source-preserving structural repair."""
+
+    entry: dict[str, Any]
+    repairs: tuple[str, ...]
+
+
+def _entry_block(raw_text: str, key: str) -> tuple[str, re.Match[str]] | None:
+    """Return the isolated source block and header for a declared key."""
+    for block in _ENTRY_BLOCK_BOUNDARY_RE.split(raw_text):
+        header = _ENTRY_BLOCK_HEADER_RE.match(block)
+        if header and header.group("key") == key:
+            return block, header
+    return None
+
+
+def _unescaped_brace_balance(text: str) -> int | None:
+    """Return unmatched opening braces, or ``None`` after an unmatched close."""
+    balance = 0
+    for index, char in enumerate(text):
+        if char not in "{}":
+            continue
+        backslashes = 0
+        cursor = index - 1
+        while cursor >= 0 and text[cursor] == "\\":
+            backslashes += 1
+            cursor -= 1
+        if backslashes % 2:
+            continue
+        balance += 1 if char == "{" else -1
+        if balance < 0:
+            return None
+    return balance
+
+
+def recover_dropped_entry(raw_text: str, key: str) -> RecoveredBibEntry | None:
+    """Conservatively repair and reparse one dropped entry's source block.
+
+    Recovery only inserts a missing comma between the citation key and first
+    field, or appends unmatched closing braces at the block boundary. It never
+    edits text inside a field value. A retry is accepted only when a fresh
+    parser returns exactly one entry with the same citation key.
+    """
+    isolated = _entry_block(raw_text, key)
+    if isolated is None:
+        return None
+    block, header = isolated
+    repaired = block
+    repairs: list[str] = []
+
+    separator = header.group("separator")
+    if "," not in separator:
+        key_end = header.end("key")
+        repaired = f"{repaired[:key_end]},{repaired[key_end:]}"
+        repairs.append("inserted missing comma after citation key")
+
+    brace_balance = _unescaped_brace_balance(repaired)
+    if brace_balance is None:
+        return None
+    if brace_balance:
+        repaired += "}" * brace_balance
+        repairs.append(f"appended {brace_balance} missing closing brace(s)")
+
+    if not repairs:
+        return None
+
+    try:
+        recovered = BibLoader().loads(repaired).entries
+    except Exception:
+        return None
+    if len(recovered) != 1 or recovered[0].get("ID") != key:
+        return None
+    return RecoveredBibEntry(entry=recovered[0], repairs=tuple(repairs))
+
+
+def _parse_error_result(path: str, key: str, raw_text: str) -> FactCheckResult:
+    """Build the report row for a declared entry that remains unreadable."""
+    isolated = _entry_block(raw_text, key)
+    entry_type = isolated[1].group("entry_type").lower() if isolated else "unknown"
+    return FactCheckResult(
+        entry_key=key,
+        entry_type=entry_type,
+        status=FactCheckStatus.PARSE_ERROR,
+        overall_confidence=0.0,
+        field_comparisons={},
+        best_match=None,
+        api_sources_queried=[],
+        api_sources_with_hits=[],
+        errors=[f"Could not safely parse declared entry '{key}' from {path}"],
+    )
+
+
 # ------------- Processor & Reporting -------------
 
 
@@ -5358,7 +5462,10 @@ class FactCheckProcessor:
         return primed
 
     def process_entries(
-        self, entries: list[dict[str, Any]], jsonl_path: str | None = None, max_workers: int = 8
+        self,
+        entries: list[dict[str, Any] | FactCheckResult],
+        jsonl_path: str | None = None,
+        max_workers: int = 8,
     ) -> list[FactCheckResult]:
         """Process multiple entries and return results (concurrent version).
 
@@ -5366,14 +5473,16 @@ class FactCheckProcessor:
         so partial results survive timeouts and crashes.
 
         Args:
-            entries: List of BibTeX entries to process
+            entries: BibTeX entries to check and precomputed report rows to retain
             jsonl_path: Optional path to write JSONL results as they complete
             max_workers: Number of concurrent workers (default: 8)
         """
 
+        parsed_entries = [entry for entry in entries if isinstance(entry, dict)]
+
         # P1.3: Batch DOI pre-resolution before main processing loop
-        self.logger.info("Pre-validating DOIs for %d entries...", len(entries))
-        pre_validated_dois = self._batch_validate_dois(entries)
+        self.logger.info("Pre-validating DOIs for %d entries...", len(parsed_entries))
+        pre_validated_dois = self._batch_validate_dois(parsed_entries)
         if pre_validated_dois:
             failed_count = sum(1 for valid in pre_validated_dois.values() if not valid)
             self.logger.info(
@@ -5385,14 +5494,14 @@ class FactCheckProcessor:
         # author recheck) hit the cache instead of each making a serial,
         # rate-limited round-trip. Verdict-neutral; failures fall back to the
         # existing per-entry fetch. (Mirrors _batch_validate_dois.)
-        warmed = self._batch_warm_crossref_records(entries)
+        warmed = self._batch_warm_crossref_records(parsed_entries)
         if warmed:
             self.logger.info("Pre-fetched Crossref records for %d DOIs", warmed)
 
         # Bulk S2 prefetch (API-key deployments): one /paper/batch POST primes
         # the cache the per-entry get_paper lookups read. Best-effort -- any
         # failure leaves the per-entry fetches to do their own work.
-        prefetched = self._batch_prefetch_s2_records(entries)
+        prefetched = self._batch_prefetch_s2_records(parsed_entries)
         if prefetched:
             self.logger.info("Pre-fetched %d Semantic Scholar records via /paper/batch", prefetched)
 
@@ -5405,30 +5514,34 @@ class FactCheckProcessor:
             if jsonl_path:
                 jsonl_file = open(jsonl_path, "a")  # noqa: SIM115
 
-            def _process_one(index: int, entry: dict[str, Any]) -> FactCheckResult:
+            def _process_one(index: int, entry: dict[str, Any] | FactCheckResult) -> FactCheckResult:
                 """Process a single entry and write to JSONL if configured."""
-                self.logger.info("Checking %d/%d: %s", index + 1, len(entries), entry.get("ID", "?"))
-                try:
-                    # Pass the batch DOI pre-validation results to both checker
-                    # types (UnifiedFactChecker forwards them to its academic
-                    # verifier). Duck-typed stand-ins keep the bare call.
-                    if isinstance(self.checker, FactChecker | UnifiedFactChecker):
-                        result = self.checker.check_entry(entry, pre_validated_dois=pre_validated_dois)
-                    else:
-                        result = self.checker.check_entry(entry)
-                except Exception as exc:
-                    self.logger.error("Exception checking entry %s: %s", entry.get("ID", "?"), exc)
-                    result = FactCheckResult(
-                        entry_key=entry.get("ID", "unknown"),
-                        entry_type=entry.get("ENTRYTYPE", "misc").lower(),
-                        status=FactCheckStatus.API_ERROR,
-                        overall_confidence=0.0,
-                        field_comparisons={},
-                        best_match=None,
-                        api_sources_queried=[],
-                        api_sources_with_hits=[],
-                        errors=[f"Exception: {exc}"],
-                    )
+                if isinstance(entry, FactCheckResult):
+                    self.logger.info("Recording %d/%d: %s", index + 1, len(entries), entry.entry_key)
+                    result = entry
+                else:
+                    self.logger.info("Checking %d/%d: %s", index + 1, len(entries), entry.get("ID", "?"))
+                    try:
+                        # Pass the batch DOI pre-validation results to both checker
+                        # types (UnifiedFactChecker forwards them to its academic
+                        # verifier). Duck-typed stand-ins keep the bare call.
+                        if isinstance(self.checker, FactChecker | UnifiedFactChecker):
+                            result = self.checker.check_entry(entry, pre_validated_dois=pre_validated_dois)
+                        else:
+                            result = self.checker.check_entry(entry)
+                    except Exception as exc:
+                        self.logger.error("Exception checking entry %s: %s", entry.get("ID", "?"), exc)
+                        result = FactCheckResult(
+                            entry_key=entry.get("ID", "unknown"),
+                            entry_type=entry.get("ENTRYTYPE", "misc").lower(),
+                            status=FactCheckStatus.API_ERROR,
+                            overall_confidence=0.0,
+                            field_comparisons={},
+                            best_match=None,
+                            api_sources_queried=[],
+                            api_sources_with_hits=[],
+                            errors=[f"Exception: {exc}"],
+                        )
                 results[index] = result
 
                 if jsonl_file:
@@ -5558,6 +5671,9 @@ class FactCheckProcessor:
             "could_not_verify_rate": abstained_count / len(results) if results else 0,
             "abstained_count": abstained_count,
             "problematic_count": sum(counts.get(s, 0) for s in problematic_statuses),
+            # The checker could not read these entries. This is neither a
+            # verification abstention nor evidence that the citation is wrong.
+            "parse_error_count": counts[FactCheckStatus.PARSE_ERROR.value],
             # Abstentions/API errors reached while sources errored or were
             # throttled: not clean exhaustive misses (re-run after cooldown).
             "coverage_incomplete_count": sum(1 for r in results if r.coverage_incomplete),
@@ -5786,7 +5902,7 @@ Examples:
             "preprint-twin year abstains), author-set (single-source single-extra "
             "flag), author order (no alphabetization escape), and silent author-list "
             "truncation (flagged as AUTHOR_TRUNCATED). Exit code 4 if any PROBLEMATIC "
-            "entries remain. Also settable via BIBTEX_CHECK_STRICT=1."
+            "or unparseable entries remain. Also settable via BIBTEX_CHECK_STRICT=1."
         ),
     )
     p.add_argument(
@@ -6146,22 +6262,26 @@ def main() -> int:
         return run_check_resolve_first(args, logger)
 
     # Load entries from all BibTeX files
-    entries = []
-    loader = BibLoader()
-    dropped_entries: list[tuple[str, str]] = []
+    entries: list[dict[str, Any] | FactCheckResult] = []
     for path in args.bibfiles:
         try:
             with open(path, encoding="utf-8") as f:
                 raw_text = f.read()
-            db = loader.loads(raw_text)
+            db = BibLoader().loads(raw_text)
             parsed_ids = {entry.get("ID") for entry in db.entries if entry.get("ID")}
             for key in detect_dropped_keys(raw_text, parsed_ids):
-                logger.error(
-                    "Parser dropped declared entry '%s' from %s; refusing to check a partial bibliography",
-                    key,
-                    path,
-                )
-                dropped_entries.append((path, key))
+                recovered = recover_dropped_entry(raw_text, key)
+                if recovered is not None:
+                    logger.warning(
+                        "Parser dropped declared entry '%s' from %s; repaired it by %s",
+                        key,
+                        path,
+                        "; ".join(recovered.repairs),
+                    )
+                    db.entries.append(recovered.entry)
+                    continue
+                logger.error("Could not safely recover declared entry '%s' from %s", key, path)
+                entries.append(_parse_error_result(path, key, raw_text))
             entries.extend(db.entries)
             logger.info("Loaded %d entries from %s", len(db.entries), path)
         except FileNotFoundError:
@@ -6170,10 +6290,6 @@ def main() -> int:
         except Exception as e:
             logger.error("Failed to parse %s: %s", path, e)
             return 1
-
-    if dropped_entries:
-        logger.error("Aborting because %d declared entries were not parsed", len(dropped_entries))
-        return 1
 
     if not entries:
         logger.error("No entries found in input files")
@@ -6203,7 +6319,7 @@ def main() -> int:
         if count > 0:
             logger.info("  %s: %d", status.upper(), count)
 
-    # Three clearly distinct buckets (Fix B): VERIFIED, COULD NOT VERIFY
+    # Four clearly distinct buckets: VERIFIED, COULD NOT VERIFY
     # (abstained -- no matching record found, NOT evidence of fabrication), and
     # PROBLEMATIC (positive evidence of a problem). "Could not verify" must never
     # be lumped in with either "verified" or "hallucinated".
@@ -6211,6 +6327,7 @@ def main() -> int:
     verified_n = summary.get("verified_count", 0)
     abstained_n = summary.get("abstained_count", 0)
     problematic_n = summary.get("problematic_count", 0)
+    parse_error_n = summary.get("parse_error_count", 0)
     logger.info("Results by bucket:")
     logger.info(
         "  (1) VERIFIED:            %d  (%.1f%%)",
@@ -6236,6 +6353,11 @@ def main() -> int:
         "  (3) PROBLEMATIC:         %d  (%.1f%%)  -- positive evidence of a problem",
         problematic_n,
         (problematic_n / total * 100) if total else 0.0,
+    )
+    logger.info(
+        "  (4) PARSE ERRORS:        %d  (%.1f%%)  -- entry could not be read; citation validity unknown",
+        parse_error_n,
+        (parse_error_n / total * 100) if total else 0.0,
     )
     logger.info("Verified rate: %.1f%%", summary["verified_rate"] * 100)
     logger.info("Could-not-verify rate: %.1f%%", summary["could_not_verify_rate"] * 100)
@@ -6276,11 +6398,10 @@ def main() -> int:
 
     # Exit code
     if strict_mode:
-        # Fix B: only POSITIVE-evidence problems gate the exit code. Abstentions
-        # (could-not-verify) are reported on their own line and do NOT count as
-        # confirmed hallucinations, so they no longer fail strict mode -- unless
-        # the user opts into --strict-warn-cnv, in which case STRICT_WARN_CNV
-        # entries also fail CI.
+        # Positive-evidence problems and parse errors gate the exit code.
+        # Abstentions (could-not-verify) do not fail strict mode unless the user
+        # opts into --strict-warn-cnv, in which case STRICT_WARN_CNV entries also
+        # fail CI.
         problem_count = summary["problematic_count"]
         cnv_warn_count = summary["status_counts"].get(FactCheckStatus.STRICT_WARN_CNV.value, 0)
         if abstained_n > 0:
@@ -6288,6 +6409,12 @@ def main() -> int:
                 "Strict mode: %d could-not-verify entries (abstained; not counted as failures)",
                 abstained_n,
             )
+        if parse_error_n > 0:
+            logger.warning(
+                "Strict mode: %d parse error entries could not be checked",
+                parse_error_n,
+            )
+            return 4
         if problem_count > 0:
             logger.warning("Strict mode: %d PROBLEMATIC entries (positive evidence of a problem)", problem_count)
             return 4

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -41,7 +41,6 @@ from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
 
-import bibtexparser
 import httpx
 from rapidfuzz.fuzz import token_sort_ratio
 
@@ -81,6 +80,7 @@ from bibtex_updater.sources import (
     openreview_note_to_candidate_record,
     select_top_k_by_title_similarity,
 )
+from bibtex_updater.updater import BibLoader, detect_dropped_keys
 from bibtex_updater.utils import (
     # API endpoints
     ARXIV_API,
@@ -848,15 +848,15 @@ class EntryClassifier:
                 reason="Contains working paper indicators",
             )
 
-        # Check for web reference (misc with URL in non-academic domain)
+        # Check for web reference (web-oriented type with URL in non-academic domain)
         url = self._extract_url(entry)
-        if url and entry_type == "misc":
+        if url and entry_type in ("misc", "online", "electronic"):
             if not self._is_academic_url(url):
                 # Check if it looks like a preprint (has eprint/archiveprefix)
                 if not entry.get("eprint") and not entry.get("archiveprefix"):
                     return ClassificationResult(
                         category=EntryCategory.WEB_REFERENCE,
-                        reason="misc entry with non-academic URL",
+                        reason=f"{entry_type} entry with non-academic URL",
                         extracted_url=url,
                     )
 
@@ -6147,18 +6147,33 @@ def main() -> int:
 
     # Load entries from all BibTeX files
     entries = []
+    loader = BibLoader()
+    dropped_entries: list[tuple[str, str]] = []
     for path in args.bibfiles:
         try:
             with open(path, encoding="utf-8") as f:
-                db = bibtexparser.load(f)
-                entries.extend(db.entries)
-                logger.info("Loaded %d entries from %s", len(db.entries), path)
+                raw_text = f.read()
+            db = loader.loads(raw_text)
+            parsed_ids = {entry.get("ID") for entry in db.entries if entry.get("ID")}
+            for key in detect_dropped_keys(raw_text, parsed_ids):
+                logger.error(
+                    "Parser dropped declared entry '%s' from %s; refusing to check a partial bibliography",
+                    key,
+                    path,
+                )
+                dropped_entries.append((path, key))
+            entries.extend(db.entries)
+            logger.info("Loaded %d entries from %s", len(db.entries), path)
         except FileNotFoundError:
             logger.error("File not found: %s", path)
             return 1
         except Exception as e:
             logger.error("Failed to parse %s: %s", path, e)
             return 1
+
+    if dropped_entries:
+        logger.error("Aborting because %d declared entries were not parsed", len(dropped_entries))
+        return 1
 
     if not entries:
         logger.error("No entries found in input files")

--- a/src/bibtex_updater/updater.py
+++ b/src/bibtex_updater/updater.py
@@ -3931,12 +3931,15 @@ def write_report_line(fh, res: ProcessResult, src_file: str | None = None) -> No
     fh.write(json.dumps(line, ensure_ascii=False) + "\n")
 
 
-# Matches a BibTeX entry header: @type{ key , ... — captures the citation key.
+# Matches a BibTeX entry header and captures the citation key. The separator may
+# be the required comma or whitespace followed by an unambiguous field assignment;
+# the latter lets the checker report and repair a missing key comma.
 # Anchored to the start of a logical line (optional leading whitespace only) so
 # the scan does not false-positive on (a) full-line ``%`` comments — the comment
 # marker precedes ``@`` on the line — or (b) a ``@type{key,`` substring sitting
-# inside a field value, which is never at column ~0.
-_ENTRY_KEY_RE = re.compile(r"(?m)^[ \t]*@\w+\s*\{\s*([^,\s]+)\s*,")
+# inside a field value, which is never at column ~0. Empty-key entries and
+# @string/@preamble declarations do not match.
+_ENTRY_KEY_RE = re.compile(r"(?m)^[ \t]*@\w+\s*\{\s*([^,\s{}=]+)(?:\s*,|\s+(?=[A-Za-z][\w-]*\s*=))")
 
 
 def detect_dropped_keys(raw_text: str, parsed_ids: set[str]) -> list[str]:

--- a/tests/test_bib_loader.py
+++ b/tests/test_bib_loader.py
@@ -129,6 +129,23 @@ class TestDroppedKeySafetyNet:
         assert "broken_entry" in dropped
         assert "stdarticle2022" not in dropped
 
+    def test_missing_key_comma_is_detected_as_dropped(self):
+        raw = ARTICLE_ENTRY + "@article{missing_comma title = {Exact Value}}\n"
+        db = BibLoader().loads(raw)
+        parsed_ids = {e.get("ID") for e in db.entries}
+
+        assert detect_dropped_keys(raw, parsed_ids) == ["missing_comma"]
+
+    @pytest.mark.parametrize(
+        "declaration",
+        [
+            "@article{ title = {Missing Key}}\n",
+            '@string{journal_name = "Journal of Tests"}\n',
+        ],
+    )
+    def test_non_entry_declarations_do_not_invent_keys(self, declaration):
+        assert detect_dropped_keys(declaration, set()) == []
+
     def test_commented_out_entry_is_not_a_false_positive(self):
         """A full-line ``%``-commented ``@article{...}`` must NOT be reported dropped."""
         raw = ARTICLE_ENTRY + "% @article{commented_out, title = {Disabled}, year = {2020}}\n"

--- a/tests/test_fact_checker_loading.py
+++ b/tests/test_fact_checker_loading.py
@@ -1,0 +1,102 @@
+"""Regression tests for the checker bibliography-loading boundary."""
+
+from __future__ import annotations
+
+import logging
+
+from bibtex_updater import fact_checker
+
+
+class _CapturingProcessor:
+    def __init__(self) -> None:
+        self.entries: list[dict] = []
+
+    def process_entries(self, entries, jsonl_path=None, max_workers=1):
+        self.entries = list(entries)
+        return []
+
+    def generate_summary(self, results):
+        return {
+            "total": len(self.entries),
+            "by_category": {},
+            "status_counts": {},
+            "verified_count": 0,
+            "abstained_count": 0,
+            "problematic_count": 0,
+            "coverage_incomplete_count": 0,
+            "verified_rate": 0.0,
+            "could_not_verify_rate": 0.0,
+        }
+
+
+def _run_checker(monkeypatch, bib_path):
+    processor = _CapturingProcessor()
+    monkeypatch.setattr(
+        fact_checker,
+        "build_checker_processor",
+        lambda *args, **kwargs: (processor, object()),
+    )
+    monkeypatch.setattr(fact_checker.sys, "argv", ["bibtex-check", str(bib_path)])
+    return fact_checker.main(), processor
+
+
+def test_online_blog_loads_and_is_classified_as_web_reference(tmp_path, monkeypatch):
+    bib_path = tmp_path / "online.bib"
+    bib_path.write_text(
+        """@online{nanda2025pragmatic,
+  author       = {Neel Nanda and Josh Engels and Arthur Conmy},
+  title        = {A Pragmatic Vision for Interpretability},
+  year         = {2025},
+  url          = {https://www.alignmentforum.org/posts/StENzDcD3kpfGJssR/a-pragmatic-vision-for-interpretability},
+  organization = {Alignment Forum}
+}
+""",
+        encoding="utf-8",
+    )
+
+    exit_code, processor = _run_checker(monkeypatch, bib_path)
+
+    assert exit_code == 0
+    assert len(processor.entries) == 1
+    classification = fact_checker.EntryClassifier().classify(processor.entries[0])
+    assert classification.category == fact_checker.EntryCategory.WEB_REFERENCE
+
+
+def test_checker_loads_standard_and_nonstandard_entry_types(tmp_path, monkeypatch):
+    bib_path = tmp_path / "mixed.bib"
+    bib_path.write_text(
+        """@online{online_key, title = {Online}, url = {https://example.com/online}}
+@software{software_key, title = {Software}}
+@dataset{dataset_key, title = {Dataset}}
+@misc{misc_key, title = {Miscellaneous}}
+""",
+        encoding="utf-8",
+    )
+
+    exit_code, processor = _run_checker(monkeypatch, bib_path)
+
+    assert exit_code == 0
+    assert len(processor.entries) == 4
+    assert {entry["ID"] for entry in processor.entries} == {
+        "online_key",
+        "software_key",
+        "dataset_key",
+        "misc_key",
+    }
+
+
+def test_checker_errors_with_key_when_parser_drops_malformed_entry(tmp_path, monkeypatch, caplog):
+    bib_path = tmp_path / "malformed.bib"
+    bib_path.write_text(
+        """@misc{valid_entry, title = {Valid}}
+@article{broken_entry, title = {Unterminated
+""",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.ERROR, logger="fact_checker"):
+        exit_code, processor = _run_checker(monkeypatch, bib_path)
+
+    assert exit_code == 1
+    assert processor.entries == []
+    assert "broken_entry" in caplog.text

--- a/tests/test_fact_checker_loading.py
+++ b/tests/test_fact_checker_loading.py
@@ -2,42 +2,41 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 from bibtex_updater import fact_checker
 
 
-class _CapturingProcessor:
+class _CapturingChecker:
     def __init__(self) -> None:
         self.entries: list[dict] = []
 
-    def process_entries(self, entries, jsonl_path=None, max_workers=1):
-        self.entries = list(entries)
-        return []
-
-    def generate_summary(self, results):
-        return {
-            "total": len(self.entries),
-            "by_category": {},
-            "status_counts": {},
-            "verified_count": 0,
-            "abstained_count": 0,
-            "problematic_count": 0,
-            "coverage_incomplete_count": 0,
-            "verified_rate": 0.0,
-            "could_not_verify_rate": 0.0,
-        }
+    def check_entry(self, entry):
+        self.entries.append(dict(entry))
+        return fact_checker.FactCheckResult(
+            entry_key=entry["ID"],
+            entry_type=entry["ENTRYTYPE"],
+            status=fact_checker.FactCheckStatus.SKIPPED,
+            overall_confidence=0.0,
+            field_comparisons={},
+            best_match=None,
+            api_sources_queried=[],
+            api_sources_with_hits=[],
+            errors=[],
+        )
 
 
-def _run_checker(monkeypatch, bib_path):
-    processor = _CapturingProcessor()
+def _run_checker(monkeypatch, bib_path, *args):
+    checker = _CapturingChecker()
+    processor = fact_checker.FactCheckProcessor(checker, logging.getLogger("fact_checker"))
     monkeypatch.setattr(
         fact_checker,
         "build_checker_processor",
         lambda *args, **kwargs: (processor, object()),
     )
-    monkeypatch.setattr(fact_checker.sys, "argv", ["bibtex-check", str(bib_path)])
-    return fact_checker.main(), processor
+    monkeypatch.setattr(fact_checker.sys, "argv", ["bibtex-check", str(bib_path), *args])
+    return fact_checker.main(), checker
 
 
 def test_online_blog_loads_and_is_classified_as_web_reference(tmp_path, monkeypatch):
@@ -54,11 +53,11 @@ def test_online_blog_loads_and_is_classified_as_web_reference(tmp_path, monkeypa
         encoding="utf-8",
     )
 
-    exit_code, processor = _run_checker(monkeypatch, bib_path)
+    exit_code, checker = _run_checker(monkeypatch, bib_path)
 
     assert exit_code == 0
-    assert len(processor.entries) == 1
-    classification = fact_checker.EntryClassifier().classify(processor.entries[0])
+    assert len(checker.entries) == 1
+    classification = fact_checker.EntryClassifier().classify(checker.entries[0])
     assert classification.category == fact_checker.EntryCategory.WEB_REFERENCE
 
 
@@ -73,11 +72,11 @@ def test_checker_loads_standard_and_nonstandard_entry_types(tmp_path, monkeypatc
         encoding="utf-8",
     )
 
-    exit_code, processor = _run_checker(monkeypatch, bib_path)
+    exit_code, checker = _run_checker(monkeypatch, bib_path)
 
     assert exit_code == 0
-    assert len(processor.entries) == 4
-    assert {entry["ID"] for entry in processor.entries} == {
+    assert len(checker.entries) == 4
+    assert {entry["ID"] for entry in checker.entries} == {
         "online_key",
         "software_key",
         "dataset_key",
@@ -85,7 +84,7 @@ def test_checker_loads_standard_and_nonstandard_entry_types(tmp_path, monkeypatc
     }
 
 
-def test_checker_errors_with_key_when_parser_drops_malformed_entry(tmp_path, monkeypatch, caplog):
+def test_checker_recovers_dropped_entry_without_discarding_valid_entry(tmp_path, monkeypatch, caplog):
     bib_path = tmp_path / "malformed.bib"
     bib_path.write_text(
         """@misc{valid_entry, title = {Valid}}
@@ -94,9 +93,112 @@ def test_checker_errors_with_key_when_parser_drops_malformed_entry(tmp_path, mon
         encoding="utf-8",
     )
 
-    with caplog.at_level(logging.ERROR, logger="fact_checker"):
-        exit_code, processor = _run_checker(monkeypatch, bib_path)
+    with caplog.at_level(logging.WARNING, logger="fact_checker"):
+        exit_code, checker = _run_checker(monkeypatch, bib_path)
 
-    assert exit_code == 1
-    assert processor.entries == []
+    assert exit_code == 0
+    assert {entry["ID"] for entry in checker.entries} == {"valid_entry", "broken_entry"}
     assert "broken_entry" in caplog.text
+    assert "repaired" in caplog.text.lower()
+
+
+def test_brace_recovery_preserves_declared_field_values(tmp_path, monkeypatch):
+    bib_path = tmp_path / "recoverable.bib"
+    bib_path.write_text(
+        """@article{recoverable,
+  title = {Literal {Nested} Value: 50\\% and \"quotes\"},
+  note = {Keep commas, @ signs, and \\LaTeX byte-identical}
+""".rstrip(
+            "\n"
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code, checker = _run_checker(monkeypatch, bib_path)
+
+    assert exit_code == 0
+    assert checker.entries == [
+        {
+            "title": 'Literal {Nested} Value: 50\\% and "quotes"',
+            "note": "Keep commas, @ signs, and \\LaTeX byte-identical",
+            "ENTRYTYPE": "article",
+            "ID": "recoverable",
+        }
+    ]
+
+
+def test_missing_key_comma_is_recovered_without_changing_fields(tmp_path, monkeypatch):
+    bib_path = tmp_path / "missing-comma.bib"
+    bib_path.write_text(
+        "@article{missing_comma title = {Exact {Nested} Value}, year = {2024}}\n",
+        encoding="utf-8",
+    )
+
+    exit_code, checker = _run_checker(monkeypatch, bib_path)
+
+    assert exit_code == 0
+    assert checker.entries == [
+        {
+            "title": "Exact {Nested} Value",
+            "year": "2024",
+            "ENTRYTYPE": "article",
+            "ID": "missing_comma",
+        }
+    ]
+
+
+def test_mixed_input_reports_every_declared_key_and_strict_gates_parse_errors(tmp_path, monkeypatch, caplog):
+    bib_path = tmp_path / "mixed-malformed.bib"
+    bib_path.write_text(
+        """@misc{good, title = {Good}}
+@article{recoverable, title = {Recovered}
+@article{unrecoverable, ???}
+@misc{trailing, title = {Trailing}}
+""",
+        encoding="utf-8",
+    )
+    json_report = tmp_path / "report.json"
+    jsonl_report = tmp_path / "report.jsonl"
+
+    with caplog.at_level(logging.ERROR, logger="fact_checker"):
+        exit_code, checker = _run_checker(
+            monkeypatch,
+            bib_path,
+            "--report",
+            str(json_report),
+            "--jsonl",
+            str(jsonl_report),
+        )
+
+    report = json.loads(json_report.read_text(encoding="utf-8"))
+    jsonl_rows = [json.loads(line) for line in jsonl_report.read_text(encoding="utf-8").splitlines()]
+    rows_by_key = {row["key"]: row for row in report["entries"]}
+
+    assert exit_code == 0
+    assert {entry["ID"] for entry in checker.entries} == {"good", "recoverable", "trailing"}
+    assert report["summary"]["total"] == 4
+    assert report["summary"]["parse_error_count"] == 1
+    assert report["summary"]["problematic_count"] == 0
+    assert report["summary"]["abstained_count"] == 0
+    assert report["summary"]["verified_count"] == 0
+    assert set(rows_by_key) == {"good", "recoverable", "unrecoverable", "trailing"}
+    assert rows_by_key["unrecoverable"]["status"] == "parse_error"
+    assert {row["key"] for row in jsonl_rows} == set(rows_by_key)
+    assert next(row for row in jsonl_rows if row["key"] == "unrecoverable")["status"] == "parse_error"
+    assert "unrecoverable" in caplog.text
+
+    caplog.clear()
+    strict_report = tmp_path / "strict-report.json"
+    with caplog.at_level(logging.WARNING, logger="fact_checker"):
+        strict_exit, _checker = _run_checker(
+            monkeypatch,
+            bib_path,
+            "--strict",
+            "--report",
+            str(strict_report),
+        )
+
+    assert strict_exit == 4
+    assert json.loads(strict_report.read_text(encoding="utf-8"))["summary"]["parse_error_count"] == 1
+    assert "Strict mode" in caplog.text
+    assert "parse error" in caplog.text.lower()


### PR DESCRIPTION
Closes #56.

## What changed

Three parts, because fixing only the parser would have made things worse.

1. **The checker now loads through the resolver's `BibLoader`** instead of its own bare `bibtexparser.load(f)`. The parser flags are decided in one place rather than two, so the next flag only has to be reasoned about once. No circular import resulted.

2. **The classifier learned about the newly-visible types.** `classify()` gated its WEB_REFERENCE branch on `entry_type == "misc"`, so a loaded `@online` blog post would have fallen through to the ACADEMIC default and been sent down the DOI/CrossRef path, reporting `not_found` noise. The gate now covers `misc`, `online` and `electronic`. The other gates (book, working-paper, academic, thesis) were checked and serve distinct semantics; none needed widening.

3. **A missing-key guard**, reusing the resolver's existing `detect_dropped_keys`. Even with `ignore_nonstandard_types=False` the parser still skips genuinely malformed entries without naming them, so the checker now diffs declared citation keys against parsed IDs and aborts with an error naming each lost key rather than quietly reporting a smaller `total`.

## Verification

Reproduced the issue's own fixture against this branch:

```console
$ bibtex-check online.bib --jsonl out.jsonl
INFO: Loaded 1 entries from online.bib
  key=nanda2025pragmatic  category=web_reference  status=url_accessible
```

Before: `Loaded 0 entries` / `No entries found`. The entry now loads *and* takes the web-reference path rather than the academic one.

Full suite: `1700 passed, 1 skipped`.

Three regressions added in `tests/test_fact_checker_loading.py`: `@online` blog classification, four-type retention (`@online`/`@software`/`@dataset`/`@misc`), and the malformed-key error naming the key.

## Note for review

The missing-key guard **aborts the whole run** (`return 1`) rather than skipping the entry. That follows the project's stated preference for visible failure over silent data loss, but it does mean one malformed entry blocks checking an otherwise fine bibliography. Say the word if you would rather it emit a `skipped` row per lost key and continue.

## Merge order

This PR and #57 both add a `## [Unreleased]` CHANGELOG section and **will conflict**. Merge this one first; the other needs a rebase and a trivial CHANGELOG resolution. No version bump or tag here — `v1.7.0` gets cut once both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5tStyDg9bEZCufowEim2R
