### PR TITLE
fix: a correct author list should not certify a corrupt index record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A bibliographic index can serve a work under the correct identifier and the correct author list but a different paper's title, and the checker read that as evidence about the entry.** OpenAlex does this today for ToolLLM (`10.48550/arxiv.2307.16789`, served as "Counterfactually Auditable Lifecycle Certification for Autonomous Agents"), Constitutional AI (`10.48550/arxiv.2212.08073`) and LoRA (`10.48550/arxiv.2106.09685`) — each with the paper's real authors, each verified by resolving the arXiv ID directly. Normalized title similarity for those pairs is 0.35–0.39, so the blended candidate score lands at 0.54–0.57: above `abstention_below`, and above the `wrong_paper_signature` bar because the author list corroborates perfectly. The entry therefore verdicted `title_mismatch` on one index's disagreement with itself, and downstream that reads as a fabricated citation. Measured over a 267-submission screening run, the signature came from a corrupt record three times for every real citation error. `_split_corrupt_index_records` now drops a candidate that is anchored on the entry's own DOI or arXiv ID, whose authors the entry confirms, and whose title similarity is below `index_corruption_max_title` (0.50, the same bar `doi_consistency_min_title` and `arxiv_consistency_min_title` already use for "this record is a different paper"). Nothing is dropped when a second identifier-anchored source corroborates the divergence, so a genuine hybrid fabrication — real identifier, real authors, invented title — keeps its verdict; and where an identifier-anchored source *confirms* the entry's title, that source wins, which for a `10.48550/arxiv.*` DOI or a bare arXiv ID means arXiv's own title cannot be overridden by an aggregator. `_check_doi_consistency` and `_check_arxiv_id_consistency` are untouched: they run against an authoritative source before the cascade and reach their own verdicts. Disable with `distrust_corrupt_index_records=False`.
+
+### Added
+
+- **`distrusted_records` on `FactCheckResult`, in the JSON report and on every JSONL line.** One readable line per record the cascade declined to score, naming the source, the identifier, the title it served and the similarity. A caller can now see that a verdict was reached without a record the run had in hand, and which index misbehaved. Additive: no existing key changes.
+
 ## [1.10.3] - 2026-09-04
 
 arXiv publishes its rate limit per caller. This release stops a sharded run from spending that budget N times over.

--- a/docs/REFERENCE_FACT_CHECKER.md
+++ b/docs/REFERENCE_FACT_CHECKER.md
@@ -213,6 +213,7 @@ Per-line fields:
 | `p_valid` | 0–1 probability that the entry **as cited** refers to a real publication with correct metadata — **threshold/rank on this**, not on `confidence`. Verified-polarity statuses map above 0.5, problem-polarity below 0.5, abstentions sit at 0.5, and a clean exhaustive `not_found` at 0.35. Note `preprint_only` is problem-polarity for `p_valid` (the claimed venue is contradicted) even though the verdict itself is confident |
 | `confidence_score` | additive 0–100 numeric confidence (next section) |
 | `sources_failed` | source names whose lookup for this entry did not complete. Non-empty means the cascade was partial: the entry cannot carry `not_found`, and whatever it does carry rests on less evidence than a clean run |
+| `distrusted_records` | records a source returned that the cascade declined to score, one readable line each. A source can serve a work under the correct identifier and the correct author list but a different paper's title; scored as a candidate that record produces a `title_mismatch` against a correctly cited entry. Non-empty means the verdict was reached **without** a record the run had in hand, and names which index misbehaved — a statement about the source, never about the entry |
 | `mismatched_fields`, `api_sources`, `errors` | non-confirmed field names, sources with hits, and per-source error strings |
 
 ## Exit Codes

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -473,6 +473,15 @@ class FactCheckResult:
     # miss NOT_FOUND asserts. Recorded per source per entry, because a run can
     # be healthy overall while one entry's every source timed out.
     sources_failed: list[str] = field(default_factory=list)
+    # Source records this entry's cascade DISTRUSTED rather than scored: an
+    # index record carrying the entry's OWN identifier and the entry's authors
+    # under a different paper's title (see
+    # ``FactChecker._split_corrupt_index_records``). One human-readable line per
+    # dropped record, naming the source, the identifier, the title it served and
+    # the similarity -- so a caller can see that a verdict was reached WITHOUT a
+    # record it might otherwise have expected, and which index misbehaved. This
+    # is a statement about the SOURCE, never about the entry.
+    distrusted_records: list[str] = field(default_factory=list)
     # Output contract -- both fields are DERIVED, recomputed in __post_init__
     # from (status, errors, overall_confidence) at EVERY construction site
     # (check_entry's early returns, the cascade assembly, the verifier
@@ -541,6 +550,23 @@ class FactCheckerConfig:
     # of it, escalate to the positive NONEXISTENT_VENUE status. Lookup errors
     # always keep the abstention. Disable with --no-check-venue-existence.
     check_venue_existence: bool = True
+    # Distrust a corrupt index record instead of convicting the entry it
+    # describes. A bibliographic index can serve a work under the CORRECT
+    # identifier and the CORRECT author list but a DIFFERENT paper's title;
+    # OpenAlex did exactly that for ToolLLM (``10.48550/arxiv.2307.16789``),
+    # Constitutional AI (``...2212.08073``) and LoRA (``...2106.09685``) in a
+    # 2026-09 screening run. That shape is indistinguishable from the strongest
+    # available evidence of a hybrid fabrication -- right identifier, wrong
+    # metadata -- so the entries verdicted TITLE_MISMATCH. When the guard is on,
+    # such a record is dropped from the candidate pool unless a SECOND
+    # identifier-anchored source corroborates the divergence; see
+    # ``FactChecker._split_corrupt_index_records``.
+    distrust_corrupt_index_records: bool = True
+    # Below this normalized title score (0-1), an identifier-anchored record is
+    # about a DIFFERENT paper. Mirrors ``doi_consistency_min_title`` and
+    # ``arxiv_consistency_min_title``, which draw the same line for the same
+    # reason; the three measured corrupt records sit at 0.35-0.39.
+    index_corruption_max_title: float = 0.50
     # Identifier-anchored fast paths (speed). After the entry's own DOI/arXiv-ID
     # consistency check found no mismatch, skip the multi-source cascade when
     # the single authoritative record behind that identifier FULLY confirms
@@ -2623,9 +2649,36 @@ class FactChecker:
         # HALLUCINATED/NOT_FOUND from a failed title search.
         candidates.extend(self._query_arxiv_by_id(entry, sources_queried, sources_with_hits, errors, sources_failed))
 
+        # Drop index records that carry the entry's own identifier and authors
+        # under a different paper's title. Such a record is a defect in the
+        # source; scored as a candidate it produces a TITLE_MISMATCH against a
+        # correctly cited paper, and it also poisons the per-source author
+        # intersection and the chimeric-title detector below. Nothing is dropped
+        # when a second identifier-anchored source corroborates the divergence.
+        candidates, distrusted_records = self._split_corrupt_index_records(entry, candidates)
+
         if not candidates:
             # Nothing came back at all. That is a clean exhaustive miss only if
             # every source actually answered; otherwise the run never asked them.
+            # A pool emptied by the distrust guard is neither: a record WAS
+            # returned and we declined to score it, so the entry is unverified,
+            # not missing.
+            if distrusted_records:
+                return FactCheckResult(
+                    entry_key=entry_key,
+                    entry_type=entry_type,
+                    status=FactCheckStatus.UNCONFIRMED,
+                    overall_confidence=0.0,
+                    field_comparisons={},
+                    best_match=None,
+                    api_sources_queried=sources_queried,
+                    api_sources_with_hits=sources_with_hits,
+                    errors=errors,
+                    sources_failed=sources_failed,
+                    author_intersection=None,
+                    source_records={},
+                    distrusted_records=distrusted_records,
+                )
             status = FactCheckStatus.API_ERROR if errors else FactCheckStatus.NOT_FOUND
             status = self._not_found_needs_complete_coverage(status, sources_failed)
             status = self._apply_strict_warn_cnv(status)
@@ -2662,6 +2715,7 @@ class FactChecker:
                 sources_failed=sources_failed,
                 author_intersection=None,
                 source_records={},
+                distrusted_records=distrusted_records,
             )
 
         # Sort candidates by score descending (used below for per-source author
@@ -2775,6 +2829,7 @@ class FactChecker:
             intersection=intersection,
             best_per_source=best_per_source,
             sources_failed=sources_failed,
+            distrusted_records=distrusted_records,
         )
 
     def _assemble_match_result(
@@ -2791,6 +2846,7 @@ class FactChecker:
         intersection: AuthorIntersectionResult,
         best_per_source: dict[str, PublishedRecord | None],
         sources_failed: list[str] | None = None,
+        distrusted_records: list[str] | None = None,
     ) -> FactCheckResult:
         """Assemble the final result for a matched record.
 
@@ -2852,6 +2908,7 @@ class FactChecker:
             api_sources_with_hits=sources_with_hits,
             errors=errors,
             sources_failed=list(sources_failed or []),
+            distrusted_records=list(distrusted_records or []),
             # Per-entry state carried on the result (not stashed on self) so
             # concurrent check_entry calls don't clobber each other.
             author_intersection=intersection,
@@ -4175,6 +4232,142 @@ class FactChecker:
                         return True
 
         return False
+
+    def _split_corrupt_index_records(
+        self,
+        entry: dict[str, Any],
+        candidates: list[tuple[float, PublishedRecord, str]],
+    ) -> tuple[list[tuple[float, PublishedRecord, str]], list[str]]:
+        """Separate candidates that look like a CORRUPT INDEX RECORD.
+
+        The shape: a candidate keyed on the entry's OWN identifier (its DOI or
+        its arXiv ID), whose author list the entry confirms, under a title that
+        belongs to a different paper (below
+        ``config.index_corruption_max_title``). An index that serves the right
+        identifier and the right authors under the wrong title is disagreeing
+        with ITSELF, and the cheapest explanation is a defective record -- not a
+        citation whose author list happens to be perfect while its title is
+        invented. Measured on OpenAlex in a 2026-09 screening run: the signature
+        was produced by a corrupt record three times for every real citation
+        error, and the entries it hit (ToolLLM, Constitutional AI, LoRA) are
+        correctly cited papers.
+
+        Corroboration is what separates the two readings, so distrust is
+        withheld whenever the divergence is genuinely multi-source:
+
+        * If any identifier-anchored source CONFIRMS the entry's title (at
+          ``config.title_threshold``), the sources contradict each other about a
+          record they both key on the entry's own identifier, and the confirming
+          one wins. For a ``10.48550/arxiv.*`` DOI or a bare arXiv ID that
+          confirming source is arXiv itself, which is authoritative for the
+          title it mints -- so no aggregator's title can override it.
+        * Otherwise, distrust only when the divergence rests on a SINGLE source.
+          Two or more identifier-anchored sources independently reporting a
+          different paper for the identifier is evidence about the ENTRY (the
+          shape of a hybrid fabrication: real identifier, real authors, invented
+          title), and it is left to stand.
+
+        A confirming candidate is never itself distrusted, so this can only
+        empty the pool when there was no confirming source to begin with; the
+        caller abstains in that case rather than reading the empty pool as an
+        exhaustive miss. The genuine wrong-identifier findings are unaffected:
+        ``_check_doi_consistency`` and ``_check_arxiv_id_consistency`` both run
+        against an authoritative source BEFORE the cascade and return their own
+        verdicts without consulting this method.
+
+        Returns:
+            ``(kept, distrusted_notes)`` -- the surviving candidates in their
+            original order, and one human-readable line per dropped record for
+            ``FactCheckResult.distrusted_records``.
+        """
+        if not self.config.distrust_corrupt_index_records or not candidates:
+            return candidates, []
+
+        entry_title = normalize_title_for_match(entry.get("title", ""))
+        if not entry_title:
+            return candidates, []
+
+        entry_doi = normalize_doi_for_resolution(entry.get("doi", "")) or None
+        entry_arxiv = self._arxiv_id_from_entry(entry)
+        if not entry_doi and not entry_arxiv:
+            return candidates, []
+
+        def _anchored(rec: PublishedRecord) -> bool:
+            """True when ``rec`` is keyed on the entry's own identifier."""
+            rec_doi = normalize_doi_for_resolution(rec.doi) if rec.doi else None
+            if entry_doi and rec_doi and rec_doi == entry_doi:
+                return True
+            return bool(entry_arxiv and rec.arxiv_id and rec.arxiv_id == entry_arxiv)
+
+        def _title_similarity(rec: PublishedRecord) -> float:
+            return token_sort_ratio(entry_title, normalize_title_for_match(rec.title or "")) / 100.0
+
+        def _authors_confirm(rec: PublishedRecord) -> bool:
+            entry_names = self._entry_surname_keys(entry, rec)
+            api_names = rec.surname_keys(limit=10_000)
+            if not entry_names or not api_names:
+                return False
+            return symmetric_author_match(
+                entry_names,
+                api_names,
+                threshold=self.config.author_threshold,
+                order_reliable=rec.order_reliable,
+            ).is_confirmed
+
+        confirming_sources: set[str] = set()
+        divergent_sources: set[str] = set()
+        suspect: list[int] = []
+        for index, (_score, rec, source) in enumerate(candidates):
+            if not _anchored(rec):
+                continue
+            similarity = _title_similarity(rec)
+            if similarity >= self.config.title_threshold:
+                confirming_sources.add(source)
+                continue
+            if similarity >= self.config.index_corruption_max_title:
+                continue
+            # Corroboration is about the TITLE divergence alone, so a source
+            # counts here whatever its author list looks like; only the records
+            # that could be DROPPED additionally need confirmed authors.
+            divergent_sources.add(source)
+            if _authors_confirm(rec):
+                suspect.append(index)
+
+        if not suspect:
+            return candidates, []
+        # No source vouches for the entry's title AND more than one source
+        # reports a different paper for the identifier: that is corroborated
+        # evidence about the ENTRY, and it stands.
+        if not confirming_sources and len(divergent_sources - confirming_sources) > 1:
+            return candidates, []
+
+        drop = {i for i in suspect if candidates[i][2] not in confirming_sources}
+        if not drop:
+            return candidates, []
+
+        kept: list[tuple[float, PublishedRecord, str]] = []
+        notes: list[str] = []
+        for index, (score, rec, source) in enumerate(candidates):
+            if index not in drop:
+                kept.append((score, rec, source))
+                continue
+            identifier = rec.doi or rec.arxiv_id or entry_doi or entry_arxiv or "?"
+            notes.append(
+                f"{source}: record for {identifier} carries the entry's authors under a "
+                f"different paper's title {rec.title!r} (title similarity "
+                f"{_title_similarity(rec):.2f}); distrusted as a corrupt index record"
+            )
+            self.logger.warning(
+                "Distrusted a %s record for entry %r: identifier %s and authors match, but the "
+                "title %r is a different paper (similarity %.2f). This is a defect in the source, "
+                "not evidence about the entry.",
+                source,
+                entry.get("ID", "?"),
+                identifier,
+                rec.title,
+                _title_similarity(rec),
+            )
+        return kept, notes
 
     @staticmethod
     def _entry_surname_keys(entry: dict[str, Any], record: PublishedRecord, limit: int = 10_000) -> list[str]:
@@ -5840,6 +6033,12 @@ class FactCheckProcessor:
                                 # entry. Non-empty means the cascade was partial,
                                 # so no exhaustive miss can be read off the status.
                                 "sources_failed": result.sources_failed,
+                                # Records a source returned that the cascade
+                                # declined to score: an index record carrying
+                                # this entry's identifier and authors under a
+                                # different paper's title. A statement about the
+                                # source, never about the entry.
+                                "distrusted_records": result.distrusted_records,
                                 "errors": result.errors,
                             },
                             ensure_ascii=False,
@@ -5995,6 +6194,9 @@ class FactCheckProcessor:
                 "api_sources_queried": r.api_sources_queried,
                 "api_sources_with_hits": r.api_sources_with_hits,
                 "sources_failed": r.sources_failed,
+                # Records a source returned that the cascade declined to score
+                # (see FactCheckResult.distrusted_records).
+                "distrusted_records": r.distrusted_records,
                 "errors": r.errors,
             }
             if r.best_match:
@@ -6056,6 +6258,9 @@ class FactCheckProcessor:
                         "api_sources": r.api_sources_with_hits,
                         # Sources whose lookup did not complete (see process_entries).
                         "sources_failed": r.sources_failed,
+                        # Records a source returned that the cascade declined to
+                        # score (see FactCheckResult.distrusted_records).
+                        "distrusted_records": r.distrusted_records,
                         "errors": r.errors,
                     },
                     ensure_ascii=False,

--- a/tests/test_corrupt_index_records.py
+++ b/tests/test_corrupt_index_records.py
@@ -1,0 +1,511 @@
+"""Tests for distrusting corrupt index records (identifier right, title wrong).
+
+Measured on a 267-submission screening run (2026-09-03): OpenAlex serves works
+that carry the CORRECT identifier and the CORRECT author list for a paper under
+a title belonging to a different work. Three verified instances, each checked by
+resolving the arXiv ID directly:
+
+* ``10.48550/arxiv.2307.16789`` -- really ToolLLM (Qin et al.) -- comes back as
+  "Counterfactually Auditable Lifecycle Certification for Autonomous Agents"
+  with ToolLLM's real author list (OpenAlex ``W4385474529``).
+* ``10.48550/arxiv.2212.08073`` -- really Constitutional AI (Bai et al.) --
+  comes back as "Affective Coherence Monitoring for Transformer-Based Language
+  Models" with Constitutional AI's real authors (``W4311991106``).
+* ``10.48550/arxiv.2106.09685`` -- really LoRA (Hu et al.) -- comes back as
+  "LoRA Fine-Tuning of a 3B Code LLM for Algorithmic Efficiency" with LoRA's
+  real authors (``W3168867926``).
+
+Normalized title similarity for those three pairs is 0.35-0.39, so the blended
+candidate score (``0.7 * title + 0.3 * author``) lands at 0.54-0.57 -- above
+``abstention_below`` and above the ``wrong_paper_signature`` bar, because the
+author list corroborates perfectly. The entry therefore verdicts TITLE_MISMATCH
+on the strength of ONE index's disagreement with itself.
+
+The guard: a candidate anchored on the entry's OWN identifier, whose authors the
+entry confirms, whose title is a different paper's, is distrusted unless a second
+identifier-anchored source corroborates the divergence AND no identifier-anchored
+source confirms the entry's title. Distrust removes the record from the candidate
+pool and is reported on ``FactCheckResult.distrusted_records``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from bibtex_updater.fact_checker import (
+    FactChecker,
+    FactCheckerConfig,
+    FactCheckProcessor,
+    FactCheckStatus,
+)
+from bibtex_updater.sources import openalex_work_to_candidate_record
+from bibtex_updater.utils import PublishedRecord, normalize_doi_for_resolution
+
+# ---------------------------------------------------------------------------
+# Real corrupt OpenAlex works (fields trimmed to what the converter reads).
+# ---------------------------------------------------------------------------
+
+TOOLLLM_AUTHORS = [
+    "Qin, Yujia",
+    "Shihao Liang",
+    "Yining Ye",
+    "Kunlun Zhu",
+    "Lan Yan",
+    "Yaxi Lu",
+    "Yankai Lin",
+    "Xin Cong",
+]
+CONSTITUTIONAL_AUTHORS = [
+    "Bai, Yuntao",
+    "Saurav Kadavath",
+    "Sandipan Kundu",
+    "Amanda Askell",
+]
+LORA_AUTHORS = [
+    "J. Edward Hu",
+    "Yelong Shen",
+    "Phillip Wallis",
+    "Zeyuan Allen-Zhu",
+]
+
+
+def _openalex_work(
+    *,
+    openalex_id: str,
+    doi: str,
+    title: str,
+    authors: list[str],
+    year: int,
+    arxiv_landing: str | None = None,
+) -> dict:
+    """An OpenAlex ``/works`` item in the shape the cascade converter reads."""
+    return {
+        "id": f"https://openalex.org/{openalex_id}",
+        "doi": f"https://doi.org/{doi}",
+        "display_name": title,
+        "title": title,
+        "publication_year": year,
+        "type": "preprint",
+        "authorships": [{"author": {"display_name": name}} for name in authors],
+        "primary_location": {
+            "landing_page_url": arxiv_landing,
+            "source": {"display_name": "arXiv (Cornell University)"},
+        },
+    }
+
+
+CORRUPT_TOOLLLM_WORK = _openalex_work(
+    openalex_id="W4385474529",
+    doi="10.48550/arxiv.2307.16789",
+    title="Counterfactually Auditable Lifecycle Certification for Autonomous Agents",
+    authors=TOOLLLM_AUTHORS,
+    year=2023,
+    arxiv_landing="http://arxiv.org/abs/2307.16789",
+)
+CORRUPT_CONSTITUTIONAL_WORK = _openalex_work(
+    openalex_id="W4311991106",
+    doi="10.48550/arxiv.2212.08073",
+    title="Affective Coherence Monitoring for Transformer-Based Language Models",
+    authors=CONSTITUTIONAL_AUTHORS,
+    year=2022,
+    arxiv_landing="http://arxiv.org/abs/2212.08073",
+)
+CORRUPT_LORA_WORK = _openalex_work(
+    openalex_id="W3168867926",
+    doi="10.48550/arxiv.2106.09685",
+    title="LoRA Fine-Tuning of a 3B Code LLM for Algorithmic Efficiency",
+    authors=LORA_AUTHORS,
+    year=2021,
+    arxiv_landing="http://arxiv.org/abs/2106.09685",
+)
+
+
+TOOLLLM_ENTRY = {
+    "ID": "qin2024toolllm",
+    "ENTRYTYPE": "inproceedings",
+    "title": "ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs",
+    "author": (
+        "Qin, Yujia and Liang, Shihao and Ye, Yining and Zhu, Kunlun and "
+        "Yan, Lan and Lu, Yaxi and Lin, Yankai and Cong, Xin"
+    ),
+    "booktitle": "International Conference on Learning Representations",
+    "year": "2024",
+    "doi": "10.48550/arXiv.2307.16789",
+}
+CONSTITUTIONAL_ENTRY = {
+    "ID": "bai2022constitutional",
+    "ENTRYTYPE": "misc",
+    "title": "Constitutional AI: Harmlessness from AI Feedback",
+    "author": "Bai, Yuntao and Kadavath, Saurav and Kundu, Sandipan and Askell, Amanda",
+    "year": "2022",
+    "doi": "10.48550/arXiv.2212.08073",
+}
+LORA_ENTRY = {
+    "ID": "hu2022lora",
+    "ENTRYTYPE": "inproceedings",
+    "title": "LoRA: Low-Rank Adaptation of Large Language Models",
+    "author": "Hu, Edward J and Shen, Yelong and Wallis, Phillip and Allen-Zhu, Zeyuan",
+    "booktitle": "International Conference on Learning Representations",
+    "year": "2022",
+    "doi": "10.48550/arXiv.2106.09685",
+}
+
+
+def _arxiv_record(*, title: str, authors: list[str], year: int, arxiv_id: str) -> PublishedRecord:
+    """The authoritative arXiv record for an ID (what ``_arxiv_record`` returns)."""
+    people = []
+    for name in authors:
+        parts = name.replace(",", " ").split()
+        people.append({"given": " ".join(parts[1:]) if len(parts) > 1 else "", "family": parts[0]})
+    return PublishedRecord(
+        doi=None,
+        title=title,
+        authors=people,
+        journal="arXiv",
+        year=year,
+        type="preprint",
+        arxiv_id=arxiv_id,
+    )
+
+
+TRUE_TOOLLLM_ARXIV = _arxiv_record(
+    title="ToolLLM: Facilitating Large Language Models to Master 16000+ Real-world APIs",
+    authors=["Qin Yujia", "Liang Shihao", "Ye Yining", "Zhu Kunlun", "Yan Lan", "Lu Yaxi", "Lin Yankai", "Cong Xin"],
+    year=2023,
+    arxiv_id="2307.16789",
+)
+TRUE_CONSTITUTIONAL_ARXIV = _arxiv_record(
+    title="Constitutional AI: Harmlessness from AI Feedback",
+    authors=["Bai Yuntao", "Kadavath Saurav", "Kundu Sandipan", "Askell Amanda"],
+    year=2022,
+    arxiv_id="2212.08073",
+)
+TRUE_LORA_ARXIV = _arxiv_record(
+    title="LoRA: Low-Rank Adaptation of Large Language Models",
+    authors=["Hu Edward", "Shen Yelong", "Wallis Phillip", "Allen-Zhu Zeyuan"],
+    year=2021,
+    arxiv_id="2106.09685",
+)
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_corrupt_index_records")
+
+
+def _checker(logger, *, config: FactCheckerConfig | None = None) -> FactChecker:
+    """A checker whose every source answers with nothing (tests seed what they need)."""
+    crossref = MagicMock()
+    crossref.search.return_value = []
+    crossref.get_by_doi.return_value = None
+    crossref.http = MagicMock()
+    crossref.http.s2_api_key = None
+    dblp = MagicMock()
+    dblp.search.return_value = []
+    s2 = MagicMock()
+    s2.search.return_value = []
+    s2.match_title.return_value = []
+    openalex = MagicMock()
+    openalex.search.return_value = []
+    openreview = MagicMock()
+    openreview.search.return_value = []
+    checker = FactChecker(
+        crossref,
+        dblp,
+        s2,
+        config or FactCheckerConfig(),
+        logger,
+        openalex=openalex,
+        openreview=openreview,
+    )
+    checker.arxiv = MagicMock()
+    return checker
+
+
+def _candidates(checker: FactChecker, entry: dict, *pairs) -> list[tuple[float, PublishedRecord, str]]:
+    """Score ``(record, source)`` pairs exactly as the cascade does."""
+    from bibtex_updater.utils import authors_last_names, entry_authors, normalize_title_for_match
+
+    title_norm = normalize_title_for_match(entry.get("title", ""))
+    authors_ref = authors_last_names(entry_authors(entry), limit=3)
+    return [(checker._score_candidate(title_norm, authors_ref, rec), rec, source) for rec, source in pairs]
+
+
+# ===========================================================================
+# The corruption signature itself
+# ===========================================================================
+
+
+class TestCorruptionSignature:
+    """``_split_corrupt_index_records`` isolates the id+authors+wrong-title shape."""
+
+    @pytest.mark.parametrize(
+        "entry, work, true_arxiv",
+        [
+            (TOOLLLM_ENTRY, CORRUPT_TOOLLLM_WORK, TRUE_TOOLLLM_ARXIV),
+            (CONSTITUTIONAL_ENTRY, CORRUPT_CONSTITUTIONAL_WORK, TRUE_CONSTITUTIONAL_ARXIV),
+            (LORA_ENTRY, CORRUPT_LORA_WORK, TRUE_LORA_ARXIV),
+        ],
+        ids=["toolllm", "constitutional-ai", "lora"],
+    )
+    def test_corrupt_openalex_record_is_distrusted(self, logger, entry, work, true_arxiv):
+        checker = _checker(logger)
+        corrupt = openalex_work_to_candidate_record(work)
+        assert corrupt is not None
+        candidates = _candidates(checker, entry, (corrupt, "openalex"), (true_arxiv, "arxiv"))
+
+        kept, distrusted = checker._split_corrupt_index_records(entry, candidates)
+
+        assert [source for _s, _r, source in kept] == ["arxiv"]
+        assert len(distrusted) == 1
+        assert distrusted[0].startswith("openalex:")
+        assert work["display_name"] in distrusted[0]
+
+    def test_lone_corrupt_record_is_distrusted_without_a_counter_source(self, logger):
+        """A single source's title disagreement never stands on its own."""
+        checker = _checker(logger)
+        corrupt = openalex_work_to_candidate_record(CORRUPT_LORA_WORK)
+        candidates = _candidates(checker, LORA_ENTRY, (corrupt, "openalex"))
+
+        kept, distrusted = checker._split_corrupt_index_records(LORA_ENTRY, candidates)
+
+        assert kept == []
+        assert len(distrusted) == 1
+
+    def test_two_divergent_sources_corroborate_and_the_finding_stands(self, logger):
+        """A real hybrid fabrication: every index that knows the identifier
+        reports the same other title, so nothing is distrusted."""
+        checker = _checker(logger)
+        corrupt = openalex_work_to_candidate_record(CORRUPT_LORA_WORK)
+        crossref_agreeing = PublishedRecord(
+            doi="10.48550/arxiv.2106.09685",
+            title="LoRA Fine-Tuning of a 3B Code LLM for Algorithmic Efficiency",
+            authors=[{"given": "Edward", "family": "Hu"}, {"given": "Yelong", "family": "Shen"}],
+            journal="arXiv",
+            year=2021,
+            structured_names=True,
+        )
+        candidates = _candidates(checker, LORA_ENTRY, (corrupt, "openalex"), (crossref_agreeing, "crossref"))
+
+        kept, distrusted = checker._split_corrupt_index_records(LORA_ENTRY, candidates)
+
+        assert distrusted == []
+        assert len(kept) == 2
+
+    def test_divergent_title_with_divergent_authors_is_not_distrusted(self, logger):
+        """A wrong identifier pointing at a genuinely different paper keeps its
+        evidentiary weight -- the authors do not corroborate."""
+        checker = _checker(logger)
+        other_paper = PublishedRecord(
+            doi="10.48550/arxiv.2106.09685",
+            title="Counterfactually Auditable Lifecycle Certification for Autonomous Agents",
+            authors=[{"given": "Jane", "family": "Roe"}, {"given": "Richard", "family": "Doe"}],
+            journal="arXiv",
+            year=2021,
+        )
+        candidates = _candidates(checker, LORA_ENTRY, (other_paper, "openalex"), (TRUE_LORA_ARXIV, "arxiv"))
+
+        kept, distrusted = checker._split_corrupt_index_records(LORA_ENTRY, candidates)
+
+        assert distrusted == []
+        assert len(kept) == 2
+
+    def test_record_without_the_entry_identifier_is_untouched(self, logger):
+        """Only records keyed on the entry's OWN identifier can be corrupt in
+        this sense; an unrelated search hit is just a weak candidate."""
+        checker = _checker(logger)
+        unrelated = PublishedRecord(
+            doi="10.1234/unrelated",
+            title="Counterfactually Auditable Lifecycle Certification for Autonomous Agents",
+            authors=[{"given": "Edward", "family": "Hu"}, {"given": "Yelong", "family": "Shen"}],
+            journal="Some Journal",
+            year=2021,
+        )
+        candidates = _candidates(checker, LORA_ENTRY, (unrelated, "openalex"), (TRUE_LORA_ARXIV, "arxiv"))
+
+        kept, distrusted = checker._split_corrupt_index_records(LORA_ENTRY, candidates)
+
+        assert distrusted == []
+        assert len(kept) == 2
+
+    def test_entry_without_an_identifier_is_untouched(self, logger):
+        checker = _checker(logger)
+        entry = {k: v for k, v in LORA_ENTRY.items() if k != "doi"}
+        corrupt = openalex_work_to_candidate_record(CORRUPT_LORA_WORK)
+        candidates = _candidates(checker, entry, (corrupt, "openalex"))
+
+        kept, distrusted = checker._split_corrupt_index_records(entry, candidates)
+
+        assert distrusted == []
+        assert len(kept) == 1
+
+    def test_guard_is_inert_when_disabled(self, logger):
+        checker = _checker(logger, config=FactCheckerConfig(distrust_corrupt_index_records=False))
+        corrupt = openalex_work_to_candidate_record(CORRUPT_LORA_WORK)
+        candidates = _candidates(checker, LORA_ENTRY, (corrupt, "openalex"), (TRUE_LORA_ARXIV, "arxiv"))
+
+        kept, distrusted = checker._split_corrupt_index_records(LORA_ENTRY, candidates)
+
+        assert distrusted == []
+        assert len(kept) == 2
+
+
+# ===========================================================================
+# arXiv precedence for arXiv identifiers
+# ===========================================================================
+
+
+class TestArxivPrecedence:
+    """For a ``10.48550/arxiv.*`` DOI or a bare arXiv ID, arXiv owns the title."""
+
+    def test_openalex_title_does_not_override_arxiv_for_an_arxiv_doi(self, logger):
+        checker = _checker(logger)
+        corrupt = openalex_work_to_candidate_record(CORRUPT_TOOLLLM_WORK)
+        candidates = _candidates(checker, TOOLLLM_ENTRY, (corrupt, "openalex"), (TRUE_TOOLLLM_ARXIV, "arxiv"))
+
+        kept, distrusted = checker._split_corrupt_index_records(TOOLLLM_ENTRY, candidates)
+
+        assert [source for _s, _r, source in kept] == ["arxiv"]
+        assert distrusted
+
+    def test_bare_eprint_id_anchors_the_same_way(self, logger):
+        """The entry carries no DOI at all -- the arXiv ID alone ties the two
+        records to the same work."""
+        checker = _checker(logger)
+        entry = {k: v for k, v in TOOLLLM_ENTRY.items() if k != "doi"}
+        entry["eprint"] = "2307.16789"
+        entry["archiveprefix"] = "arXiv"
+        corrupt = openalex_work_to_candidate_record(CORRUPT_TOOLLLM_WORK)
+        assert corrupt.arxiv_id == "2307.16789"
+        candidates = _candidates(checker, entry, (corrupt, "openalex"), (TRUE_TOOLLLM_ARXIV, "arxiv"))
+
+        kept, distrusted = checker._split_corrupt_index_records(entry, candidates)
+
+        assert [source for _s, _r, source in kept] == ["arxiv"]
+        assert distrusted
+
+
+# ===========================================================================
+# End-to-end verdict
+# ===========================================================================
+
+
+class TestVerdict:
+    """The corrupt record must not carry the entry to a mismatch verdict."""
+
+    def _run(self, logger, entry, work, true_arxiv, *, config=None):
+        checker = _checker(logger, config=config)
+        checker.openalex.search.return_value = [work]
+        checker._arxiv_record_cache[true_arxiv.arxiv_id] = true_arxiv
+        return checker.check_entry(entry)
+
+    @pytest.mark.parametrize(
+        "entry, work, true_arxiv",
+        [
+            (TOOLLLM_ENTRY, CORRUPT_TOOLLLM_WORK, TRUE_TOOLLLM_ARXIV),
+            (CONSTITUTIONAL_ENTRY, CORRUPT_CONSTITUTIONAL_WORK, TRUE_CONSTITUTIONAL_ARXIV),
+            (LORA_ENTRY, CORRUPT_LORA_WORK, TRUE_LORA_ARXIV),
+        ],
+        ids=["toolllm", "constitutional-ai", "lora"],
+    )
+    def test_no_title_mismatch_and_the_distrust_is_reported(self, logger, entry, work, true_arxiv):
+        result = self._run(logger, entry, work, true_arxiv)
+
+        assert result.status is not FactCheckStatus.TITLE_MISMATCH
+        assert result.distrusted_records
+        assert any("openalex" in note for note in result.distrusted_records)
+
+    def test_arxiv_unreachable_leaves_the_corrupt_record_alone_but_unconfirmed(self, logger):
+        """The shape the screening run hit: no counter-record in the pool at
+        all. Distrusting the only candidate must abstain, never assert a miss
+        the sources did not support."""
+        checker = _checker(logger)
+        checker.arxiv = None
+        checker.openalex.search.return_value = [CORRUPT_LORA_WORK]
+
+        result = checker.check_entry(LORA_ENTRY)
+
+        assert result.status is FactCheckStatus.UNCONFIRMED
+        assert result.distrusted_records
+
+    def test_without_the_guard_the_same_input_verdicts_title_mismatch(self, logger):
+        """Pins the defect this guard exists for."""
+        checker = _checker(logger, config=FactCheckerConfig(distrust_corrupt_index_records=False))
+        checker.arxiv = None
+        checker.openalex.search.return_value = [CORRUPT_LORA_WORK]
+
+        result = checker.check_entry(LORA_ENTRY)
+
+        assert result.status is FactCheckStatus.TITLE_MISMATCH
+        assert result.distrusted_records == []
+
+
+# ===========================================================================
+# Output surface
+# ===========================================================================
+
+
+class TestOutputSurface:
+    """A caller must be able to see that a record was distrusted, and why."""
+
+    def test_json_and_jsonl_carry_distrusted_records(self, logger):
+        checker = _checker(logger)
+        checker.arxiv = None
+        checker.openalex.search.return_value = [CORRUPT_LORA_WORK]
+        result = checker.check_entry(LORA_ENTRY)
+
+        processor = FactCheckProcessor.__new__(FactCheckProcessor)
+        report = FactCheckProcessor.generate_json_report(processor, [result])
+        assert report["entries"][0]["distrusted_records"] == result.distrusted_records
+
+        line = json.loads(FactCheckProcessor.generate_jsonl(processor, [result])[0])
+        assert line["distrusted_records"] == result.distrusted_records
+
+    def test_clean_result_reports_an_empty_list(self, logger):
+        checker = _checker(logger)
+        checker._arxiv_record_cache[TRUE_LORA_ARXIV.arxiv_id] = TRUE_LORA_ARXIV
+        result = checker.check_entry(LORA_ENTRY)
+        assert result.distrusted_records == []
+
+
+# ===========================================================================
+# arXiv DataCite DOI case
+# ===========================================================================
+
+
+class TestArxivDoiCase:
+    """arXiv registers its DOIs lowercase; entries carry the ``arXiv`` casing."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "10.48550/arXiv.2503.19786",
+            "10.48550/ARXIV.2503.19786",
+            "https://doi.org/10.48550/arXiv.2503.19786",
+            "10.48550/arXiv.2503.19786v2",
+        ],
+    )
+    def test_resolution_form_is_lowercase_and_unversioned(self, raw):
+        assert normalize_doi_for_resolution(raw) == "10.48550/arxiv.2503.19786"
+
+    def test_validate_doi_probes_the_normalized_form(self, logger, monkeypatch):
+        """``_validate_doi`` must hand doi.org the lowercase form, never the raw
+        capital-X string that reads as an invented DOI."""
+        import bibtex_updater.fact_checker as fc_mod
+
+        checker = _checker(logger)
+        probed: list[str] = []
+
+        def _fake_resolves(_client, doi):
+            probed.append(doi)
+            return True
+
+        monkeypatch.setattr(fc_mod, "_doi_resolves", _fake_resolves)
+        entry = {"ID": "gemma3", "ENTRYTYPE": "misc", "doi": "10.48550/arXiv.2503.19786"}
+
+        assert checker._validate_doi(entry) is None
+        assert probed == ["10.48550/arxiv.2503.19786"]


### PR DESCRIPTION
Moved off `main` onto its own branch so CI runs on it before it ships. The commit was made directly on local `main` by an agent and had never been reviewed or tested by CI; `main` has been reset to `origin/main` and this PR carries the change.

## What it fixes

OpenAlex serves records where the DOI and author list are correct but the **title belongs to a different paper**. Three were reproduced at source during a 5,043-reference screening run: ToolLLM (`2307.16789`), Constitutional AI (`2212.08073`), and LoRA (`2106.09685`) — the last with a third variant where `10.48550/arxiv.2106.09685` serves "LoRA Fine-Tuning of a 3B Code LLM for Algorithmic Efficiency" under LoRA's real author list.

Why the checker convicts on these: title similarity for the three pairs is 0.35–0.39, the blended score lands at 0.54–0.57, and the abstention bar is 0.50 — so the record scores as a match. The existing `wrong_paper_signature` guard cannot fire, because it requires the authors NOT to match, and here they match perfectly. The corroborating author list is exactly what defeats the only guard present.

Measured impact on that corpus: 3 of 855 records, 0.4%, but 16% of the entries that reached an accusation — and on `hybrid_fabrication` specifically it was three artefacts against one real finding.

## Review notes

I did not write this change and have not reviewed the diff line by line; it comes from an agent dispatched by a peer session. CI on this PR is the first automated check it has had. Please read it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqPLG1FhkJjic9MvmM716h