### PR TITLE
fix(checker): route multi-field mismatches by severity instead of collapsing to partial_match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Entries with multiple mismatched fields now report the most decisive mismatch instead of `partial_match`.
+
+Upgrade note: entries previously reported as `partial_match` will now report a specific mismatch status, which changes how status-based consumers route them.
+
+### Fixed
+
+- **Multiple field mismatches collapsed to `partial_match`.** The checker selected a field-specific status only when exactly one field mismatched, so adding another incorrect field weakened the reported status. Multi-mismatch entries now report the most decisive mismatch in title, author, year, then venue order while retaining every mismatched field in the report.
+
 ## [1.6.1] - 2026-07-28
 
 A conference cited by name still matches when the index stores only its acronym.

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -15,7 +15,7 @@ It outputs detailed reports categorizing mismatches:
 - AUTHOR_MISMATCH: Author list differs
 - YEAR_MISMATCH: Publication year differs beyond tolerance
 - VENUE_MISMATCH: Journal/venue differs
-- PARTIAL_MATCH: Multiple fields differ
+- PARTIAL_MATCH: Fallback for an unrecognized mismatched field
 - API_ERROR: Errors during API queries
 
 Usage:
@@ -4900,6 +4900,12 @@ class FactChecker:
         # Positive evidence of a problem: a field that is a real MISMATCH (both
         # sides populated and conflicting). These take priority over abstention.
         mismatches = [name for name, c in comparisons.items() if c.is_mismatch]
+        mismatch_map = {
+            "title": FactCheckStatus.TITLE_MISMATCH,
+            "author": FactCheckStatus.AUTHOR_MISMATCH,
+            "year": FactCheckStatus.YEAR_MISMATCH,
+            "venue": FactCheckStatus.VENUE_MISMATCH,
+        }
 
         if mismatches:
             # P2.6: Prioritize venue mismatch when title+author are confirmed.
@@ -4939,14 +4945,13 @@ class FactChecker:
                     note = comparisons["title"].note or ""
                     if note.startswith("Strict near-miss"):
                         return FactCheckStatus.TITLE_NEAR_MISS
-                mismatch_map = {
-                    "title": FactCheckStatus.TITLE_MISMATCH,
-                    "author": FactCheckStatus.AUTHOR_MISMATCH,
-                    "year": FactCheckStatus.YEAR_MISMATCH,
-                    "venue": FactCheckStatus.VENUE_MISMATCH,
-                }
                 return mismatch_map.get(mismatches[0], FactCheckStatus.PARTIAL_MATCH)
 
+            # Multiple mismatches report the most decisive field while the
+            # report retains the complete ``mismatched_fields`` list.
+            for field in ("title", "author", "year", "venue"):
+                if field in mismatches:
+                    return mismatch_map[field]
             return FactCheckStatus.PARTIAL_MATCH
 
         # No mismatch, but require POSITIVE confirmation of every claimed field.

--- a/tests/test_fact_checker.py
+++ b/tests/test_fact_checker.py
@@ -482,7 +482,7 @@ class TestFactCheckerStatusDetermination:
         status = fact_checker._determine_status(0.85, comparisons, ["crossref"])
         assert status == FactCheckStatus.YEAR_MISMATCH
 
-    def test_partial_match_multiple_mismatches(self, fact_checker):
+    def test_title_outweighs_author_in_multiple_mismatches(self, fact_checker):
         comparisons = {
             "title": FieldComparison("title", "A", "B", 0.6, False),
             "author": FieldComparison("author", "X", "Y", 0.5, False),
@@ -490,7 +490,74 @@ class TestFactCheckerStatusDetermination:
             "venue": FieldComparison("venue", "J", "J", 1.0, True),
         }
         status = fact_checker._determine_status(0.70, comparisons, ["crossref"])
-        assert status == FactCheckStatus.PARTIAL_MATCH
+        assert status == FactCheckStatus.TITLE_MISMATCH
+
+    def test_chimera_second_mismatch_does_not_weaken_author_status(self, fact_checker):
+        title = "Additive Decoders for Latent Variables Identification and Cartesian-Product Extrapolation"
+        entry_authors = (
+            "Lachapelle, S{\\'e}bastien and Deleu, Tristan and Mahajan, Divyat and "
+            "Mitliagkas, Ioannis and Bengio, Yoshua and Lacoste-Julien, Simon and "
+            "Bhargav, Dhanya Sridhar"
+        )
+        record = PublishedRecord(
+            doi="",
+            title=title,
+            authors=[
+                {"given": "Sébastien", "family": "Lachapelle"},
+                {"given": "Divyat", "family": "Mahajan"},
+                {"given": "Ioannis", "family": "Mitliagkas"},
+                {"given": "Simon", "family": "Lacoste-Julien"},
+            ],
+            journal="Advances in Neural Information Processing Systems",
+            year=2023,
+            order_reliable=True,
+            structured_names=True,
+        )
+        per_source_records = {
+            "crossref": record,
+            "openalex": PublishedRecord(
+                doi="",
+                title=record.title,
+                authors=record.authors,
+                journal=record.journal,
+                year=record.year,
+                order_reliable=True,
+                structured_names=True,
+            ),
+        }
+
+        def comparisons_for(entry_year: str):
+            entry = {
+                "ID": "chimera",
+                "ENTRYTYPE": "inproceedings",
+                "title": title,
+                "author": entry_authors,
+                "booktitle": "Advances in Neural Information Processing Systems",
+                "year": entry_year,
+            }
+            return fact_checker._compare_all_fields(entry, record, per_source_records=per_source_records)
+
+        author_only = comparisons_for("2023")
+        author_and_year = comparisons_for("2024")
+        assert author_only["author"].is_mismatch
+        assert not author_only["year"].is_mismatch
+        assert author_and_year["author"].is_mismatch
+        assert author_and_year["year"].is_mismatch
+
+        author_only_status = fact_checker._determine_status(0.95, author_only, ["crossref", "openalex"])
+        author_and_year_status = fact_checker._determine_status(0.95, author_and_year, ["crossref", "openalex"])
+        assert author_only_status is FactCheckStatus.AUTHOR_MISMATCH
+        assert author_and_year_status is author_only_status
+
+    def test_venue_rule_wins_when_title_and_author_are_confirmed(self, fact_checker):
+        comparisons = {
+            "title": FieldComparison("title", "A", "A", 1.0, True),
+            "author": FieldComparison("author", "X", "X", 1.0, True),
+            "year": FieldComparison("year", "2023", "2024", 0.0, False),
+            "venue": FieldComparison("venue", "NeurIPS", "ICML", 0.0, False),
+        }
+        status = fact_checker._determine_status(0.90, comparisons, ["crossref"])
+        assert status is FactCheckStatus.VENUE_MISMATCH
 
 
 class TestPositiveConfirmationGate:


### PR DESCRIPTION
Closes #57.

## What changed

`_determine_status` reached its field-specific `mismatch_map` only when exactly one field mismatched; every multi-mismatch case fell through to a bare `return PARTIAL_MATCH`. Severity was inverted — the more fields were wrong, the more benign the status read.

Multi-mismatch entries now report the most decisive field, in `title` → `author` → `year` → `venue` order. `mismatched_fields` already carried the full list, so naming the worst field in `status` loses nothing. The `mismatch_map` was hoisted so both paths share one definition.

Deliberately unchanged: the venue-confirmation rule, and every `--strict` special case (`TITLE_NEAR_MISS`, `AUTHOR_TRUNCATED`, `GIVEN_NAME_SUBSTITUTION`). The comments around those encode real past incidents, including one where routing to a benign-sounding status buried a 9-of-10-fabricated author list.

Also unchanged, because I checked before assuming it was broken: `partial_match` already counted toward `problematic_count` and `--strict` already returned exit 4 for it. The CI gate was never bypassed. What this fixes is status-based routing by downstream consumers.

## Verification

The issue's two fixtures, differing only in `year`, run against this branch:

```console
  two.bib -> status=author_mismatch  mismatched=['author', 'year']
  one.bib -> status=author_mismatch  mismatched=['author']
```

Before: `two.bib` reported `partial_match` and `one.bib` reported `author_mismatch`, so correcting the year made the entry look worse.

Full suite: `1699 passed, 1 skipped`.

New tests: `test_chimera_second_mismatch_does_not_weaken_author_status` (which asserts `author_and_year_status is author_only_status`, encoding the invariant directly), title-over-author precedence, and the venue rule still winning when title and author are confirmed.

## One existing test changed

`test_partial_match_multiple_mismatches` asserted `PARTIAL_MATCH` for a title+author mismatch — it encoded the bug. Renamed to `test_title_outweighs_author_in_multiple_mismatches` with the expectation corrected to `TITLE_MISMATCH`. Flagging it explicitly since a changed assertion is not something to discover in review.

## Merge order

This PR and #58 both add a `## [Unreleased]` CHANGELOG section and **will conflict**. Merge #58 first; this branch then needs a rebase and a trivial CHANGELOG resolution. No version bump or tag here — `v1.7.0` gets cut once both land.

## Downstream

A fix here changes hallmark's cascade behaviour for these entries: `cascade.py` has `partial_match` in `ROUTE_TO_STAGE2` but `author_mismatch` in `STATUS_TO_TYPE`, so entries like this move from "deferred to the Stage 2 LLM as uncertain" to "decided at Stage 1" — which is where the cascade's cost advantage lives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5tStyDg9bEZCufowEim2R
