### PR TITLE
fix: budget arXiv's 20/min limit per caller, not per process

### DIFF
--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -6137,7 +6137,11 @@ def _cli_service_rate_limits(rate_limit: int, s2_api_key: str | None) -> dict[st
         # /notes/search declares 5 req/min, so this one does not scale with
         # --rate-limit: going past it buys a 429 and a retry, not throughput.
         "openreview_search": 5,
-        "arxiv": 20,
+        # arXiv publishes ~20/min PER CALLER, not per process. Sharding a corpus
+        # across N processes multiplies the offered load by N, which buys 429s and
+        # an open circuit rather than throughput. A launcher that shards divides
+        # the caller budget by setting BIBTEX_ARXIV_RATE.
+        "arxiv": max(1, int(os.environ.get("BIBTEX_ARXIV_RATE", "20"))),
         "semanticscholar": 60 if s2_api_key else max(5, int(10 * rate_scale)),
         "openlibrary": max(10, int(30 * rate_scale)),
         "google_books": max(10, int(30 * rate_scale)),

--- a/src/bibtex_updater/utils.py
+++ b/src/bibtex_updater/utils.py
@@ -217,7 +217,7 @@ def retry_after_seconds(exc: httpx.HTTPError, fallback: float, cap: float = 60.0
 
 # API endpoints
 CROSSREF_API = "https://api.crossref.org/works"
-ARXIV_API = "http://export.arxiv.org/api/query"
+ARXIV_API = "https://export.arxiv.org/api/query"  # http:// 301-redirects here anyway
 DBLP_API_SEARCH = "https://dblp.org/search/publ/api"
 DBLP_API_VENUE_SEARCH = "https://dblp.org/search/venue/api"
 S2_API = "https://api.semanticscholar.org/graph/v1"

--- a/tests/test_rate_limits_and_mailto.py
+++ b/tests/test_rate_limits_and_mailto.py
@@ -108,6 +108,40 @@ class TestCliServiceRateLimits:
 
 
 # ===========================================================================
+# arXiv rate budget: BIBTEX_ARXIV_RATE (per-caller, not per-process)
+# ===========================================================================
+
+
+class TestArxivRateEnvOverride:
+    def test_default_is_20_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("BIBTEX_ARXIV_RATE", raising=False)
+        limits = _cli_service_rate_limits(45, None)
+        assert limits["arxiv"] == 20
+
+    def test_explicit_value_is_honored(self, monkeypatch):
+        monkeypatch.setenv("BIBTEX_ARXIV_RATE", "7")
+        limits = _cli_service_rate_limits(45, None)
+        assert limits["arxiv"] == 7
+
+    def test_zero_floors_to_one(self, monkeypatch):
+        # A shard count that would divide the budget to zero must not disable
+        # the caller entirely -- max(1, ...) keeps it a working rate limit.
+        monkeypatch.setenv("BIBTEX_ARXIV_RATE", "0")
+        limits = _cli_service_rate_limits(45, None)
+        assert limits["arxiv"] == 1
+
+    def test_negative_floors_to_one(self, monkeypatch):
+        monkeypatch.setenv("BIBTEX_ARXIV_RATE", "-5")
+        limits = _cli_service_rate_limits(45, None)
+        assert limits["arxiv"] == 1
+
+    def test_not_scaled_by_rate_limit_flag(self, monkeypatch):
+        monkeypatch.setenv("BIBTEX_ARXIV_RATE", "9")
+        limits = _cli_service_rate_limits(900, None)
+        assert limits["arxiv"] == 9
+
+
+# ===========================================================================
 # HttpClient -> adapt() wiring
 # ===========================================================================
 


### PR DESCRIPTION
## Why

arXiv rate-limits the caller, not the process. `_cli_service_rate_limits()` set `"arxiv": 20` as a flat per-process rate, so a screening run sharded across three processes each ran the CLI's own 20/min limit and together offered arXiv 60 requests/minute. arXiv answered 429, the circuit breaker opened (fail threshold 4, cooldown escalating 90 to 1800 seconds), and only 90 of 750 lookups succeeded (12%).

A single-process probe over the same entries reached arXiv 6 times out of 6, which is what distinguished self-inflicted load from an arXiv outage.

## Reproduction

Three concurrent processes, each at the default per-process budget of 20/min, offer arXiv 60/min against its ~20/min-per-caller politeness ask. That triggered the 429s and the circuit open above. A simulated three-shard load after this fix — each process budgeted at a third of the caller limit via `BIBTEX_ARXIV_RATE` — reached arXiv 18/18 (100%).

## What changed

- `src/bibtex_updater/fact_checker.py`: `_cli_service_rate_limits()` now reads the arXiv budget from `BIBTEX_ARXIV_RATE` (default 20, floored at 1 via `max(1, ...)`), so a sharding launcher divides the shared caller budget across its processes instead of each process claiming the full 20/min. This mirrors the existing `openreview_search` precedent in the same function, which already documents why a per-caller limit must not scale with `--rate-limit`.
- `src/bibtex_updater/utils.py`: `ARXIV_API` now points at `https://export.arxiv.org/api/query` instead of `http://`. The `httpx` client is built with `follow_redirects=True`, so the `http` URL was never the cause of the circuit-open problem — it cost one redirect hop per call, which only matters because the budget is small. This is not a fix for the 429/circuit-open issue above.
- `tests/test_rate_limits_and_mailto.py`: new `TestArxivRateEnvOverride` covering the default (20, env unset), an explicit override being honored, and a `0` or negative value flooring to 1 rather than crashing the caller.

## Tests

Before: 1846 passed, 3 failed, 1 skipped.
After: 1851 passed, 3 failed, 1 skipped.

The 3 failures are pre-existing on `main` and unrelated to this change: a live-network OpenAlex test that hit a real HTTP 429, and two CLI subprocess tests that fail because `python` isn't on this machine's `PATH` (only `python3`/`.venv`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqPLG1FhkJjic9MvmM716h