### PR TITLE
No test can reach the network, and none reads the developer's credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
+markers = [
+    "network: allow a test to access the live network",
+]
 
 [tool.coverage.run]
 source = ["src/bibtex_updater"]

--- a/src/bibtex_updater/calibration.py
+++ b/src/bibtex_updater/calibration.py
@@ -64,19 +64,29 @@ _PROB_SOFT = 0.78  # CLEARLY-PROBLEM, single fuzzy-compared field disagrees
 _PROB_WEAK = 0.45  # CLEARLY-PROBLEM, real but weak evidence (see doi_not_found)
 _CORRECT_WEAK = 0.45  # CLEARLY-CORRECT, real but weak evidence (see url_accessible)
 _ABSTAIN = 0.45  # DON'T-KNOW, near-neutral, strictly below both above
-STATUS_BASE_CONFIDENCE = {
+_SKIPPED = 0.0
+_CONFIDENCE_ANCHOR_VALUES = {
+    "_CONF_CORRECT": _CONF_CORRECT,
+    "_PROB_STRONG": _PROB_STRONG,
+    "_PROB_SOFT": _PROB_SOFT,
+    "_PROB_WEAK": _PROB_WEAK,
+    "_CORRECT_WEAK": _CORRECT_WEAK,
+    "_ABSTAIN": _ABSTAIN,
+    "_SKIPPED": _SKIPPED,
+}
+_STATUS_CONFIDENCE_ANCHORS = {
     # --- CLEARLY-CORRECT: a positive record confirms the entry ---
-    "verified": _CONF_CORRECT,
-    "published_version_exists": _CONF_CORRECT,
-    "url_verified": _CONF_CORRECT,
-    "book_verified": _CONF_CORRECT,
-    "working_paper_verified": _CONF_CORRECT,
+    "verified": "_CONF_CORRECT",
+    "published_version_exists": "_CONF_CORRECT",
+    "url_verified": "_CONF_CORRECT",
+    "book_verified": "_CONF_CORRECT",
+    "working_paper_verified": "_CONF_CORRECT",
     # --- CLEARLY-PROBLEM (strong): self-contained positive evidence ---
-    "hallucinated": _PROB_STRONG,  # no real paper / chimeric title
-    "future_date": _PROB_STRONG,  # arithmetic, not a fuzzy match
-    "invalid_year": _PROB_STRONG,  # arithmetic, not a fuzzy match
-    "doi_mismatch": _PROB_STRONG,  # cited DOI resolves to a different paper
-    "arxiv_id_mismatch": _PROB_STRONG,  # cited arXiv ID resolves elsewhere
+    "hallucinated": "_PROB_STRONG",  # no real paper / chimeric title
+    "future_date": "_PROB_STRONG",  # arithmetic, not a fuzzy match
+    "invalid_year": "_PROB_STRONG",  # arithmetic, not a fuzzy match
+    "doi_mismatch": "_PROB_STRONG",  # cited DOI resolves to a different paper
+    "arxiv_id_mismatch": "_PROB_STRONG",  # cited arXiv ID resolves elsewhere
     # --- CLEARLY-PROBLEM (soft): one disagreeing field, rest match ---
     # A preprint cited as published: the claimed venue is unconfirmed and the
     # record is preprint-only. It sat at _CONF_CORRECT while carrying PROBLEM
@@ -85,37 +95,40 @@ STATUS_BASE_CONFIDENCE = {
     # nearly as extreme as a DOI resolving to a different paper (0.035). A
     # preprint-as-published is weaker evidence than either, so the ordering was
     # inverted. Soft-problem is where the other unconfirmed-venue verdicts live.
-    "preprint_only": _PROB_SOFT,
-    "title_mismatch": _PROB_SOFT,
-    "author_mismatch": _PROB_SOFT,
-    "given_name_substitution": _PROB_SOFT,  # surnames match, a given name is a different person
-    "author_truncated": _PROB_SOFT,  # silent author-list truncation (one disagreeing field)
-    "year_mismatch": _PROB_SOFT,
-    "venue_mismatch": _PROB_SOFT,
+    "preprint_only": "_PROB_SOFT",
+    "title_mismatch": "_PROB_SOFT",
+    "author_mismatch": "_PROB_SOFT",
+    "given_name_substitution": "_PROB_SOFT",  # surnames match, a given name is a different person
+    "author_truncated": "_PROB_SOFT",  # silent author-list truncation (one disagreeing field)
+    "year_mismatch": "_PROB_SOFT",
+    "venue_mismatch": "_PROB_SOFT",
     # Claimed venue unknown to the DBLP/OpenAlex venue registries while the
     # paper itself is real: positive (registry-backed) evidence, but the
     # registries are fuzzy-matched name lookups -> soft tier, not strong.
-    "nonexistent_venue": _PROB_SOFT,
-    "partial_match": _PROB_SOFT,
-    "url_content_mismatch": _PROB_SOFT,
+    "nonexistent_venue": "_PROB_SOFT",
+    "partial_match": "_PROB_SOFT",
+    "url_content_mismatch": "_PROB_SOFT",
     # --- DON'T-KNOW / abstention: could not adjudicate, near-neutral ---
-    "not_found": _ABSTAIN,
-    "unconfirmed": _ABSTAIN,
-    "api_error": _ABSTAIN,
+    "not_found": "_ABSTAIN",
+    "unconfirmed": "_ABSTAIN",
+    "api_error": "_ABSTAIN",
     # Weak but real evidence, so PROBLEM polarity is right -- but it was drawing
     # _ABSTAIN, documented as "DON'T-KNOW, near-neutral". Same number, now from
     # a constant that means what the polarity says. p_valid is unchanged at 0.275.
-    "doi_not_found": _PROB_WEAK,
-    "url_not_found": _ABSTAIN,
-    "book_not_found": _ABSTAIN,
-    "working_paper_not_found": _ABSTAIN,
+    "doi_not_found": "_PROB_WEAK",
+    "url_not_found": "_ABSTAIN",
+    "book_not_found": "_ABSTAIN",
+    "working_paper_not_found": "_ABSTAIN",
     # HTTP 200 with no content check: the page is reachable, which weakly
     # supports the entry but confirms nothing about the paper. VALID polarity is
     # right; drawing _ABSTAIN was borrowing the don't-know anchor to assert
     # something. Same number, now from a constant that says so.
-    "url_accessible": _CORRECT_WEAK,  # 200 only, no content check -> weak signal
+    "url_accessible": "_CORRECT_WEAK",  # 200 only, no content check -> weak signal
     # --- not verifiable ---
-    "skipped": 0.0,
+    "skipped": "_SKIPPED",
+}
+STATUS_BASE_CONFIDENCE = {
+    status: _CONFIDENCE_ANCHOR_VALUES[anchor] for status, anchor in _STATUS_CONFIDENCE_ANCHORS.items()
 }
 
 # Abstention ("don't-know") statuses. These must stay near-neutral: their

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import socket
 from typing import Any
 
 import pytest
@@ -21,7 +22,62 @@ from bibtex_updater.utils import HttpClient, PublishedRecord
 @pytest.fixture(autouse=True)
 def _isolated_openreview_token_cache(tmp_path, monkeypatch):
     """No test may read or write the developer's real OpenReview token cache."""
-    monkeypatch.setenv("BIBTEX_CHECK_OPENREVIEW_TOKEN_CACHE", str(tmp_path / "openreview-tokens.json"))
+    path = tmp_path / "openreview-tokens.json"
+    monkeypatch.setenv("BIBTEX_CHECK_OPENREVIEW_TOKEN_CACHE", str(path))
+    # OpenReviewAuth.from_env(env={...}) treats that mapping as authoritative
+    # and therefore does not read the process environment override above.
+    monkeypatch.setattr("bibtex_updater.utils._default_openreview_token_cache_path", lambda: path)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_service_environment(monkeypatch):
+    """Keep developer credentials and local rate overrides out of tests."""
+    monkeypatch.delenv("OPENREVIEW_USERNAME", raising=False)
+    monkeypatch.delenv("OPENREVIEW_PASSWORD", raising=False)
+    monkeypatch.delenv("BIBTEX_ARXIV_RATE", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _no_live_network(request, monkeypatch):
+    """Block and report every socket connection unless a test opts in."""
+    if request.node.get_closest_marker("network") is not None:
+        yield
+        return
+
+    attempts: list[object] = []
+    real_connect = socket.socket.connect
+    real_connect_ex = socket.socket.connect_ex
+    real_create_connection = socket.create_connection
+
+    def is_loopback(address) -> bool:
+        host = address[0] if isinstance(address, tuple) else address
+        return host in {"127.0.0.1", "::1", "localhost"}
+
+    def blocked_connect(sock, address):
+        if sock.family == socket.AF_UNIX or is_loopback(address):
+            return real_connect(sock, address)
+        attempts.append(address)
+        raise OSError(f"Live network access is disabled during tests: {address!r}")
+
+    def blocked_connect_ex(sock, address):
+        if sock.family == socket.AF_UNIX or is_loopback(address):
+            return real_connect_ex(sock, address)
+        attempts.append(address)
+        raise OSError(f"Live network access is disabled during tests: {address!r}")
+
+    def blocked_create_connection(address, *args, **kwargs):
+        if is_loopback(address):
+            return real_create_connection(address, *args, **kwargs)
+        attempts.append(address)
+        raise OSError(f"Live network access is disabled during tests: {address!r}")
+
+    monkeypatch.setattr(socket.socket, "connect", blocked_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", blocked_connect_ex)
+    monkeypatch.setattr(socket, "create_connection", blocked_create_connection)
+
+    yield
+
+    assert not attempts, f"Test attempted live network connections: {attempts!r}"
 
 
 @pytest.fixture

--- a/tests/test_arxiv_version_retitling.py
+++ b/tests/test_arxiv_version_retitling.py
@@ -18,10 +18,12 @@ cited title no version ever carried.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
-from bibtex_updater.fact_checker import ArxivClient, FactChecker, FactCheckerConfig
-from bibtex_updater.utils import SourceUnavailableError
+from bibtex_updater.fact_checker import ArxivClient, FactChecker, FactCheckerConfig, FactCheckStatus
+from bibtex_updater.utils import PublishedRecord, SourceUnavailableError
 
 
 def abs_page(title: str, versions: int, arxiv_id: str = "2308.10248") -> str:
@@ -71,10 +73,12 @@ class FakeHttp:
         return R()
 
 
-def make_checker(http, **cfg) -> FactChecker:
+def make_checker(http, *, arxiv_records=None, **cfg) -> FactChecker:
     checker = FactChecker.__new__(FactChecker)
     checker.config = FactCheckerConfig(**cfg)
     checker.arxiv = ArxivClient(http)
+    checker._arxiv_cache_lock = threading.Lock()
+    checker._arxiv_record_cache = dict(arxiv_records or {})
     import logging
 
     checker.logger = logging.getLogger("test")
@@ -97,6 +101,32 @@ class TestVersionTitleFetch:
 
 
 class TestRetitlingIsNotAMismatch:
+    @pytest.mark.parametrize(
+        "arxiv_id,cited_title,current_title,expected",
+        [
+            ("2308.10248", ACTIVATION_ADDITION_V1, ACTIVATION_ADDITION_NOW, None),
+            ("2304.14767", DISSECTING_CITED, DISSECTING_ALL, FactCheckStatus.ARXIV_ID_MISMATCH),
+        ],
+    )
+    def test_consistency_check_uses_version_history(self, arxiv_id, cited_title, current_title, expected):
+        http = FakeHttp({1: ACTIVATION_ADDITION_V1 if arxiv_id == "2308.10248" else DISSECTING_ALL}, versions=3)
+        checker = make_checker(
+            http,
+            arxiv_records={arxiv_id: PublishedRecord(doi="", title=current_title)},
+            arxiv_consistency_min_title=0.8,
+        )
+        entry = {
+            "ID": "cited",
+            "ENTRYTYPE": "article",
+            "title": cited_title,
+            "eprint": arxiv_id,
+            "archiveprefix": "arXiv",
+        }
+
+        result = checker._check_arxiv_id_consistency(entry)
+
+        assert (result.status if result is not None else None) is expected
+
     def test_cited_title_matching_v1_clears_the_finding(self):
         http = FakeHttp({1: ACTIVATION_ADDITION_V1}, versions=5)
         checker = make_checker(http)

--- a/tests/test_calibration_polarity_invariant.py
+++ b/tests/test_calibration_polarity_invariant.py
@@ -49,9 +49,8 @@ assert _ABSTAIN_STATUSES
 @pytest.mark.parametrize("status", _PROBLEM_STATUSES)
 def test_problem_statuses_yield_p_valid_below_one_half(status):
     conf = STATUS_BASE_CONFIDENCE[status]
-    assert (
-        p_valid_from_result(status, conf) < 0.5
-    ), f"{status} is PROBLEM-polarity but P(valid) is {p_valid_from_result(status, conf)}"
+    p_valid = p_valid_from_result(status, conf)
+    assert p_valid < 0.5, f"{status} is PROBLEM-polarity but P(valid) is {p_valid}"
 
 
 @pytest.mark.parametrize("status", _VALID_STATUSES)
@@ -97,12 +96,6 @@ def test_abstentions_stay_neutral():
         assert p_valid_from_result(status, STATUS_BASE_CONFIDENCE[status]) == P_VALID_NEUTRAL
 
 
-#: Statuses that deliberately assert at the weak-evidence value. Each draws
-#: _PROB_WEAK or _CORRECT_WEAK, which share the abstention anchor's NUMBER but
-#: not its meaning: the evidence is real and thin, rather than absent.
-_DELIBERATELY_WEAK = {"doi_not_found", "url_accessible"}
-
-
 def test_asserting_statuses_document_why_they_sit_at_the_weak_value():
     """A verdict asserting something must not silently borrow the don't-know anchor.
 
@@ -117,10 +110,15 @@ def test_asserting_statuses_document_why_they_sit_at_the_weak_value():
     offenders = sorted(s for s in asserting if _STATUS_CONFIDENCE_ANCHORS.get(s) == "_ABSTAIN")
     assert not offenders, (
         f"{offenders} assert a polarity at the abstention anchor "
-        "without being declared weak evidence. Either give them a real tier or add "
-        "them to _DELIBERATELY_WEAK with a reason."
+        "without a weak-evidence anchor. Give them a real tier or a named weak-evidence anchor."
     )
-    assert {_STATUS_CONFIDENCE_ANCHORS[s] for s in _DELIBERATELY_WEAK} == {"_PROB_WEAK", "_CORRECT_WEAK"}
+    assert {
+        "doi_not_found": _STATUS_CONFIDENCE_ANCHORS["doi_not_found"],
+        "url_accessible": _STATUS_CONFIDENCE_ANCHORS["url_accessible"],
+    } == {
+        "doi_not_found": "_PROB_WEAK",
+        "url_accessible": "_CORRECT_WEAK",
+    }
 
 
 def test_preprint_only_is_not_the_systems_most_confident_invalid():

--- a/tests/test_calibration_polarity_invariant.py
+++ b/tests/test_calibration_polarity_invariant.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import pytest
 
 from bibtex_updater.calibration import (
+    _STATUS_CONFIDENCE_ANCHORS,
     P_VALID_ABSTAIN_STATUSES,
     P_VALID_NEUTRAL,
     P_VALID_PROBLEM_STATUSES,
@@ -32,16 +33,20 @@ from bibtex_updater.calibration import (
     p_valid_from_result,
 )
 
-#: The anchor reserved for "we could not decide". A PROBLEM or VALID status
-#: drawing this is asserting something with don't-know confidence.
-_ABSTAIN_ANCHOR = 0.45
-
 
 def _statuses(bucket) -> list[str]:
     return sorted(s for s in bucket if s in STATUS_BASE_CONFIDENCE)
 
 
-@pytest.mark.parametrize("status", _statuses(P_VALID_PROBLEM_STATUSES))
+_PROBLEM_STATUSES = _statuses(P_VALID_PROBLEM_STATUSES)
+_VALID_STATUSES = _statuses(P_VALID_VALID_STATUSES)
+_ABSTAIN_STATUSES = _statuses(P_VALID_ABSTAIN_STATUSES)
+assert _PROBLEM_STATUSES
+assert _VALID_STATUSES
+assert _ABSTAIN_STATUSES
+
+
+@pytest.mark.parametrize("status", _PROBLEM_STATUSES)
 def test_problem_statuses_yield_p_valid_below_one_half(status):
     conf = STATUS_BASE_CONFIDENCE[status]
     assert (
@@ -49,7 +54,7 @@ def test_problem_statuses_yield_p_valid_below_one_half(status):
     ), f"{status} is PROBLEM-polarity but P(valid) is {p_valid_from_result(status, conf)}"
 
 
-@pytest.mark.parametrize("status", _statuses(P_VALID_VALID_STATUSES))
+@pytest.mark.parametrize("status", _VALID_STATUSES)
 def test_valid_statuses_yield_p_valid_above_one_half(status):
     conf = STATUS_BASE_CONFIDENCE[status]
     assert p_valid_from_result(status, conf) > 0.5
@@ -88,7 +93,7 @@ def test_a_problem_status_is_never_more_extreme_than_the_strongest_evidence():
 
 
 def test_abstentions_stay_neutral():
-    for status in _statuses(P_VALID_ABSTAIN_STATUSES):
+    for status in _ABSTAIN_STATUSES:
         assert p_valid_from_result(status, STATUS_BASE_CONFIDENCE[status]) == P_VALID_NEUTRAL
 
 
@@ -108,15 +113,14 @@ def test_asserting_statuses_document_why_they_sit_at_the_weak_value():
     _CORRECT_WEAK, so the constant states the intent and a new status cannot
     reach that value by accident.
     """
-    asserting = set(_statuses(P_VALID_PROBLEM_STATUSES)) | set(_statuses(P_VALID_VALID_STATUSES))
-    offenders = sorted(
-        s for s in asserting if STATUS_BASE_CONFIDENCE[s] == _ABSTAIN_ANCHOR and s not in _DELIBERATELY_WEAK
-    )
+    asserting = set(_PROBLEM_STATUSES) | set(_VALID_STATUSES)
+    offenders = sorted(s for s in asserting if _STATUS_CONFIDENCE_ANCHORS.get(s) == "_ABSTAIN")
     assert not offenders, (
-        f"{offenders} assert a polarity at the abstention anchor ({_ABSTAIN_ANCHOR}) "
+        f"{offenders} assert a polarity at the abstention anchor "
         "without being declared weak evidence. Either give them a real tier or add "
         "them to _DELIBERATELY_WEAK with a reason."
     )
+    assert {_STATUS_CONFIDENCE_ANCHORS[s] for s in _DELIBERATELY_WEAK} == {"_PROB_WEAK", "_CORRECT_WEAK"}
 
 
 def test_preprint_only_is_not_the_systems_most_confident_invalid():

--- a/tests/test_openreview_auth.py
+++ b/tests/test_openreview_auth.py
@@ -27,7 +27,6 @@ import base64
 import json
 import logging
 import os
-import socket
 import stat
 import subprocess
 import sys
@@ -112,31 +111,32 @@ def _urls(http_mock) -> list[str]:
 
 
 class TestNetworkGuard:
-    def test_allows_loopback_connections(self):
-        """The suite guard must leave hermetic local servers usable."""
-        assert socket.socket.connect.__name__ == "blocked_connect"
-        address = ("127.0.0.1", 1)
-        for connect in (
-            lambda: socket.socket().connect(address),
-            lambda: socket.create_connection(address, timeout=0.01),
-        ):
-            with pytest.raises(OSError) as exc_info:
-                connect()
-            assert "Live network access is disabled" not in str(exc_info.value)
+    def _write_harness(self, tmp_path) -> Path:
+        """Install harmless originals before the guard captures them.
 
-        client = socket.socket()
-        try:
-            assert isinstance(client.connect_ex(address), int)
-        finally:
-            client.close()
-
-    def test_fails_when_a_non_loopback_attempt_is_swallowed(self, tmp_path):
-        """Blocking alone is insufficient because OpenReview login catches OSError."""
+        This makes a missing wrapper observable without allowing a socket call
+        to leave the subprocess.
+        """
         source_conftest = Path(__file__).with_name("conftest.py")
         (tmp_path / "conftest.py").write_text(
             "\n".join(
                 [
                     "import importlib.util",
+                    "import socket",
+                    "",
+                    "def _safe_connect(sock, address):",
+                    "    return 'connect'",
+                    "",
+                    "def _safe_connect_ex(sock, address):",
+                    "    return 0",
+                    "",
+                    "def _safe_create_connection(address, *args, **kwargs):",
+                    "    return 'create_connection'",
+                    "",
+                    "socket.socket.connect = _safe_connect",
+                    "socket.socket.connect_ex = _safe_connect_ex",
+                    "socket.create_connection = _safe_create_connection",
+                    "",
                     f"spec = importlib.util.spec_from_file_location('suite_guard', {str(source_conftest)!r})",
                     "suite_guard = importlib.util.module_from_spec(spec)",
                     "spec.loader.exec_module(suite_guard)",
@@ -144,39 +144,96 @@ class TestNetworkGuard:
                 ]
             )
         )
-        test_path = tmp_path / "test_swallowed_connection.py"
+        test_path = tmp_path / "test_socket_guard.py"
         test_path.write_text(
             "\n".join(
                 [
                     "import socket",
+                    "import pytest",
                     "",
-                    "def test_swallowed_connection_attempt():",
-                    "    attempts = (",
-                    "        lambda: socket.socket().connect(('example.com', 443)),",
-                    "        lambda: socket.socket().connect_ex(('example.com', 443)),",
-                    "        lambda: socket.create_connection(('example.com', 443)),",
-                    "    )",
-                    "    for attempt in attempts:",
+                    "def test_connect_is_recorded_when_swallowed():",
+                    "    try:",
+                    "        socket.socket().connect(('outside.invalid', 443))",
+                    "    except OSError:",
+                    "        pass",
+                    "",
+                    "def test_connect_ex_is_recorded_when_swallowed():",
+                    "    try:",
+                    "        socket.socket().connect_ex(('outside.invalid', 443))",
+                    "    except OSError:",
+                    "        pass",
+                    "",
+                    "def test_create_connection_is_recorded_when_swallowed():",
+                    "    try:",
+                    "        socket.create_connection(('outside.invalid', 443))",
+                    "    except OSError:",
+                    "        pass",
+                    "",
+                    "@pytest.mark.network",
+                    "def test_network_marker_leaves_all_wrappers_unpatched():",
+                    "    assert socket.socket().connect(('outside.invalid', 443)) == 'connect'",
+                    "    assert socket.socket().connect_ex(('outside.invalid', 443)) == 0",
+                    "    assert socket.create_connection(('outside.invalid', 443)) == 'create_connection'",
+                    "",
+                    "def test_loopback_sockets_remain_available():",
+                    "    for host in ('127.0.0.1', '::1', 'localhost'):",
+                    "        address = (host, 443)",
+                    "        client = socket.socket()",
                     "        try:",
-                    "            attempt()",
-                    "        except OSError:",
-                    "            pass",
+                    "            assert client.connect(address) == 'connect'",
+                    "            assert client.connect_ex(address) == 0",
+                    "        finally:",
+                    "            client.close()",
+                    "        assert socket.create_connection(address) == 'create_connection'",
+                    "",
+                    "def test_unix_sockets_remain_available():",
+                    "    client = socket.socket(socket.AF_UNIX)",
+                    "    try:",
+                    "        assert client.connect('/tmp/bu3-guard.sock') == 'connect'",
+                    "        assert client.connect_ex('/tmp/bu3-guard.sock') == 0",
+                    "    finally:",
+                    "        client.close()",
                 ]
             )
         )
+        return test_path
+
+    def _run_case(self, test_path: Path, case: str) -> subprocess.CompletedProcess[str]:
         root = Path(__file__).parents[1]
         env = os.environ | {"PYTHONPATH": str(root / "src")}
-        completed = subprocess.run(
-            [sys.executable, "-m", "pytest", "-q", str(test_path)],
+        return subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", f"{test_path}::{case}"],
             cwd=root,
             env=env,
             text=True,
             capture_output=True,
             check=False,
+            timeout=10,
         )
 
-        assert completed.returncode == 1
-        assert "Test attempted live network connections" in completed.stdout
+    def test_fails_when_each_non_loopback_attempt_is_swallowed(self, tmp_path):
+        """OpenReview login catches OSError, so teardown must still fail each path."""
+        test_path = self._write_harness(tmp_path)
+        for case in (
+            "test_connect_is_recorded_when_swallowed",
+            "test_connect_ex_is_recorded_when_swallowed",
+            "test_create_connection_is_recorded_when_swallowed",
+        ):
+            completed = self._run_case(test_path, case)
+            assert completed.returncode == 1, completed.stdout + completed.stderr
+            assert "Test attempted live network connections" in completed.stdout
+            assert "('outside.invalid', 443)" in completed.stdout
+
+    def test_network_marker_loopback_and_unix_socket_opt_outs(self, tmp_path):
+        """Intentional network tests and local transports stay usable."""
+        test_path = self._write_harness(tmp_path)
+        for case in (
+            "test_network_marker_leaves_all_wrappers_unpatched",
+            "test_loopback_sockets_remain_available",
+            "test_unix_sockets_remain_available",
+        ):
+            completed = self._run_case(test_path, case)
+            assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
 # ===========================================================================

--- a/tests/test_openreview_auth.py
+++ b/tests/test_openreview_auth.py
@@ -26,7 +26,11 @@ import asyncio
 import base64
 import json
 import logging
+import os
+import socket
 import stat
+import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -105,6 +109,74 @@ def _note(title="Adam: A Method", ident="note1"):
 def _urls(http_mock) -> list[str]:
     """The URLs a mocked ``HttpClient._request`` was asked for, in order."""
     return [call.args[1] if len(call.args) > 1 else call.kwargs["url"] for call in http_mock._request.call_args_list]
+
+
+class TestNetworkGuard:
+    def test_allows_loopback_connections(self):
+        """The suite guard must leave hermetic local servers usable."""
+        assert socket.socket.connect.__name__ == "blocked_connect"
+        address = ("127.0.0.1", 1)
+        for connect in (
+            lambda: socket.socket().connect(address),
+            lambda: socket.create_connection(address, timeout=0.01),
+        ):
+            with pytest.raises(OSError) as exc_info:
+                connect()
+            assert "Live network access is disabled" not in str(exc_info.value)
+
+        client = socket.socket()
+        try:
+            assert isinstance(client.connect_ex(address), int)
+        finally:
+            client.close()
+
+    def test_fails_when_a_non_loopback_attempt_is_swallowed(self, tmp_path):
+        """Blocking alone is insufficient because OpenReview login catches OSError."""
+        source_conftest = Path(__file__).with_name("conftest.py")
+        (tmp_path / "conftest.py").write_text(
+            "\n".join(
+                [
+                    "import importlib.util",
+                    f"spec = importlib.util.spec_from_file_location('suite_guard', {str(source_conftest)!r})",
+                    "suite_guard = importlib.util.module_from_spec(spec)",
+                    "spec.loader.exec_module(suite_guard)",
+                    "_no_live_network = suite_guard._no_live_network",
+                ]
+            )
+        )
+        test_path = tmp_path / "test_swallowed_connection.py"
+        test_path.write_text(
+            "\n".join(
+                [
+                    "import socket",
+                    "",
+                    "def test_swallowed_connection_attempt():",
+                    "    attempts = (",
+                    "        lambda: socket.socket().connect(('example.com', 443)),",
+                    "        lambda: socket.socket().connect_ex(('example.com', 443)),",
+                    "        lambda: socket.create_connection(('example.com', 443)),",
+                    "    )",
+                    "    for attempt in attempts:",
+                    "        try:",
+                    "            attempt()",
+                    "        except OSError:",
+                    "            pass",
+                ]
+            )
+        )
+        root = Path(__file__).parents[1]
+        env = os.environ | {"PYTHONPATH": str(root / "src")}
+        completed = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", str(test_path)],
+            cwd=root,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert completed.returncode == 1
+        assert "Test attempted live network connections" in completed.stdout
 
 
 # ===========================================================================
@@ -618,8 +690,16 @@ class TestTokenReuseAcrossProcesses:
         assert len(fake.calls) == 1
 
     def test_an_expired_cached_token_is_not_served(self, tmp_path):
-        store = OpenReviewTokenStore(tmp_path / "openreview-tokens.json")
-        store.put("a@b.c", OPENREVIEW_API, _jwt(time.time() - 60))
+        path = tmp_path / "openreview-tokens.json"
+        store = OpenReviewTokenStore(path)
+        store.put("a@b.c", OPENREVIEW_API, _jwt(time.time() + 3600))
+        assert store.get("a@b.c", OPENREVIEW_API) is not None
+
+        raw = json.loads(path.read_text())
+        for token in raw["tokens"].values():
+            token["expires"] = time.time() - 1
+        path.write_text(json.dumps(raw))
+
         assert store.get("a@b.c", OPENREVIEW_API) is None
 
     def test_a_refusal_drops_the_shared_copy(self, tmp_path):
@@ -662,6 +742,16 @@ class TestTokenReuseAcrossProcesses:
             auth.token_for_url(NOTES_V1)
         assert path.exists()
 
+    def test_explicit_env_mapping_uses_the_isolated_default_cache(self, tmp_path):
+        auth = OpenReviewAuth.from_env(
+            env={
+                "OPENREVIEW_USERNAME": "a@b.c",
+                "OPENREVIEW_PASSWORD": PASSWORD,
+            }
+        )
+        assert auth is not None and auth._store is not None
+        assert auth._store.path == tmp_path / "openreview-tokens.json"
+
     def test_the_default_path_is_the_user_cache_never_the_repo(self):
         path = _default_openreview_token_cache_path()
         assert path.name == "openreview-tokens.json"
@@ -677,6 +767,7 @@ class TestTokenReuseAcrossProcesses:
 
     def test_expiry_comes_from_the_token_itself(self):
         assert _jwt_expiry(_jwt(1800000000)) == 1800000000.0
+        assert _jwt_expiry(_jwt(1800000000 * 1000)) == 1800000000.0
         assert _jwt_expiry("not-a-jwt") is None
 
 

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -38,9 +38,11 @@ from bibtex_updater.fact_checker import (
     FactCheckProcessor,
     FactCheckResult,
     FactCheckStatus,
+    FieldComparison,
     _compute_coverage_incomplete,
     build_verification_result,
 )
+from bibtex_updater.matching import MatchOutcome
 
 LOGGER = logging.getLogger("test_output_contract")
 
@@ -363,6 +365,49 @@ def _contract_results() -> tuple[list[dict[str, str]], list[FactCheckResult]]:
 
 
 class TestSerialization:
+    def test_jsonl_reports_only_real_contradictions_as_mismatches(self, tmp_path):
+        comparisons = {
+            outcome.value: FieldComparison(
+                field_name=outcome.value,
+                entry_value="claimed",
+                api_value="observed",
+                similarity_score=0.0,
+                matches=False,
+                outcome=outcome,
+            )
+            for outcome in (MatchOutcome.MISMATCH, MatchOutcome.NON_COMPARABLE, MatchOutcome.PARTIAL)
+        }
+        result = FactCheckResult(
+            entry_key="mixed",
+            entry_type="article",
+            status=FactCheckStatus.PARTIAL_MATCH,
+            overall_confidence=0.78,
+            field_comparisons=comparisons,
+            best_match=None,
+            api_sources_queried=["crossref"],
+            api_sources_with_hits=["crossref"],
+            errors=[],
+        )
+        checker = _FakeChecker({result.entry_key: result})
+        processor = FactCheckProcessor(checker, LOGGER)
+        batch_record = json.loads(processor.generate_jsonl([result])[0])
+        jsonl_path = tmp_path / "out.jsonl"
+
+        processor.process_entries(
+            [{"ID": result.entry_key, "ENTRYTYPE": "article", "title": "Mixed outcomes"}],
+            jsonl_path=str(jsonl_path),
+            max_workers=1,
+        )
+        streamed_record = json.loads(jsonl_path.read_text())
+
+        assert batch_record["mismatched_fields"] == [MatchOutcome.MISMATCH.value]
+        assert batch_record["unconfirmed_fields"] == [
+            MatchOutcome.NON_COMPARABLE.value,
+            MatchOutcome.PARTIAL.value,
+        ]
+        assert streamed_record["mismatched_fields"] == batch_record["mismatched_fields"]
+        assert streamed_record["unconfirmed_fields"] == batch_record["unconfirmed_fields"]
+
     def test_streamed_jsonl_carries_the_contract_keys(self, tmp_path):
         entries, results = _contract_results()
         checker = _FakeChecker({r.entry_key: r for r in results})

--- a/tests/test_rate_limits_and_mailto.py
+++ b/tests/test_rate_limits_and_mailto.py
@@ -28,6 +28,7 @@ import httpx
 import pytest
 
 import bibtex_updater.fact_checker as fact_checker_module
+import bibtex_updater.utils as utils_module
 from bibtex_updater.fact_checker import (
     DEFAULT_MAILTO_PLACEHOLDER,
     _cli_service_rate_limits,
@@ -43,6 +44,27 @@ from bibtex_updater.utils import (
     RateLimiterRegistry,
     SqliteCache,
 )
+
+
+@pytest.mark.parametrize(
+    "endpoint_name",
+    [
+        "CROSSREF_API",
+        "ARXIV_API",
+        "DBLP_API_SEARCH",
+        "DBLP_API_VENUE_SEARCH",
+        "S2_API",
+        "ACL_ANTHOLOGY_URL",
+        "OPENALEX_API",
+        "EUROPEPMC_API",
+        "OPENREVIEW_API",
+        "OPENREVIEW_API_V2",
+    ],
+)
+def test_api_endpoints_use_https(endpoint_name):
+    """A redirect must not expose a lookup to a plaintext first hop."""
+    assert getattr(utils_module, endpoint_name).startswith("https://")
+
 
 # ===========================================================================
 # Per-service CLI rate limits


### PR DESCRIPTION
Test-hygiene package from the 2026-09-06 review (findings B4-1 through B4-10, each confirmed by a verifier). Background: on 2026-09-04 `main` went red because `test_openalex_client_search_returns_empty_on_http_error` reached the live OpenAlex API and got a 429 (fixed for that one test in 7221c48). This PR removes the class.

## What changes

- **No socket leaves the machine during tests.** `tests/conftest.py` gains an autouse fixture that blocks every non-loopback connection (`socket.socket.connect`, `connect_ex`, `socket.create_connection`), records the attempt, and fails the test at teardown if it swallowed the error. `@pytest.mark.network` (registered in `pyproject.toml`) opts a test out; no test currently needs it.
- **The developer's environment stays out of assertions.** `OPENREVIEW_USERNAME`, `OPENREVIEW_PASSWORD` and `BIBTEX_ARXIV_RATE` are removed for every test; with them present, the CLI outage tests and the rate-limit tests passed for the wrong reason. The token-cache redirect now covers `OpenReviewAuth.from_env(env=...)` as well as the environment route, so no test can touch `~/.cache/bibtex-updater/openreview-tokens.json`.
- **Tests that could not fail now can.** `test_arxiv_version_retitling` initialises the arXiv cache so its end-to-end cases actually exercise `_check_arxiv_id_consistency`; `test_output_contract` checks batch/streaming JSONL parity on `MISMATCH`, `NON_COMPARABLE` and `PARTIAL`; the JWT millisecond-expiry branch and expiry of a persisted token are exercised; all ten endpoint constants are pinned to `https`.
- **One production-side change, values unchanged:** `calibration.py` writes the status table as status → anchor *name* and derives the numeric table from it, so the polarity-invariant test asserts which anchor a status draws instead of a float that two anchors share. `STATUS_BASE_CONFIDENCE` is byte-for-byte the same mapping.

## Verification

Full suite 2069 passed / 1 skipped with the network blocked; `pre-commit run` (black, ruff, whitespace) clean. mypy reports the same 61 pre-existing errors as `main`, none in changed production code. Each new regression was checked against its pre-fix mutation (details in the commit message). Diff produced by codex from the review's specification and read before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
