### PR TITLE
Every report shape records which sources were queried, not only which hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`api_sources_queried` on every JSONL line, next to the `api_sources` key that lists only the sources with hits.** A consumer counting API calls per entry had nothing but `api_sources` to count, so a downstream cost metric reported hits as calls: a source queried to no effect was invisible. The new key names every source the cascade queried for the entry, in query order with repeats collapsed, and is present on every JSONL line and every JSON report entry (empty when nothing was queried); `api_sources` is unchanged and remains the subset that returned a candidate.
+
 - **`distrusted_records` on `FactCheckResult`, in the JSON report and on every JSONL line.** One readable line per record the cascade declined to score, naming the source, the identifier, the title it served and the similarity. A caller can now see that a verdict was reached without a record the run had in hand, and which index misbehaved. Additive: no existing key changes.
 
 ### Changed

--- a/docs/REFERENCE_FACT_CHECKER.md
+++ b/docs/REFERENCE_FACT_CHECKER.md
@@ -207,8 +207,8 @@ Full structured report: a `summary` block (totals, status counts, verified/absta
 One JSON object per line, streamed as entries complete — useful for large bibliographies and incremental processing:
 
 ```jsonl
-{"key": "smith2020", "category": "academic", "status": "verified", "abstained": false, "coverage_incomplete": false, "confidence": 0.89, "p_valid": 0.945, "confidence_score": 96.0, "mismatched_fields": [], "unconfirmed_fields": [], "api_sources": ["crossref", "dblp"], "errors": []}
-{"key": "fake2099", "category": "academic", "status": "hallucinated", "abstained": false, "coverage_incomplete": false, "confidence": 0.93, "p_valid": 0.035, "confidence_score": 12.0, "mismatched_fields": ["title", "author"], "unconfirmed_fields": [], "api_sources": [], "errors": []}
+{"key": "smith2020", "category": "academic", "status": "verified", "abstained": false, "coverage_incomplete": false, "confidence": 0.89, "p_valid": 0.945, "confidence_score": 96.0, "mismatched_fields": [], "unconfirmed_fields": [], "api_sources": ["crossref", "dblp"], "api_sources_queried": ["crossref", "dblp"], "errors": []}
+{"key": "fake2099", "category": "academic", "status": "hallucinated", "abstained": false, "coverage_incomplete": false, "confidence": 0.93, "p_valid": 0.035, "confidence_score": 12.0, "mismatched_fields": ["title", "author"], "unconfirmed_fields": [], "api_sources": [], "api_sources_queried": ["crossref", "semanticscholar", "openalex", "dblp"], "errors": []}
 ```
 
 Per-line fields:
@@ -226,6 +226,7 @@ Per-line fields:
 | `unconfirmed_fields` | fields neither confirmed nor contradicted (`NON_COMPARABLE`/`PARTIAL`): an arXiv record cannot confirm a claimed ICLR venue, and a `journal = {arXiv preprint arXiv:NNNN.NNNNN}` citation claims no published venue to confirm. These are abstentions the checker made deliberately, never findings against the entry |
 | `distrusted_records` | records a source returned that the cascade declined to score, one readable line each. A source can serve a work under the correct identifier and the correct author list but a different paper's title; scored as a candidate that record produces a `title_mismatch` against a correctly cited entry. Non-empty means the verdict was reached **without** a record the run had in hand, and names which index misbehaved — a statement about the source, never about the entry |
 | `api_sources`, `errors` | sources with hits, and per-source error strings |
+| `api_sources_queried` | sources the cascade queried for this entry, whether or not they returned a candidate; `api_sources` is the subset that did |
 
 ## Exit Codes
 

--- a/src/bibtex_updater/fact_checker.py
+++ b/src/bibtex_updater/fact_checker.py
@@ -361,6 +361,17 @@ def _is_abstained_status(status: FactCheckStatus) -> bool:
     return status.value in ABSTAINED_STATUS_VALUES
 
 
+def _queried_sources(api_sources_queried: list[str]) -> list[str]:
+    """Sources queried for one entry, in query order, with repeats collapsed.
+
+    ``api_sources`` in the reports names the sources that returned a candidate,
+    which is a hit count and not a call count: a source queried to no effect is
+    absent from it. Consumers deriving per-entry API cost need the full list,
+    so every report shape carries this one alongside it.
+    """
+    return list(dict.fromkeys(api_sources_queried))
+
+
 def _compute_coverage_incomplete(
     status: FactCheckStatus,
     errors: list[str],
@@ -6591,6 +6602,11 @@ class FactCheckProcessor:
                                     n for n, c in result.field_comparisons.items() if c.is_non_confirming
                                 ],
                                 "api_sources": result.api_sources_with_hits,
+                                # Every source the cascade asked, hit or no
+                                # hit. ``api_sources`` above is the subset that
+                                # answered with a candidate, so reading a call
+                                # count off it undercounts the run.
+                                "api_sources_queried": _queried_sources(result.api_sources_queried),
                                 # Sources whose lookup did not complete for this
                                 # entry. Non-empty means the cascade was partial,
                                 # so no exhaustive miss can be read off the status.
@@ -6761,7 +6777,7 @@ class FactCheckProcessor:
                     for name, c in r.field_comparisons.items()
                 },
                 "best_match": None,
-                "api_sources_queried": r.api_sources_queried,
+                "api_sources_queried": _queried_sources(r.api_sources_queried),
                 "api_sources_with_hits": r.api_sources_with_hits,
                 "sources_failed": r.sources_failed,
                 # Records a source returned that the cascade declined to score
@@ -6834,6 +6850,8 @@ class FactCheckProcessor:
                         "mismatched_fields": [n for n, c in r.field_comparisons.items() if c.is_mismatch],
                         "unconfirmed_fields": [n for n, c in r.field_comparisons.items() if c.is_non_confirming],
                         "api_sources": r.api_sources_with_hits,
+                        # Every source asked (see process_entries).
+                        "api_sources_queried": _queried_sources(r.api_sources_queried),
                         # Sources whose lookup did not complete (see process_entries).
                         "sources_failed": r.sources_failed,
                         # Records a source returned that the cascade declined to

--- a/tests/test_output_contract.py
+++ b/tests/test_output_contract.py
@@ -464,3 +464,104 @@ class TestSerialization:
             _result(FactCheckStatus.NOT_FOUND),
         ]
         assert processor.generate_summary(results)["coverage_incomplete_count"] == 0
+
+
+# ===========================================================================
+# api_sources_queried: the call count, next to api_sources' hit count
+# ===========================================================================
+
+
+def _sources_result(key: str, queried: list[str], hits: list[str]) -> FactCheckResult:
+    return FactCheckResult(
+        entry_key=key,
+        entry_type="article",
+        status=FactCheckStatus.VERIFIED if hits else FactCheckStatus.NOT_FOUND,
+        overall_confidence=0.9 if hits else 0.4,
+        field_comparisons={},
+        best_match=None,
+        api_sources_queried=list(queried),
+        api_sources_with_hits=list(hits),
+        errors=[],
+    )
+
+
+def _every_shape(
+    processor: FactCheckProcessor, results: list[FactCheckResult], jsonl_path
+) -> dict[str, dict[str, dict]]:
+    """The same results rendered through all three report shapes, keyed by
+    entry key: the streamed JSONL, the batch JSONL and the JSON report."""
+    entries = [{"ID": r.entry_key, "ENTRYTYPE": "article", "title": r.entry_key} for r in results]
+    processor.process_entries(entries, jsonl_path=str(jsonl_path), max_workers=1)
+    streamed = [json.loads(line) for line in jsonl_path.read_text().splitlines() if line]
+    batch = [json.loads(line) for line in processor.generate_jsonl(results)]
+    report = processor.generate_json_report(results)["entries"]
+    return {
+        "streamed": {rec["key"]: rec for rec in streamed},
+        "batch": {rec["key"]: rec for rec in batch},
+        "report": {rec["key"]: rec for rec in report},
+    }
+
+
+class TestApiSourcesQueried:
+    """``api_sources`` lists the sources that returned a candidate. A consumer
+    deriving a per-entry API-call count from it counts hits, so every report
+    shape also carries the sources that were actually queried."""
+
+    def test_present_on_every_shape_and_equal_across_them(self, tmp_path):
+        results = [
+            _sources_result("hit", ["crossref", "dblp", "openalex"], ["crossref"]),
+            _sources_result("miss", ["crossref", "dblp", "openalex"], []),
+        ]
+        processor = FactCheckProcessor(_FakeChecker({r.entry_key: r for r in results}), LOGGER)
+        shapes = _every_shape(processor, results, tmp_path / "out.jsonl")
+
+        for key in ("hit", "miss"):
+            queried = shapes["streamed"][key]["api_sources_queried"]
+            assert queried == ["crossref", "dblp", "openalex"]
+            assert shapes["batch"][key]["api_sources_queried"] == queried
+            assert shapes["report"][key]["api_sources_queried"] == queried
+
+    def test_hits_are_a_subset_of_queried(self, tmp_path):
+        results = [
+            _sources_result("hit", ["crossref", "dblp", "openalex"], ["crossref"]),
+            _sources_result("miss", ["crossref", "dblp", "openalex"], []),
+        ]
+        processor = FactCheckProcessor(_FakeChecker({r.entry_key: r for r in results}), LOGGER)
+        shapes = _every_shape(processor, results, tmp_path / "out.jsonl")
+
+        for shape in ("streamed", "batch"):
+            for key in ("hit", "miss"):
+                rec = shapes[shape][key]
+                assert set(rec["api_sources"]) <= set(rec["api_sources_queried"])
+
+    def test_a_queried_source_with_no_hit_shows_only_in_queried(self, tmp_path):
+        """DBLP and OpenAlex were asked and returned nothing: they cost a call
+        each, and only the queried list says so."""
+        results = [_sources_result("hit", ["crossref", "dblp", "openalex"], ["crossref"])]
+        processor = FactCheckProcessor(_FakeChecker({r.entry_key: r for r in results}), LOGGER)
+        shapes = _every_shape(processor, results, tmp_path / "out.jsonl")
+
+        for shape in ("streamed", "batch"):
+            rec = shapes[shape]["hit"]
+            assert rec["api_sources"] == ["crossref"]
+            assert set(rec["api_sources_queried"]) - set(rec["api_sources"]) == {"dblp", "openalex"}
+
+    def test_key_is_present_even_when_nothing_was_queried(self, tmp_path):
+        """Consumers can rely on the key existing, so it is emitted empty
+        rather than omitted."""
+        results = [_sources_result("nothing", [], [])]
+        processor = FactCheckProcessor(_FakeChecker({r.entry_key: r for r in results}), LOGGER)
+        shapes = _every_shape(processor, results, tmp_path / "out.jsonl")
+
+        for shape in ("streamed", "batch", "report"):
+            rec = shapes[shape]["nothing"]
+            assert "api_sources_queried" in rec
+            assert rec["api_sources_queried"] == []
+
+    def test_repeated_queries_collapse_in_query_order(self, tmp_path):
+        results = [_sources_result("repeat", ["crossref", "openalex", "crossref", "arxiv"], ["arxiv"])]
+        processor = FactCheckProcessor(_FakeChecker({r.entry_key: r for r in results}), LOGGER)
+        shapes = _every_shape(processor, results, tmp_path / "out.jsonl")
+
+        for shape in ("streamed", "batch", "report"):
+            assert shapes[shape]["repeat"]["api_sources_queried"] == ["crossref", "openalex", "arxiv"]


### PR DESCRIPTION
Decision DEC-5 from the 2026-09-06 review, ruled "fix the number".

Both JSONL writers emitted `api_sources` from `api_sources_with_hits`, so HALLMARK's `api_calls = len(api_sources)` and its published `mean_api_calls` for bibtex-updater counted the sources that returned a candidate, not the sources queried. A source asked and answering nothing was invisible to the cost metric.

Every report shape (streamed JSONL, batch JSONL, JSON report) now carries `api_sources_queried`: the sources the cascade queried for the entry, in query order, repeats collapsed, always present (an empty list when nothing was queried). `api_sources` is unchanged and is a subset of the new key. The JSON report already had the key; its value is now normalised the same way. Documented in `docs/REFERENCE_FACT_CHECKER.md`'s per-line fields table with both example lines updated.

Known limit, stated in the docs: the list is deduplicated, so it counts distinct sources, not round trips.

Tests: `tests/test_output_contract.py::TestApiSourcesQueried` (presence and cross-shape equality; hits ⊆ queried; a queried source with no hit appears only in the new key; empty case; repeats collapse); all five fail on the previous commit with `KeyError: 'api_sources_queried'`. 297 passed over the four targeted files; pre-commit (black, ruff, whitespace) clean. The reader side lands in hallmark as part of its follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud2hsbiqTpWq1XiWkLeWbt
