### PR TITLE
fix(openreview): serialize the login per origin, not per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A cold token cache let every worker thread that wanted the same OpenReview origin issue its own `POST /login` at once.** `token_for_url` had no lock around the login step, so a `ThreadPoolExecutor` with no cached token yet sent one login per thread for the same host. OpenReview refuses roughly the fourth login within two minutes with `429`, and each thread that lost that race latched its origin as disabled and proceeded anonymously for the rest of the process. Measured over a 5,043-reference screening run: 44 logins came back `429` against 3 that succeeded, which is what degraded those runs to anonymous, and it is also the race that made the 403-latch bug fixed in 1.10.1 reachable, since the anonymous requests it produced were what a 403 used to latch permanently. `token_for_url` now takes a per-origin lock before logging in: the first thread to arrive logs in, the rest wait and reuse its result once it is cached, a failed login is shared the same way instead of retried per thread, and a login to one origin never blocks a lookup against the other. The cross-process token store from 1.10.0 and the sibling-token sharing from 1.10.1 already hid most of this in practice, so the race was real but non-urgent.
+
 ## [1.10.1] - 2026-09-03
 
 1.9.0 got past OpenReview's challenge gate and 1.10.0 fixed what the lookup did once it was through. This release fixes what happened when a lookup that was already authenticated was refused once: the run stopped asking OpenReview at all, and told the user to set the credentials they had set.

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -2138,6 +2138,17 @@ class OpenReviewAuth:
         # entry, so one attempt per origin per run is enough; the rest of the run
         # proceeds anonymously.
         self._disabled: set[str] = set()
+        # One lock per origin, created lazily under ``_lock`` and then held for
+        # the duration of that origin's login. A cold token cache under a
+        # ThreadPoolExecutor otherwise lets every worker that wants the same
+        # origin issue its own ``POST /login`` at once; measured on a
+        # 5,043-reference run, 44 of those concurrent logins came back
+        # ``429 Too Many Requests`` against 3 that succeeded, and each loser
+        # then treated the refusal as "this origin is disabled" and proceeded
+        # anonymously for the rest of the process. Keying the lock by origin
+        # (rather than one lock for the whole object) means a slow login to one
+        # host never blocks a lookup against the other.
+        self._login_locks: dict[str, threading.Lock] = {}
 
     @staticmethod
     def _store_from_env(env: Mapping[str, str]) -> OpenReviewTokenStore | None:
@@ -2193,6 +2204,20 @@ class OpenReviewAuth:
             return ()
         return tuple(other for other in cls.SHARED_ORIGINS if other != origin)
 
+    def _login_lock_for(self, origin: str) -> threading.Lock:
+        """Return the per-origin login lock, creating it on first use.
+
+        Guarded by ``_lock``, but only for the dict lookup/insert -- the lock
+        itself is then held by the caller across the login, outside ``_lock``,
+        so two different origins never wait on each other.
+        """
+        with self._lock:
+            lock = self._login_locks.get(origin)
+            if lock is None:
+                lock = threading.Lock()
+                self._login_locks[origin] = lock
+            return lock
+
     def token_for_url(self, url: str) -> str | None:
         """Return a bearer token for ``url``'s host, logging in on first use.
 
@@ -2225,15 +2250,33 @@ class OpenReviewAuth:
         # rides on the other one's token instead of falling back to anonymous.
         if disabled:
             return None
-        token = self._login(origin)
-        with self._lock:
-            if token:
-                self._tokens[origin] = token
-            else:
-                self._disabled.add(origin)
-        if token and self._store is not None:
-            self._store.put(self._username, origin, token)
-        return token
+        # Serialize the login itself per origin. Everything above this point
+        # only reads shared state, so several threads reach here together with
+        # a cold cache; without a lock each one would issue its own
+        # ``POST /login`` and race the others into OpenReview's ~4-per-two-
+        # minutes limit. The lock is acquired outside ``_lock`` (a login is a
+        # network call, not a dict mutation) and scoped to this origin, so a
+        # login to one host never blocks a lookup against the other.
+        with self._login_lock_for(origin):
+            # Re-check now that we hold the lock: the common case is that
+            # whichever thread got here first already logged in (or already
+            # failed) while we were waiting, and we must reuse that outcome
+            # rather than repeating it.
+            with self._lock:
+                token = self._tokens.get(origin)
+                if token:
+                    return token
+                if origin in self._disabled:
+                    return None
+            token = self._login(origin)
+            with self._lock:
+                if token:
+                    self._tokens[origin] = token
+                else:
+                    self._disabled.add(origin)
+            if token and self._store is not None:
+                self._store.put(self._username, origin, token)
+            return token
 
     def invalidate(self, url: str) -> None:
         """Drop the cached token for ``url``'s host so the next call logs in again.

--- a/tests/test_openreview_auth.py
+++ b/tests/test_openreview_auth.py
@@ -26,6 +26,7 @@ import base64
 import json
 import logging
 import stat
+import threading
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -798,3 +799,168 @@ class TestOneLoginServesBothHosts:
             assert auth.token_for_url(NOTES_V1) == TOKEN_V1
             assert auth.token_for_url(NOTES_V2) == TOKEN_V1
         assert len(fake.calls) == 2
+
+
+# ===========================================================================
+# The per-origin login lock (concurrent workers, cold cache)
+# ===========================================================================
+
+
+class _CountingLoginClient:
+    """Fake ``httpx.Client`` for a login race: thread-safe call counter, and a
+    short pause inside ``post`` so several threads racing ``token_for_url``
+    actually overlap inside ``_login`` instead of running one after another.
+
+    The pause is an unset ``Event.wait(timeout=...)``, not ``time.sleep`` --
+    ``bibtex_updater.utils.time`` is the same module object as the stdlib
+    ``time``, so the ``_fast`` autouse fixture's
+    ``monkeypatch.setattr("bibtex_updater.utils.time.sleep", ...)`` replaces
+    ``time.sleep`` everywhere for the duration of the test, this file's own
+    calls included. ``Event.wait`` is a different code path and is untouched.
+    """
+
+    def __init__(self, *, status_code: int = 200, token: str | None = None, delay: float = 0.05):
+        self._status_code = status_code
+        self._token = token
+        self._delay = delay
+        self._count_lock = threading.Lock()
+        self._never = threading.Event()
+        self.call_count = 0
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, json=None):
+        with self._count_lock:
+            self.call_count += 1
+        self._never.wait(timeout=self._delay)
+        resp = MagicMock()
+        resp.status_code = self._status_code
+        if self._status_code == 200:
+            resp.json.return_value = {"token": self._token, "user": {"id": "~Test_User1"}}
+        else:
+            resp.json.return_value = {}
+        return resp
+
+
+class _BlockingLoginClient:
+    """Fake ``httpx.Client`` whose login for one chosen origin blocks on an
+    ``Event`` until the test releases it, so a second origin's login can be
+    driven concurrently and its timing checked against the first.
+    """
+
+    def __init__(
+        self, tokens: dict[str, str], *, block_origin: str, started: threading.Event, release: threading.Event
+    ):
+        self._tokens = tokens
+        self._block_origin = block_origin
+        self._started = started
+        self._release = release
+        self.calls: list[str] = []
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, json=None):
+        self.calls.append(url)
+        origin = url.rsplit("/login", 1)[0]
+        if origin == self._block_origin:
+            self._started.set()
+            assert self._release.wait(timeout=5), "test never released the blocked login"
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"token": self._tokens[origin], "user": {"id": "~Test_User1"}}
+        return resp
+
+
+class TestConcurrentLoginsAreSerializedPerOrigin:
+    """Measured on a 5,043-reference screening run with a cold token cache:
+    44 logins came back ``429 Too Many Requests`` against 3 that succeeded,
+    because every worker thread that wanted a token for the same origin issued
+    its own ``POST /login`` at once, and OpenReview refuses roughly the fourth
+    login within two minutes. Each loser then latched its origin as disabled
+    and proceeded anonymously for the rest of the process.
+    """
+
+    def test_concurrent_callers_for_one_origin_share_a_single_login(self):
+        fake = _CountingLoginClient(token=TOKEN_V1)
+        auth = OpenReviewAuth("a@b.c", PASSWORD)
+        results: list[str | None] = []
+        results_lock = threading.Lock()
+
+        def worker():
+            token = auth.token_for_url(NOTES_V1)
+            with results_lock:
+                results.append(token)
+
+        with patch("bibtex_updater.utils.httpx.Client", fake):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert fake.call_count == 1
+        assert results == [TOKEN_V1] * 8
+
+    def test_a_failed_login_is_shared_not_retried_per_thread(self, caplog):
+        fake = _CountingLoginClient(status_code=400)
+        auth = OpenReviewAuth("a@b.c", PASSWORD)
+        results: list[str | None] = []
+        results_lock = threading.Lock()
+
+        def worker():
+            token = auth.token_for_url(NOTES_V1)
+            with results_lock:
+                results.append(token)
+
+        with caplog.at_level(logging.DEBUG), patch("bibtex_updater.utils.httpx.Client", fake):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert fake.call_count == 1
+        assert results == [None] * 8
+
+    def test_a_login_to_one_origin_does_not_block_a_lookup_against_another(self):
+        started = threading.Event()
+        release = threading.Event()
+        other_origin = "https://mirror.example.org"
+        fake = _BlockingLoginClient(
+            {OPENREVIEW_API: TOKEN_V1, other_origin: TOKEN_V2},
+            block_origin=OPENREVIEW_API,
+            started=started,
+            release=release,
+        )
+        auth = OpenReviewAuth("a@b.c", PASSWORD)
+        slow_result: dict[str, str | None] = {}
+
+        def slow_worker():
+            slow_result["token"] = auth.token_for_url(NOTES_V1)
+
+        with patch("bibtex_updater.utils.httpx.Client", fake):
+            t = threading.Thread(target=slow_worker)
+            t.start()
+            assert started.wait(timeout=5), "the blocked login never started"
+            # The blocked login for OPENREVIEW_API is a different origin from
+            # this one, so it must not be serialized behind it.
+            fast_token = auth.token_for_url(f"{other_origin}/notes")
+            assert fast_token == TOKEN_V2
+            release.set()
+            t.join(timeout=5)
+
+        assert slow_result["token"] == TOKEN_V1


### PR DESCRIPTION
## Summary

`OpenReviewAuth.token_for_url` had no lock around the login step. With a cold token cache, every worker thread that needed a token for the same origin issued its own `POST /login` at once. OpenReview refuses roughly the fourth login within two minutes with `429`, and each thread that lost that race latched its origin as disabled and proceeded anonymously for the rest of the process.

Measured over a production run of 5,043 references: **44 logins came back `429 Too Many Requests` against 3 that succeeded**, degrading those runs to anonymous. It is also the race that made the separate latch bug fixed in #65 reachable, because the anonymous requests it produces answer 403, and 403 used to latch a host permanently.

`token_for_url` now takes a per-origin `threading.Lock` before logging in:
- The first thread to arrive for an origin performs the login; the rest wait on that origin's lock, then re-check the cache and reuse the winner's token instead of logging in themselves.
- A failed login is shared the same way (the origin lands in `_disabled` under the lock before it is released), so losers don't each retry it and reproduce the stampede.
- The lock is per origin, not global, so a slow login to one host never blocks a lookup against the other — matches the existing double-checked-locking discipline used for `_arxiv_record_cache` / `_venue_existence_cache` in `fact_checker.py`.
- The lock is only held across the login itself; the pre-login sibling/store lookups and the post-login store write happen exactly where they did before.
- A process that finds a valid token in the cross-process store never reaches the login path at all — unchanged.

## Test plan

- [x] New `TestConcurrentLoginsAreSerializedPerOrigin` in `tests/test_openreview_auth.py`, driving real `threading.Thread`s against a fake login endpoint:
  - `test_concurrent_callers_for_one_origin_share_a_single_login`: 8 threads, one origin, cold cache → asserts exactly one login call and all 8 threads get the same token. **Fails on `main` (8 calls, not 1)**, passes with the fix.
  - `test_a_failed_login_is_shared_not_retried_per_thread`: same shape with a failing login → asserts exactly one login call and all 8 threads get `None`. **Fails on `main`**, passes with the fix.
  - `test_a_login_to_one_origin_does_not_block_a_lookup_against_another`: blocks one origin's login mid-flight and asserts a concurrent lookup against an unrelated origin returns before the blocked one is released (guards against a naive global-lock implementation).
- [x] Full suite: 1846 passed, 1 skipped, 3 failed — the three failures are pre-existing and unrelated (`TestCLI::test_cli_help` / `test_cli_nonexistent_path`, both `FileNotFoundError: 'python'`; one OpenAlex test that hits the live API and got a live `429`).
- [x] `pre-commit run --all-files`: clean.
- [x] `mypy src/bibtex_updater --ignore-missing-imports --no-error-summary`: identical error set to `main` (one line-number shift from the insertion, no new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqPLG1FhkJjic9MvmM716h